### PR TITLE
Explicit refs and clone depth for job checkout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -184,6 +184,11 @@ func (c *Client) Claim(ctx context.Context, agentID string, labels []string) (*C
 	return &response, nil
 }
 
+// ReportCheckout records the ref and commit an agent checked out.
+func (c *Client) ReportCheckout(ctx context.Context, jobID string, req JobCheckoutRequest) error {
+	return c.do(ctx, http.MethodPost, "/api/job/"+jobID+"/checkout", req, nil, true)
+}
+
 // Heartbeat extends this agent's lease on a job.
 func (c *Client) Heartbeat(ctx context.Context, jobID, agentID string) error {
 	return c.do(ctx, http.MethodPost, "/api/job/"+jobID+"/heartbeat", ClaimRequest{AgentID: agentID}, nil, true)

--- a/client/repository.go
+++ b/client/repository.go
@@ -32,11 +32,20 @@ type Checkout struct {
 }
 
 // Payload converts the checkout into a dispatch payload.
+//
+// The ref is the commit rather than the branch. A dispatched run belongs
+// to the code in front of the person who started it, and a branch name
+// would let the agent build whatever that branch has moved to by the
+// time the job is claimed.
 func (c *Checkout) Payload() RepositoryPayload {
+	ref := c.Revision
+	if ref == "" {
+		ref = c.Branch
+	}
+
 	return RepositoryPayload{
 		RemoteURL:     c.RemoteURL,
-		Branch:        c.Branch,
-		Revision:      c.Revision,
+		Ref:           ref,
 		DefaultBranch: c.DefaultBranch,
 	}
 }

--- a/client/repository_test.go
+++ b/client/repository_test.go
@@ -50,9 +50,11 @@ func TestDetectCheckout(t *testing.T) {
 	assert.Len(t, checkout.Revision, 40)
 	assert.Empty(t, checkout.WorkingDirectory)
 
+	// The dispatched ref is the commit, not the branch: the run belongs
+	// to the code in front of whoever started it.
 	payload := checkout.Payload()
 	assert.Equal(t, checkout.RemoteURL, payload.RemoteURL)
-	assert.Equal(t, checkout.Revision, payload.Revision)
+	assert.Equal(t, checkout.Revision, payload.Ref)
 }
 
 func TestDetectCheckoutReportsSubdirectory(t *testing.T) {

--- a/client/types.go
+++ b/client/types.go
@@ -40,10 +40,15 @@ type TokenResponse struct {
 }
 
 // RepositoryPayload describes the checkout a run happens in.
+//
+// Ref is what the agent checks out: a branch, a tag, a commit sha or a
+// fully qualified refname. The client fills it with the commit it is
+// sitting on, because a run dispatched from a laptop should build that
+// commit rather than whatever the branch has moved to by the time an
+// agent picks the job up.
 type RepositoryPayload struct {
 	RemoteURL     string `json:"remote_url"`
-	Branch        string `json:"branch"`
-	Revision      string `json:"revision"`
+	Ref           string `json:"ref,omitempty"`
 	DefaultBranch string `json:"default_branch"`
 }
 
@@ -128,11 +133,19 @@ type Job struct {
 	RepositoryID     string `json:"repository_id"`
 	WorkingDirectory string `json:"working_directory"`
 	Command          string `json:"command"`
-	Branch           string `json:"branch"`
-	Revision         string `json:"revision"`
+	Ref              string `json:"ref"`
+	CommitSHA        string `json:"commit_sha"`
+	CloneDepth       int64  `json:"clone_depth"`
 	Labels           string `json:"labels"`
 	Params           string `json:"params"`
 	Status           string `json:"status"`
+}
+
+// JobCheckoutRequest is the body of POST /api/job/{jobID}/checkout: what
+// the agent actually put in the work tree.
+type JobCheckoutRequest struct {
+	Ref       string `json:"ref"`
+	CommitSHA string `json:"commit_sha"`
 }
 
 // JobLogRequest is the body of POST /api/job/{jobID}/log.

--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -183,11 +183,21 @@ type Job struct {
 	RepositoryID     string `json:"repository_id"`
 	WorkingDirectory string `json:"working_directory"`
 	Command          string `json:"command"`
-	Branch           string `json:"branch"`
-	Revision         string `json:"revision"`
+	Ref              string `json:"ref"`
+	CommitSHA        string `json:"commit_sha"`
+	CloneDepth       int64  `json:"clone_depth"`
 	Labels           string `json:"labels"`
 	Params           string `json:"params"`
 	Status           string `json:"status"`
+}
+```
+
+```go
+// JobCheckoutRequest is the body of POST /api/job/{jobID}/checkout: what
+// the agent actually put in the work tree.
+type JobCheckoutRequest struct {
+	Ref       string `json:"ref"`
+	CommitSHA string `json:"commit_sha"`
 }
 ```
 
@@ -272,10 +282,14 @@ type Repository struct {
 
 ```go
 // RepositoryPayload describes the checkout a run happens in.
+// Ref is what the agent checks out: a branch, a tag, a commit sha or a
+// fully qualified refname. The client fills it with the commit it is
+// sitting on, because a run dispatched from a laptop should build that
+// commit rather than whatever the branch has moved to by the time an
+// agent picks the job up.
 type RepositoryPayload struct {
 	RemoteURL     string `json:"remote_url"`
-	Branch        string `json:"branch"`
-	Revision      string `json:"revision"`
+	Ref           string `json:"ref,omitempty"`
 	DefaultBranch string `json:"default_branch"`
 }
 ```
@@ -453,6 +467,7 @@ var UserAgent = "atkins"
 - `func (*Client) Policy (ctx context.Context) (*PolicyResponse, error)`
 - `func (*Client) Refresh (ctx context.Context) error`
 - `func (*Client) Register (ctx context.Context, req RegisterRequest) (*Credential, error)`
+- `func (*Client) ReportCheckout (ctx context.Context, jobID string, req JobCheckoutRequest) error`
 - `func (*Client) ReportStatus (ctx context.Context, jobID string, req JobStatusRequest) error`
 - `func (*Client) SSHKeys (ctx context.Context) ([]AgentSSHKey, error)`
 - `func (*Client) Server () string`
@@ -667,6 +682,11 @@ func (*APIError) Error() string
 
 Payload converts the checkout into a dispatch payload.
 
+The ref is the commit rather than the branch. A dispatched run belongs
+to the code in front of the person who started it, and a branch name
+would let the agent build whatever that branch has moved to by the
+time the job is claimed.
+
 ```go
 func (*Checkout) Payload() RepositoryPayload
 ```
@@ -769,6 +789,14 @@ Register creates an account and stores the credential it returns.
 
 ```go
 func (*Client) Register(ctx context.Context, req RegisterRequest) (*Credential, error)
+```
+
+### ReportCheckout
+
+ReportCheckout records the ref and commit an agent checked out.
+
+```go
+func (*Client) ReportCheckout(ctx context.Context, jobID string, req JobCheckoutRequest) error
 ```
 
 ### ReportStatus

--- a/docs/api/atkins_server_api.md
+++ b/docs/api/atkins_server_api.md
@@ -80,6 +80,10 @@ type DispatchRequest struct {
 
 	// Params is an arbitrary JSON object handed to the job.
 	Params map[string]any `json:"params"`
+
+	// CloneDepth limits the history of the work tree the agent builds.
+	// 0, the default, is the whole history.
+	CloneDepth int64 `json:"clone_depth"`
 }
 ```
 
@@ -135,6 +139,21 @@ type Handlers struct {
 	rules        *storage.RepositoryRuleStorage
 	settings     *storage.SettingStorage
 	sshKeys      *storage.SSHKeyStorage
+}
+```
+
+```go
+// JobCheckoutRequest is the body of /api/job/{jobID}/checkout.
+// It is the agent answering the question the job asked. A job may name a
+// tag, and a tag moves; without the commit that tag pointed at, a run
+// cannot be reproduced once it has.
+type JobCheckoutRequest struct {
+	// Ref is the effective ref, which is the one the job named unless
+	// it named none and the agent resolved the default branch.
+	Ref string `json:"ref"`
+
+	// CommitSHA is the commit the work tree was placed at.
+	CommitSHA string `json:"commit_sha"`
 }
 ```
 
@@ -248,10 +267,22 @@ type RegisterRequest struct {
 ```go
 // RepositoryPayload is the git detail a client reports about its checkout.
 type RepositoryPayload struct {
-	RemoteURL     string `json:"remote_url"`
-	Branch        string `json:"branch"`
-	Revision      string `json:"revision"`
+	RemoteURL string `json:"remote_url"`
+
+	// Ref is what to check out: a branch, a tag, a commit sha or a
+	// fully qualified refname. The atkins client sends the commit it is
+	// on, so a dispatched run builds the code in front of whoever
+	// started it.
+	Ref string `json:"ref"`
+
+	// DefaultBranch is what the agent falls back to when Ref is empty.
 	DefaultBranch string `json:"default_branch"`
+
+	// Branch and Revision are the pre-ref spelling of Ref, kept so a
+	// client or a script written against the earlier API keeps working.
+	// Deprecated: send Ref.
+	Branch   string `json:"branch,omitempty"`
+	Revision string `json:"revision,omitempty"`
 }
 ```
 
@@ -307,9 +338,19 @@ type TriggerRequest struct {
 	// WorkingDirectory is relative to the repository root.
 	WorkingDirectory string `json:"working_directory"`
 
-	// Branch and Revision pin what gets checked out. Empty lets the
-	// agent fall back to the repository's default branch, which is
-	// what a "run this nightly" trigger wants.
+	// Ref pins what gets checked out: a branch, a tag, a commit sha or
+	// a fully qualified refname. Empty lets the agent resolve the
+	// repository's default branch when the job runs, which is what a
+	// "run this nightly" trigger wants.
+	Ref string `json:"ref"`
+
+	// CloneDepth limits the history of the work tree. 0 is all of it.
+	// A fan-out over tags usually wants 1: each child builds one commit
+	// and never looks behind it.
+	CloneDepth int64 `json:"clone_depth"`
+
+	// Branch and Revision are the pre-ref spelling of Ref.
+	// Deprecated: send Ref.
 	Branch   string `json:"branch"`
 	Revision string `json:"revision"`
 
@@ -374,6 +415,7 @@ const DefaultTokenTTL = time.Hour
 - `func (*Handlers) Enrol (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) GetJob (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) GetJobLog (w http.ResponseWriter, r *http.Request)`
+- `func (*Handlers) JobCheckout (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) JobHeartbeat (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) JobStatus (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) ListJobs (w http.ResponseWriter, r *http.Request)`
@@ -399,6 +441,7 @@ const DefaultTokenTTL = time.Hour
 - `func (*Handlers) Whoami (w http.ResponseWriter, r *http.Request)`
 - `func (*RequestError) Error () string`
 - `func (*RequestError) Unwrap () error`
+- `func (RepositoryPayload) CheckoutRef () string`
 
 ### NewHandlers
 
@@ -518,6 +561,14 @@ GetJobLog returns the recorded output for a job.
 
 ```go
 func (*Handlers) GetJobLog(w http.ResponseWriter, r *http.Request)
+```
+
+### JobCheckout
+
+JobCheckout records what an agent checked out for a job.
+
+```go
+func (*Handlers) JobCheckout(w http.ResponseWriter, r *http.Request)
 ```
 
 ### JobHeartbeat
@@ -730,4 +781,14 @@ Unwrap exposes the wrapped error to errors.Is/As.
 
 ```go
 func (*RequestError) Unwrap() error
+```
+
+### CheckoutRef
+
+CheckoutRef folds the deprecated branch and revision fields into the
+single ref a job records. The more specific of the two wins: a
+revision names one commit, a branch names wherever it has got to.
+
+```go
+func (RepositoryPayload) CheckoutRef() string
 ```

--- a/docs/api/atkins_server_model.md
+++ b/docs/api/atkins_server_model.md
@@ -35,12 +35,6 @@ type Job struct {
 	// Command
 	Command string `db:"command" json:"command"`
 
-	// Branch
-	Branch string `db:"branch" json:"branch"`
-
-	// Revision
-	Revision string `db:"revision" json:"revision"`
-
 	// Labels
 	Labels string `db:"labels" json:"labels"`
 
@@ -73,6 +67,15 @@ type Job struct {
 
 	// Updated At
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at"`
+
+	// Ref
+	Ref string `db:"ref" json:"ref"`
+
+	// Commit Sha
+	CommitSha string `db:"commit_sha" json:"commit_sha"`
+
+	// Clone Depth
+	CloneDepth int64 `db:"clone_depth" json:"clone_depth"`
 }
 ```
 
@@ -504,7 +507,7 @@ const (
 
 ```go
 // JobFields is a list of all columns in the DB table.
-var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "branch", "revision", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at"}
+var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "ref", "commit_sha", "clone_depth"}
 ```
 
 ```go
@@ -678,8 +681,9 @@ var (
 - `func WithWhere (clause string) QueryOption`
 - `func (*Job) Delete (opts ...QueryOption) string`
 - `func (*Job) GetAgentID () string`
-- `func (*Job) GetBranch () string`
+- `func (*Job) GetCloneDepth () int64`
 - `func (*Job) GetCommand () string`
+- `func (*Job) GetCommitSha () string`
 - `func (*Job) GetCreatedAt () *time.Time`
 - `func (*Job) GetDepth () int64`
 - `func (*Job) GetError () string`
@@ -690,8 +694,8 @@ var (
 - `func (*Job) GetLeaseExpiresAt () *time.Time`
 - `func (*Job) GetParams () string`
 - `func (*Job) GetParentID () string`
+- `func (*Job) GetRef () string`
 - `func (*Job) GetRepositoryID () string`
-- `func (*Job) GetRevision () string`
 - `func (*Job) GetRootID () string`
 - `func (*Job) GetStartedAt () *time.Time`
 - `func (*Job) GetStatus () string`
@@ -702,8 +706,9 @@ var (
 - `func (*Job) IsTerminal () bool`
 - `func (*Job) Select (opts ...QueryOption) string`
 - `func (*Job) SetAgentID (val string)`
-- `func (*Job) SetBranch (val string)`
+- `func (*Job) SetCloneDepth (val int64)`
 - `func (*Job) SetCommand (val string)`
+- `func (*Job) SetCommitSha (val string)`
 - `func (*Job) SetCreatedAt (stamp time.Time)`
 - `func (*Job) SetDepth (val int64)`
 - `func (*Job) SetError (val string)`
@@ -714,8 +719,8 @@ var (
 - `func (*Job) SetLeaseExpiresAt (stamp time.Time)`
 - `func (*Job) SetParams (val string)`
 - `func (*Job) SetParentID (val string)`
+- `func (*Job) SetRef (val string)`
 - `func (*Job) SetRepositoryID (val string)`
-- `func (*Job) SetRevision (val string)`
 - `func (*Job) SetRootID (val string)`
 - `func (*Job) SetStartedAt (stamp time.Time)`
 - `func (*Job) SetStatus (val string)`
@@ -1037,12 +1042,12 @@ GetAgentID will return the value of AgentID.
 func (*Job) GetAgentID() string
 ```
 
-### GetBranch
+### GetCloneDepth
 
-GetBranch will return the value of Branch.
+GetCloneDepth will return the value of CloneDepth.
 
 ```go
-func (*Job) GetBranch() string
+func (*Job) GetCloneDepth() int64
 ```
 
 ### GetCommand
@@ -1051,6 +1056,14 @@ GetCommand will return the value of Command.
 
 ```go
 func (*Job) GetCommand() string
+```
+
+### GetCommitSha
+
+GetCommitSha will return the value of CommitSha.
+
+```go
+func (*Job) GetCommitSha() string
 ```
 
 ### GetCreatedAt
@@ -1133,20 +1146,20 @@ GetParentID will return the value of ParentID.
 func (*Job) GetParentID() string
 ```
 
+### GetRef
+
+GetRef will return the value of Ref.
+
+```go
+func (*Job) GetRef() string
+```
+
 ### GetRepositoryID
 
 GetRepositoryID will return the value of RepositoryID.
 
 ```go
 func (*Job) GetRepositoryID() string
-```
-
-### GetRevision
-
-GetRevision will return the value of Revision.
-
-```go
-func (*Job) GetRevision() string
 ```
 
 ### GetRootID
@@ -1229,12 +1242,12 @@ SetAgentID sets AgentID to the provided value.
 func (*Job) SetAgentID(val string)
 ```
 
-### SetBranch
+### SetCloneDepth
 
-SetBranch sets Branch to the provided value.
+SetCloneDepth sets CloneDepth to the provided value.
 
 ```go
-func (*Job) SetBranch(val string)
+func (*Job) SetCloneDepth(val int64)
 ```
 
 ### SetCommand
@@ -1243,6 +1256,14 @@ SetCommand sets Command to the provided value.
 
 ```go
 func (*Job) SetCommand(val string)
+```
+
+### SetCommitSha
+
+SetCommitSha sets CommitSha to the provided value.
+
+```go
+func (*Job) SetCommitSha(val string)
 ```
 
 ### SetCreatedAt
@@ -1325,20 +1346,20 @@ SetParentID sets ParentID to the provided value.
 func (*Job) SetParentID(val string)
 ```
 
+### SetRef
+
+SetRef sets Ref to the provided value.
+
+```go
+func (*Job) SetRef(val string)
+```
+
 ### SetRepositoryID
 
 SetRepositoryID sets RepositoryID to the provided value.
 
 ```go
 func (*Job) SetRepositoryID(val string)
-```
-
-### SetRevision
-
-SetRevision sets Revision to the provided value.
-
-```go
-func (*Job) SetRevision(val string)
 ```
 
 ### SetRootID

--- a/docs/api/atkins_server_storage.md
+++ b/docs/api/atkins_server_storage.md
@@ -19,6 +19,18 @@ instead so transactions and scoping stay in one place.
 ## Types
 
 ```go
+// CheckoutRequest is what an agent reports having checked out.
+type CheckoutRequest struct {
+	// Ref is the effective ref: the one the job named, or the default
+	// branch the agent resolved for a job that named none.
+	Ref string
+
+	// CommitSHA is the commit the work tree was placed at.
+	CommitSHA string
+}
+```
+
+```go
 // CreateRequest is the input for creating a user. It is what
 // `atkins --register` collects at the prompt.
 type CreateRequest struct {
@@ -65,9 +77,17 @@ type JobRequest struct {
 	// Command is the atkins invocation to run, verbatim.
 	Command string
 
-	Branch   string
-	Revision string
-	Labels   []string
+	// Ref is what to check out: a branch, a tag, a commit sha or a
+	// fully qualified refname. Empty means the repository's default
+	// branch, resolved by the agent when the job runs rather than here,
+	// so a nightly trigger follows the branch it is pointed at.
+	Ref string
+
+	// CloneDepth limits the history of the job's work tree. 0 is the
+	// whole history.
+	CloneDepth int64
+
+	Labels []string
 
 	// Params is a JSON object handed to the job as ATKINS_JOB_PARAMS.
 	Params string
@@ -309,6 +329,7 @@ const (
 - `func (*JobStorage) Heartbeat (ctx context.Context, jobID,agentID string) error`
 - `func (*JobStorage) List (ctx context.Context, filter ListFilter) ([]model.Job, error)`
 - `func (*JobStorage) ReclaimExpired (ctx context.Context) (int64, error)`
+- `func (*JobStorage) RecordCheckout (ctx context.Context, jobID string, req CheckoutRequest) error`
 - `func (*RepositoryRuleStorage) Allowed (ctx context.Context, slug string) (bool, error)`
 - `func (*RepositoryRuleStorage) Create (ctx context.Context, userID string, req RuleRequest) (*model.RepositoryRule, error)`
 - `func (*RepositoryRuleStorage) Delete (ctx context.Context, id string) error`
@@ -527,6 +548,18 @@ so an agent that disappears mid-job doesn't strand its work.
 
 ```go
 func (*JobStorage) ReclaimExpired(ctx context.Context) (int64, error)
+```
+
+### RecordCheckout
+
+RecordCheckout stores what an agent checked out for a job.
+
+It is guarded on the job still running, so a late report from an agent
+whose lease was already swept cannot rewrite the checkout of the run
+that replaced it.
+
+```go
+func (*JobStorage) RecordCheckout(ctx context.Context, jobID string, req CheckoutRequest) error
 ```
 
 ### Allowed

--- a/docs/api/atkins_worker.md
+++ b/docs/api/atkins_worker.md
@@ -20,6 +20,22 @@ its own work tree under <DataDir>/work.
 ## Types
 
 ```go
+// Checkout records what the agent actually put in the work tree.
+// Ref is the effective ref: the one the job named, or the default branch
+// resolved for a job that named nothing. CommitSHA is what that ref
+// pointed at when the job ran — a tag moves, so a run recorded as
+// "v1.2.3" alone cannot be reproduced later.
+type Checkout struct {
+	Ref       string
+	CommitSHA string
+
+	// Branch is set when Ref named a branch and empty for a tag or a
+	// bare commit. A job reads it as ATKINS_BRANCH.
+	Branch string
+}
+```
+
+```go
 // Options configures an agent.
 // Values come from .atkins/config.yml with the ATKINS_* overlay already
 // applied; see FromConfig. The struct stays plain so a caller embedding
@@ -99,6 +115,9 @@ type Workspace struct {
 	// Dir is the directory the command runs in: Root joined with the
 	// job's working directory.
 	Dir string
+
+	// Checkout is what the work tree ended up at.
+	Checkout Checkout
 }
 ```
 

--- a/docs/content/usage/ci-cd.md
+++ b/docs/content/usage/ci-cd.md
@@ -78,13 +78,16 @@ Once logged in, `atkins` posts to `/api/dispatch` and prints the job URL:
 
 | Field               | Value                                               |
 |---------------------|-----------------------------------------------------|
-| `repository`        | `origin` remote URL, branch and revision            |
+| `repository`        | `origin` remote URL, ref and default branch         |
 | `working_directory` | Pipeline directory, relative to the repository root |
 | `command`           | The atkins invocation, e.g. `atkins test:build`     |
 | `parent_id`         | `ATKINS_JOB_ID`, when a job dispatches further work |
 | `labels`            | Which agents may run it                             |
+| `clone_depth`       | History the agent's work tree needs; 0 is all of it |
 
 The server normalizes the remote URL into a `host/owner/name` slug, so `git@github.com:you/repo.git` and `https://github.com/you/repo` are one repository. Repositories are created on first sight; nothing has to be registered up front.
+
+The ref atkins sends is the **commit you are on**, not the branch you are on. A dispatched run belongs to the code in front of you, and a branch name would let the agent build whatever that branch had moved to by the time it claimed the job. The consequence is worth knowing: dispatching a commit you have not pushed fails, naming the ref it could not find, rather than quietly building the branch tip instead.
 
 Delegation degrades to a local run rather than to an error. If the machine isn't logged in, isn't inside a git repository, or the server can't be reached, the pipeline runs here as it always did — with the reason on stderr.
 
@@ -109,8 +112,10 @@ An agent publishes these to the command it runs:
 | `ATKINS_JOB_PARAMS`    | The JSON object the job was dispatched with |
 | `ATKINS_WORKSPACE`     | The checkout the job runs in                |
 | `ATKINS_REPOSITORY`    | Repository slug                             |
-| `ATKINS_REVISION`      | Commit that was checked out                 |
-| `ATKINS_BRANCH`        | Branch the job was dispatched from          |
+| `ATKINS_REF`           | The ref that was checked out                |
+| `ATKINS_COMMIT_SHA`    | The commit that ref resolved to             |
+| `ATKINS_REVISION`      | The same commit, under its older name       |
+| `ATKINS_BRANCH`        | Set only when the ref named a branch        |
 | `CI`                   | `true`                                      |
 
 It also sets `ATKINS_NO_DISPATCH=1`. Without it, the atkins the agent runs would see the agent's own credentials, hand the work straight back to the server, and nothing would ever execute. A pipeline that genuinely wants to queue child work clears it:
@@ -143,7 +148,7 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO
   -d '{"job": "analyze"}'
 ```
 
-`job` becomes `atkins analyze`, so a trigger payload stays a name rather than a shell string somebody has to quote. `command` overrides the whole invocation when a bare job name isn't enough. With neither `branch` nor `revision`, the agent checks out the repository's default branch — what a nightly wants.
+`job` becomes `atkins analyze`, so a trigger payload stays a name rather than a shell string somebody has to quote. `command` overrides the whole invocation when a bare job name isn't enough. With no `ref`, the agent resolves the repository's default branch when it runs the job — what a nightly wants.
 
 `params` is how a dispatching job hands each child its work. It reaches the job as `ATKINS_JOB_PARAMS`:
 
@@ -151,11 +156,49 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO
 for tag in $(git tag --list); do
   curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO/trigger" \
     -d "$(jq -n --arg tag "$tag" --arg parent "$ATKINS_JOB_ID" \
-      '{job: "analyzeTag", parent_id: $parent, params: {tag: $tag}}')"
+      '{job: "analyzeTag", parent_id: $parent, ref: $tag, clone_depth: 1, params: {tag: $tag}}')"
 done
 ```
 
+`ref` is what the child checks out; `params` is what it is told. Here they carry the same tag, and the child gets one commit of history rather than the whole repository.
+
 Each child records `parent_id`, shares the root job's ID, and counts against `job.max_depth`.
+
+## Refs, tags and clone depth
+
+A job says what to check out in one field. `ref` takes whatever git takes:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO/trigger" \
+  -d '{"job": "release", "ref": "v1.2.3", "clone_depth": 1}'
+```
+
+| `ref`              | Resolves to                                  |
+|--------------------|----------------------------------------------|
+| *(empty)*          | The repository's default branch, at run time |
+| `v1.2.3`           | That tag, then a branch of the same name     |
+| `main`             | That branch                                  |
+| `4f2a1c…`          | That commit, abbreviated or in full          |
+| `refs/tags/v1.2.3` | Exactly that ref, and nothing else           |
+| `refs/pull/7/head` | Anything else the remote carries             |
+
+A bare name is looked for as a tag first and then as a branch, which is git's own order. A fully qualified `refs/...` name is taken at its word.
+
+**A ref that does not resolve fails the job, naming the ref.** There is no fallback to the default branch: a typo in a tag name should not produce a green run of the wrong code.
+
+**The commit is recorded.** Before it runs anything the agent reports what it actually checked out, and the job page shows the ref and the commit side by side. A tag moves; a job that remembered only `v1.2.3` could not be reproduced after it did. `ATKINS_COMMIT_SHA` carries the same value into the pipeline, so an artefact can be labelled with the commit even when the job named a branch.
+
+A retry repeats the **ref**, not the commit: a retried job pointed at a branch asks for whatever that branch holds now. Put a commit in the ref to get the same code twice.
+
+### Clone depth
+
+`clone_depth` limits the history the job's work tree carries. `1` is one commit, `0` — the default — is all of it.
+
+Depth applies to the **work tree**, never to the agent's repository cache. The cache is a full mirror shared by every job for that repository, and it stays that way: a shallow cache would have to be deepened the first time a job named an older tag, and deepening repeatedly costs more than never having discarded the objects. The work tree is thrown away when the job ends, so limiting it costs nothing later.
+
+What a shallow work tree buys is a small `.git`: it matters when the job packages the tree, copies it into a docker build context, or uploads it. It does not make the clone faster — a full work tree is hardlinked out of the cache and is very nearly free, while a shallow one has to be fetched. Ask for depth when the size of `.git` matters to the job, not to save the agent time.
+
+A job with `clone_depth: 1` has no history and no tags: `git describe`, `git log` past the tip and `git merge-base` will not work, even for the tag the job itself named. `ATKINS_REF` carries that name into the job, which is what a build usually wanted `git describe` for. Fan-outs over tags are the case that wants a depth — each child builds one commit and never looks behind it.
 
 ## Retrying and cancelling
 
@@ -168,7 +211,7 @@ A retry is a **new job** built from the finished one, not a reset: the previous 
 
 ## The job page
 
-`/job/{ULID}` is the URL atkins prints. It shows the status, the command, the repository and revision, timing, the exit code, and the output the agent captured, and it refreshes itself until the job settles. `/` lists recent jobs.
+`/job/{ULID}` is the URL atkins prints. It shows the status, the command, the repository, the ref the job asked for and the commit the agent resolved it to, timing, the exit code, and the output the agent captured, and it refreshes itself until the job settles. `/` lists recent jobs.
 
 The pages are readable without a session: a ULID is not enumerable in practice, and the point of printing a URL in a terminal is that pasting it into a browser works. Put the server behind your own auth if the output is sensitive.
 
@@ -235,10 +278,13 @@ Agents don't have passwords. One shared enrolment token, given to the agent, is 
 For each claimed job the agent:
 
 1. mirrors the repository into `<data_dir>/repos/<slug>.git`, or fetches it when already cached;
-2. clones a work tree into `<data_dir>/work/<job-id>` and checks out the revision, falling back to the branch and then the default branch;
-3. runs the command in the job's working directory;
-4. streams the output back as it goes;
-5. reports `passed`, `failed` or `timeout`, and removes the work tree.
+2. resolves the job's ref against that mirror, once, into a commit — a tag that moves mid-job cannot split the run across two commits;
+3. builds a work tree in `<data_dir>/work/<job-id>` at that commit, shallow if the job asked for a depth, and reports the ref and commit back to the server;
+4. runs the command in the job's working directory;
+5. streams the output back as it goes;
+6. reports `passed`, `failed` or `timeout`, and removes the work tree.
+
+The work tree is checked out detached. A job builds one commit; leaving a branch checked out would suggest it has somewhere to push it back to.
 
 The lease is renewed every 30 seconds. A job whose lease lapses is swept back out of `running` and marked `timeout`, so a worker that disappears mid-job doesn't strand its work.
 
@@ -346,6 +392,7 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/job/{id}/cancel`         | POST            | user   | Settle an unfinished job               |
 | `/api/job/claim`               | POST            | agent  | Lease the oldest pending job           |
 | `/api/job/{id}/status`         | POST            | agent  | Settle a job                           |
+| `/api/job/{id}/checkout`       | POST            | agent  | Record the ref and commit it built     |
 | `/api/job/{id}/heartbeat`      | POST            | agent  | Extend the lease                       |
 | `/api/job/{id}/log`            | POST            | agent  | Append output                          |
 | `/api/agent/enrol`             | POST            | token  | Trade the shared token for credentials |

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -84,6 +84,7 @@ func (s *Handlers) Mount(r platform.Router) {
 		r.Post("/api/job/claim", s.ClaimJob)
 		r.Get("/api/job/{jobID}", s.GetJob)
 		r.Post("/api/job/{jobID}/status", s.JobStatus)
+		r.Post("/api/job/{jobID}/checkout", s.JobCheckout)
 		r.Post("/api/job/{jobID}/heartbeat", s.JobHeartbeat)
 		r.Get("/api/job/{jobID}/log", s.GetJobLog)
 		r.Post("/api/job/{jobID}/log", s.AppendJobLog)

--- a/server/api/dispatch.go
+++ b/server/api/dispatch.go
@@ -41,14 +41,37 @@ type DispatchRequest struct {
 
 	// Params is an arbitrary JSON object handed to the job.
 	Params map[string]any `json:"params"`
+
+	// CloneDepth limits the history of the work tree the agent builds.
+	// 0, the default, is the whole history.
+	CloneDepth int64 `json:"clone_depth"`
 }
 
 // RepositoryPayload is the git detail a client reports about its checkout.
 type RepositoryPayload struct {
-	RemoteURL     string `json:"remote_url"`
-	Branch        string `json:"branch"`
-	Revision      string `json:"revision"`
+	RemoteURL string `json:"remote_url"`
+
+	// Ref is what to check out: a branch, a tag, a commit sha or a
+	// fully qualified refname. The atkins client sends the commit it is
+	// on, so a dispatched run builds the code in front of whoever
+	// started it.
+	Ref string `json:"ref"`
+
+	// DefaultBranch is what the agent falls back to when Ref is empty.
 	DefaultBranch string `json:"default_branch"`
+
+	// Branch and Revision are the pre-ref spelling of Ref, kept so a
+	// client or a script written against the earlier API keeps working.
+	// Deprecated: send Ref.
+	Branch   string `json:"branch,omitempty"`
+	Revision string `json:"revision,omitempty"`
+}
+
+// CheckoutRef folds the deprecated branch and revision fields into the
+// single ref a job records. The more specific of the two wins: a
+// revision names one commit, a branch names wherever it has got to.
+func (p RepositoryPayload) CheckoutRef() string {
+	return checkoutRef(p.Ref, p.Revision, p.Branch)
 }
 
 // DispatchResponse is what /api/dispatch returns.
@@ -71,6 +94,20 @@ type JobStatusRequest struct {
 	Status   string `json:"status"`
 	ExitCode int64  `json:"exit_code"`
 	Error    string `json:"error"`
+}
+
+// JobCheckoutRequest is the body of /api/job/{jobID}/checkout.
+//
+// It is the agent answering the question the job asked. A job may name a
+// tag, and a tag moves; without the commit that tag pointed at, a run
+// cannot be reproduced once it has.
+type JobCheckoutRequest struct {
+	// Ref is the effective ref, which is the one the job named unless
+	// it named none and the agent resolved the default branch.
+	Ref string `json:"ref"`
+
+	// CommitSHA is the commit the work tree was placed at.
+	CommitSHA string `json:"commit_sha"`
 }
 
 // ClaimRequest is the body of /api/job/claim.
@@ -151,8 +188,8 @@ func (s *Handlers) dispatch(w http.ResponseWriter, r *http.Request) error {
 		UserID:           user.ID,
 		WorkingDirectory: cleanWorkingDirectory(req.WorkingDirectory),
 		Command:          req.Command,
-		Branch:           req.Repository.Branch,
-		Revision:         req.Repository.Revision,
+		Ref:              req.Repository.CheckoutRef(),
+		CloneDepth:       req.CloneDepth,
 		Labels:           req.Labels,
 		Params:           params,
 	})
@@ -331,6 +368,40 @@ func (s *Handlers) jobStatus(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	platform.JSON(w, r, http.StatusOK, job)
+	return nil
+}
+
+// JobCheckout records what an agent checked out for a job.
+func (s *Handlers) JobCheckout(w http.ResponseWriter, r *http.Request) {
+	s.respond(w, r, s.jobCheckout(w, r))
+}
+
+func (s *Handlers) jobCheckout(w http.ResponseWriter, r *http.Request) error {
+	if _, err := s.requireAgent(r); err != nil {
+		return err
+	}
+
+	var req JobCheckoutRequest
+	if err := decode(r, &req); err != nil {
+		return err
+	}
+
+	commit := strings.TrimSpace(req.CommitSHA)
+	if commit == "" {
+		return requestError(http.StatusBadRequest, errors.New("commit_sha is required"))
+	}
+
+	if err := s.jobs.RecordCheckout(r.Context(), platform.URLParam(r, "jobID"), storage.CheckoutRequest{
+		Ref:       strings.TrimSpace(req.Ref),
+		CommitSHA: commit,
+	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return requestError(http.StatusConflict, errors.New("job is not running"))
+		}
+		return err
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 

--- a/server/api/payload.go
+++ b/server/api/payload.go
@@ -26,6 +26,22 @@ func cleanWorkingDirectory(dir string) string {
 	return dir
 }
 
+// checkoutRef picks the ref a job should record.
+//
+// One field decides what gets checked out. Branch and revision were two
+// fields for that one decision, which is how a tag ended up travelling
+// in the branch field and working only by accident; they are still
+// accepted so an existing trigger script keeps working, with the more
+// specific of the two winning.
+func checkoutRef(ref, revision, branch string) string {
+	for _, candidate := range []string{ref, revision, branch} {
+		if candidate = strings.TrimSpace(candidate); candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // encodeParams serializes job parameters to the JSON object stored on
 // the job. A nil map becomes an empty object rather than null, so
 // consumers can always unmarshal into a map.

--- a/server/api/trigger.go
+++ b/server/api/trigger.go
@@ -30,9 +30,19 @@ type TriggerRequest struct {
 	// WorkingDirectory is relative to the repository root.
 	WorkingDirectory string `json:"working_directory"`
 
-	// Branch and Revision pin what gets checked out. Empty lets the
-	// agent fall back to the repository's default branch, which is
-	// what a "run this nightly" trigger wants.
+	// Ref pins what gets checked out: a branch, a tag, a commit sha or
+	// a fully qualified refname. Empty lets the agent resolve the
+	// repository's default branch when the job runs, which is what a
+	// "run this nightly" trigger wants.
+	Ref string `json:"ref"`
+
+	// CloneDepth limits the history of the work tree. 0 is all of it.
+	// A fan-out over tags usually wants 1: each child builds one commit
+	// and never looks behind it.
+	CloneDepth int64 `json:"clone_depth"`
+
+	// Branch and Revision are the pre-ref spelling of Ref.
+	// Deprecated: send Ref.
 	Branch   string `json:"branch"`
 	Revision string `json:"revision"`
 
@@ -99,19 +109,17 @@ func (s *Handlers) trigger(w http.ResponseWriter, r *http.Request) error {
 		return requestError(http.StatusBadRequest, err)
 	}
 
-	branch := req.Branch
-	if branch == "" && req.Revision == "" {
-		branch = repository.DefaultBranch
-	}
-
+	// An empty ref is left empty rather than filled in with the default
+	// branch here: a nightly trigger should follow the branch, and the
+	// agent records which commit it resolved to when it runs.
 	job, err := s.jobs.Create(r.Context(), storage.JobRequest{
 		ParentID:         req.ParentID,
 		RepositoryID:     repository.ID,
 		UserID:           user.ID,
 		WorkingDirectory: cleanWorkingDirectory(req.WorkingDirectory),
 		Command:          command,
-		Branch:           branch,
-		Revision:         req.Revision,
+		Ref:              checkoutRef(req.Ref, req.Revision, req.Branch),
+		CloneDepth:       req.CloneDepth,
 		Labels:           req.Labels,
 		Params:           params,
 	})
@@ -179,14 +187,19 @@ func (s *Handlers) retryJob(w http.ResponseWriter, r *http.Request) error {
 	// The retry keeps the original's parent, so a re-run child stays
 	// under the job that dispatched it rather than becoming a root of
 	// its own.
+	//
+	// It repeats the ref rather than the commit the first attempt
+	// resolved: a retry is "run this again", and a job pointed at a
+	// branch is asking for whatever that branch holds now. Pin the
+	// commit in the ref if you want the same code twice.
 	job, err := s.jobs.Create(r.Context(), storage.JobRequest{
 		ParentID:         previous.ParentID,
 		RepositoryID:     previous.RepositoryID,
 		UserID:           user.ID,
 		WorkingDirectory: previous.WorkingDirectory,
 		Command:          previous.Command,
-		Branch:           previous.Branch,
-		Revision:         previous.Revision,
+		Ref:              previous.Ref,
+		CloneDepth:       previous.CloneDepth,
 		Labels:           splitLabels(previous.Labels),
 		Params:           previous.Params,
 	})

--- a/server/model/types.mig.go
+++ b/server/model/types.mig.go
@@ -150,12 +150,6 @@ type Job struct {
 	// Command
 	Command string `db:"command" json:"command"`
 
-	// Branch
-	Branch string `db:"branch" json:"branch"`
-
-	// Revision
-	Revision string `db:"revision" json:"revision"`
-
 	// Labels
 	Labels string `db:"labels" json:"labels"`
 
@@ -188,6 +182,15 @@ type Job struct {
 
 	// Updated At
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at"`
+
+	// Ref
+	Ref string `db:"ref" json:"ref"`
+
+	// Commit Sha
+	CommitSha string `db:"commit_sha" json:"commit_sha"`
+
+	// Clone Depth
+	CloneDepth int64 `db:"clone_depth" json:"clone_depth"`
 }
 
 // GetID will return the value of ID.
@@ -237,18 +240,6 @@ func (j *Job) GetCommand() string { return j.Command }
 
 // SetCommand sets Command to the provided value.
 func (j *Job) SetCommand(val string) { j.Command = val }
-
-// GetBranch will return the value of Branch.
-func (j *Job) GetBranch() string { return j.Branch }
-
-// SetBranch sets Branch to the provided value.
-func (j *Job) SetBranch(val string) { j.Branch = val }
-
-// GetRevision will return the value of Revision.
-func (j *Job) GetRevision() string { return j.Revision }
-
-// SetRevision sets Revision to the provided value.
-func (j *Job) SetRevision(val string) { j.Revision = val }
 
 // GetLabels will return the value of Labels.
 func (j *Job) GetLabels() string { return j.Labels }
@@ -316,11 +307,29 @@ func (j *Job) GetUpdatedAt() *time.Time { return j.UpdatedAt }
 // SetUpdatedAt sets UpdatedAt to the provided value.
 func (j *Job) SetUpdatedAt(stamp time.Time) { j.UpdatedAt = &stamp }
 
+// GetRef will return the value of Ref.
+func (j *Job) GetRef() string { return j.Ref }
+
+// SetRef sets Ref to the provided value.
+func (j *Job) SetRef(val string) { j.Ref = val }
+
+// GetCommitSha will return the value of CommitSha.
+func (j *Job) GetCommitSha() string { return j.CommitSha }
+
+// SetCommitSha sets CommitSha to the provided value.
+func (j *Job) SetCommitSha(val string) { j.CommitSha = val }
+
+// GetCloneDepth will return the value of CloneDepth.
+func (j *Job) GetCloneDepth() int64 { return j.CloneDepth }
+
+// SetCloneDepth sets CloneDepth to the provided value.
+func (j *Job) SetCloneDepth(val int64) { j.CloneDepth = val }
+
 // JobTable is the name of the table in the DB.
 const JobTable = "`job`"
 
 // JobFields is a list of all columns in the DB table.
-var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "branch", "revision", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at"}
+var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "ref", "commit_sha", "clone_depth"}
 
 // JobPrimaryFields are the primary key fields in the DB table.
 var JobPrimaryFields = []string{"id"}

--- a/server/schema/docs/job.md
+++ b/server/schema/docs/job.md
@@ -12,8 +12,6 @@ Job.
 | user_id           | char(26) | MUL | User ID           |
 | working_directory | varchar  |     | Working Directory |
 | command           | varchar  |     | Command           |
-| branch            | varchar  |     | Branch            |
-| revision          | varchar  |     | Revision          |
 | labels            | varchar  |     | Labels            |
 | params            | varchar  |     | Params            |
 | status            | varchar  | MUL | Status            |
@@ -25,3 +23,6 @@ Job.
 | finished_at       | datetime |     | Finished At       |
 | created_at        | datetime | MUL | Created At        |
 | updated_at        | datetime |     | Updated At        |
+| ref               | varchar  |     | Ref               |
+| commit_sha        | varchar  | MUL | Commit Sha        |
+| clone_depth       | bigint   |     | Clone Depth       |

--- a/server/schema/job_checkout.up.sql
+++ b/server/schema/job_checkout.up.sql
@@ -1,0 +1,29 @@
+-- Replace branch and revision on job with an explicit checkout model.
+--
+-- `ref` is the request, named the way git names things: a branch, a tag,
+-- a commit sha, or a fully qualified refname. Carrying `branch` and
+-- `revision` side by side meant two columns for one decision, and a tag
+-- had to be smuggled through the branch field and hope the agent's
+-- fallback chain caught it.
+--
+-- `commit_sha` is the answer rather than the question: the commit the
+-- agent actually checked out. A tag moves, so a job that records only
+-- "v1.2.3" cannot be reproduced later.
+--
+-- `clone_depth` limits the history of the job's work tree; 0 is the
+-- whole history. It is deliberately not called `depth`, which already
+-- means how deeply this job nests under its parent.
+ALTER TABLE job ADD COLUMN ref TEXT NOT NULL DEFAULT '';
+ALTER TABLE job ADD COLUMN commit_sha TEXT NOT NULL DEFAULT '';
+ALTER TABLE job ADD COLUMN clone_depth INTEGER NOT NULL DEFAULT 0;
+
+-- Carry the old columns over: a pinned revision was the more specific of
+-- the two, so it wins where a row has both.
+UPDATE job SET ref = revision WHERE ref = '' AND revision <> '';
+UPDATE job SET ref = branch WHERE ref = '' AND branch <> '';
+UPDATE job SET commit_sha = revision WHERE commit_sha = '' AND length(revision) = 40;
+
+ALTER TABLE job DROP COLUMN branch;
+ALTER TABLE job DROP COLUMN revision;
+
+CREATE INDEX IF NOT EXISTS idx_job_commit_sha ON job(commit_sha);

--- a/server/schema/schema.yml
+++ b/server/schema/schema.yml
@@ -39,14 +39,6 @@
       type: text
       comment: Command
       datatype: varchar
-    - name: branch
-      type: text
-      comment: Branch
-      datatype: varchar
-    - name: revision
-      type: text
-      comment: Revision
-      datatype: varchar
     - name: labels
       type: text
       comment: Labels
@@ -103,12 +95,29 @@
       type: timestamp
       comment: Updated At
       datatype: datetime
+    - name: ref
+      type: text
+      comment: Ref
+      datatype: varchar
+    - name: commit_sha
+      type: text
+      key: MUL
+      comment: Commit Sha
+      datatype: varchar
+    - name: clone_depth
+      type: integer
+      comment: Clone Depth
+      datatype: bigint
+      size: 8
   indexes:
     - name: sqlite_autoindex_job_1
       columns:
         - id
       primary: true
       unique: true
+    - name: idx_job_commit_sha
+      columns:
+        - commit_sha
     - name: idx_job_lease_expires_at
       columns:
         - lease_expires_at

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -146,8 +146,7 @@ func dispatch(t *testing.T, url, token, command, parentID string) dispatchRespon
 	status := call(t, http.MethodPost, url+"/api/dispatch", token, map[string]any{
 		"repository": map[string]string{
 			"remote_url": "git@github.com:titpetric/atkins.git",
-			"branch":     "main",
-			"revision":   "0123456789abcdef",
+			"ref":        "0123456789abcdef",
 		},
 		"working_directory": "docs",
 		"command":           command,
@@ -381,6 +380,65 @@ func TestClaimLeasesOnePendingJob(t *testing.T) {
 		"agent_id": "agent-2",
 	}, nil)
 	assert.Equal(t, http.StatusNoContent, status)
+}
+
+func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
+	url := testServer(t)
+	token := register(t, url)
+
+	var triggered dispatchResponse
+	seed := dispatch(t, url, token.Token, "atkins", "")
+	status := call(t, http.MethodPost, url+"/api/repository/"+seed.RepositoryID+"/trigger", token.Token, map[string]any{
+		"job": "build",
+		"ref": "v1.2.3",
+	}, &triggered)
+	require.Equal(t, http.StatusCreated, status)
+
+	// A checkout can only be reported for a job an agent is running.
+	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", token.Token, map[string]any{
+		"ref":        "v1.2.3",
+		"commit_sha": "0123456789abcdef0123456789abcdef01234567",
+	}, nil)
+	assert.Equal(t, http.StatusConflict, status)
+
+	// The seed dispatch is ahead of it in the queue, so the agent takes
+	// two jobs to reach the triggered one.
+	var claimed claimResponse
+	for range 2 {
+		status = call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+			"agent_id": "agent-1",
+		}, &claimed)
+		require.Equal(t, http.StatusOK, status)
+	}
+	require.NotNil(t, claimed.Job)
+	require.Equal(t, triggered.JobID, claimed.Job.ID)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", token.Token, map[string]any{
+		"ref":        "v1.2.3",
+		"commit_sha": "0123456789abcdef0123456789abcdef01234567",
+	}, nil)
+	require.Equal(t, http.StatusNoContent, status)
+
+	var job map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+triggered.JobID, token.Token, nil, &job)
+	require.Equal(t, http.StatusOK, status)
+
+	// The tag says what was asked for; the sha says what ran, and only
+	// one of the two survives the tag being moved.
+	assert.Equal(t, "v1.2.3", job["ref"])
+	assert.Equal(t, "0123456789abcdef0123456789abcdef01234567", job["commit_sha"])
+}
+
+func TestJobCheckoutRequiresACommit(t *testing.T) {
+	url := testServer(t)
+	token := register(t, url)
+
+	job := dispatch(t, url, token.Token, "atkins build", "")
+
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/checkout", token.Token, map[string]any{
+		"ref": "main",
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
 }
 
 func TestClaimRespectsLabels(t *testing.T) {

--- a/server/storage/job.go
+++ b/server/storage/job.go
@@ -71,9 +71,17 @@ type JobRequest struct {
 	// Command is the atkins invocation to run, verbatim.
 	Command string
 
-	Branch   string
-	Revision string
-	Labels   []string
+	// Ref is what to check out: a branch, a tag, a commit sha or a
+	// fully qualified refname. Empty means the repository's default
+	// branch, resolved by the agent when the job runs rather than here,
+	// so a nightly trigger follows the branch it is pointed at.
+	Ref string
+
+	// CloneDepth limits the history of the job's work tree. 0 is the
+	// whole history.
+	CloneDepth int64
+
+	Labels []string
 
 	// Params is a JSON object handed to the job as ATKINS_JOB_PARAMS.
 	Params string
@@ -122,8 +130,8 @@ func (s *JobStorage) Create(ctx context.Context, req JobRequest) (*model.Job, er
 		UserID:           req.UserID,
 		WorkingDirectory: req.WorkingDirectory,
 		Command:          req.Command,
-		Branch:           req.Branch,
-		Revision:         req.Revision,
+		Ref:              req.Ref,
+		CloneDepth:       req.CloneDepth,
 		Labels:           strings.Join(req.Labels, ","),
 		Params:           params,
 		Status:           model.JobStatusPending,
@@ -213,6 +221,40 @@ func (s *JobStorage) Heartbeat(ctx context.Context, jobID, agentID string) error
 	if db.RowsAffected() == 0 {
 		return sql.ErrNoRows
 	}
+	return nil
+}
+
+// CheckoutRequest is what an agent reports having checked out.
+type CheckoutRequest struct {
+	// Ref is the effective ref: the one the job named, or the default
+	// branch the agent resolved for a job that named none.
+	Ref string
+
+	// CommitSHA is the commit the work tree was placed at.
+	CommitSHA string
+}
+
+// RecordCheckout stores what an agent checked out for a job.
+//
+// It is guarded on the job still running, so a late report from an agent
+// whose lease was already swept cannot rewrite the checkout of the run
+// that replaced it.
+func (s *JobStorage) RecordCheckout(ctx context.Context, jobID string, req CheckoutRequest) error {
+	ctx, span := telemetry.StartAuto(ctx, s.RecordCheckout)
+	defer span.End()
+
+	now := time.Now()
+	db := client(s.db)
+
+	query := `UPDATE ` + model.JobTable + ` SET ref = ?, commit_sha = ?, updated_at = ?
+		WHERE id = ? AND status = ?`
+	if err := db.Exec(ctx, query, req.Ref, req.CommitSHA, now, jobID, model.JobStatusRunning); err != nil {
+		return fmt.Errorf("record checkout: %w", err)
+	}
+	if db.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
 	return nil
 }
 

--- a/server/trigger_test.go
+++ b/server/trigger_test.go
@@ -46,7 +46,8 @@ func TestTriggerAcceptsAnExplicitCommand(t *testing.T) {
 	status := call(t, http.MethodPost, url+"/api/repository/"+seed.RepositoryID+"/trigger", admin.Token, map[string]any{
 		"command":           "atkins -f ci/nightly.yml build",
 		"working_directory": "server",
-		"revision":          "0123456789abcdef",
+		"ref":               "refs/tags/v1.2.3",
+		"clone_depth":       1,
 	}, &triggered)
 	require.Equal(t, http.StatusCreated, status)
 
@@ -55,7 +56,60 @@ func TestTriggerAcceptsAnExplicitCommand(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	assert.Equal(t, "atkins -f ci/nightly.yml build", job["command"])
 	assert.Equal(t, "server", job["working_directory"])
-	assert.Equal(t, "0123456789abcdef", job["revision"])
+	assert.Equal(t, "refs/tags/v1.2.3", job["ref"])
+	assert.Equal(t, float64(1), job["clone_depth"])
+}
+
+func TestTriggerAcceptsATag(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	seed := dispatch(t, url, admin.Token, "atkins", "")
+
+	// The point of the ref field: a tag says it is a tag rather than
+	// travelling in the branch field and working by accident.
+	var triggered dispatchResponse
+	status := call(t, http.MethodPost, url+"/api/repository/"+seed.RepositoryID+"/trigger", admin.Token, map[string]any{
+		"job": "analyzeTag",
+		"ref": "v1.2.3",
+	}, &triggered)
+	require.Equal(t, http.StatusCreated, status)
+
+	var job map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+triggered.JobID, admin.Token, nil, &job)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "v1.2.3", job["ref"])
+	assert.Empty(t, job["commit_sha"])
+}
+
+func TestTriggerFoldsTheDeprecatedFields(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	seed := dispatch(t, url, admin.Token, "atkins", "")
+
+	// A trigger script written against the earlier API keeps working:
+	// branch and revision fold into ref, with the revision winning as
+	// the more specific of the two.
+	for _, testcase := range []struct {
+		name    string
+		payload map[string]any
+		ref     string
+	}{
+		{"branch only", map[string]any{"job": "build", "branch": "main"}, "main"},
+		{"revision only", map[string]any{"job": "build", "revision": "0123456789abcdef"}, "0123456789abcdef"},
+		{"both", map[string]any{"job": "build", "branch": "main", "revision": "0123456789abcdef"}, "0123456789abcdef"},
+		{"neither", map[string]any{"job": "build"}, ""},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			var triggered dispatchResponse
+			status := call(t, http.MethodPost, url+"/api/repository/"+seed.RepositoryID+"/trigger", admin.Token, testcase.payload, &triggered)
+			require.Equal(t, http.StatusCreated, status)
+
+			var job map[string]any
+			status = call(t, http.MethodGet, url+"/api/job/"+triggered.JobID, admin.Token, nil, &job)
+			require.Equal(t, http.StatusOK, status)
+			assert.Equal(t, testcase.ref, job["ref"])
+		})
+	}
 }
 
 func TestTriggerNestsUnderADispatchingJob(t *testing.T) {

--- a/server/web/templates/job.html
+++ b/server/web/templates/job.html
@@ -30,12 +30,16 @@
       <td class="mono">{{if .Job.WorkingDirectory}}{{.Job.WorkingDirectory}}{{else}}.{{end}}</td>
     </tr>
     <tr>
-      <th>Branch</th>
-      <td class="mono">{{if .Job.Branch}}{{.Job.Branch}}{{else}}—{{end}}</td>
+      <th>Ref</th>
+      <td class="mono">{{if .Job.Ref}}{{.Job.Ref}}{{else}}default branch{{end}}</td>
     </tr>
     <tr>
-      <th>Revision</th>
-      <td class="mono">{{if .Job.Revision}}{{.Job.Revision}}{{else}}—{{end}}</td>
+      <th>Commit</th>
+      <td class="mono">{{if .Job.CommitSha}}{{.Job.CommitSha}}{{else}}—{{end}}</td>
+    </tr>
+    <tr>
+      <th>Clone depth</th>
+      <td class="mono">{{if .Job.CloneDepth}}{{.Job.CloneDepth}}{{else}}full history{{end}}</td>
     </tr>
     <tr>
       <th>Labels</th>

--- a/worker/execute.go
+++ b/worker/execute.go
@@ -95,11 +95,21 @@ func (w *Worker) environment(job *jobContext, workspace *Workspace) []string {
 			"ATKINS_REMOTE_URL="+job.Repository.RemoteURL,
 		)
 	}
-	if job.Job.Revision != "" {
-		env = append(env, "ATKINS_REVISION="+job.Job.Revision)
+	// The checkout the agent produced, not the one the job asked for.
+	// ATKINS_REVISION stays the name it has always had and now always
+	// holds a resolved sha, so a pipeline reading it can pin an artefact
+	// to a commit even when the job named a branch or a moving tag.
+	if workspace.Checkout.Ref != "" {
+		env = append(env, "ATKINS_REF="+workspace.Checkout.Ref)
 	}
-	if job.Job.Branch != "" {
-		env = append(env, "ATKINS_BRANCH="+job.Job.Branch)
+	if sha := workspace.Checkout.CommitSHA; sha != "" {
+		env = append(env,
+			"ATKINS_COMMIT_SHA="+sha,
+			"ATKINS_REVISION="+sha,
+		)
+	}
+	if workspace.Checkout.Branch != "" {
+		env = append(env, "ATKINS_BRANCH="+workspace.Checkout.Branch)
 	}
 
 	return env

--- a/worker/repository.go
+++ b/worker/repository.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -18,16 +19,39 @@ type Workspace struct {
 	// Dir is the directory the command runs in: Root joined with the
 	// job's working directory.
 	Dir string
+
+	// Checkout is what the work tree ended up at.
+	Checkout Checkout
+}
+
+// Checkout records what the agent actually put in the work tree.
+//
+// Ref is the effective ref: the one the job named, or the default branch
+// resolved for a job that named nothing. CommitSHA is what that ref
+// pointed at when the job ran — a tag moves, so a run recorded as
+// "v1.2.3" alone cannot be reproduced later.
+type Checkout struct {
+	Ref       string
+	CommitSHA string
+
+	// Branch is set when Ref named a branch and empty for a tag or a
+	// bare commit. A job reads it as ATKINS_BRANCH.
+	Branch string
 }
 
 // prepare produces a checkout for a job.
 //
 // Clones are cached per repository under <DataDir>/repos, so the second
 // job for a repository fetches instead of downloading it again. Each
-// job then gets its own work tree cloned from that cache, which keeps
+// job then gets its own work tree built from that cache, which keeps
 // concurrent jobs from fighting over one checkout.
 func (w *Worker) prepare(ctx context.Context, job *jobContext) (*Workspace, error) {
 	cache, err := w.cacheRepository(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+
+	checkout, err := w.resolve(ctx, cache, job)
 	if err != nil {
 		return nil, err
 	}
@@ -37,12 +61,7 @@ func (w *Worker) prepare(ctx context.Context, job *jobContext) (*Workspace, erro
 		return nil, fmt.Errorf("create work directory: %w", err)
 	}
 
-	// A local clone of the mirror is cheap: git hardlinks the objects.
-	if _, err := w.git(ctx, "", "clone", "--no-checkout", cache, root); err != nil {
-		return nil, fmt.Errorf("clone work tree: %w", err)
-	}
-
-	if err := w.checkout(ctx, root, job); err != nil {
+	if err := w.workTree(ctx, cache, root, checkout.CommitSHA, cloneDepth(job.Job.CloneDepth)); err != nil {
 		return nil, err
 	}
 
@@ -54,7 +73,7 @@ func (w *Worker) prepare(ctx context.Context, job *jobContext) (*Workspace, erro
 		}
 	}
 
-	return &Workspace{Root: root, Dir: dir}, nil
+	return &Workspace{Root: root, Dir: dir, Checkout: *checkout}, nil
 }
 
 // CleanWorkingDirectory normalizes a job's working directory into a
@@ -81,6 +100,12 @@ func CleanWorkingDirectory(dir string) string {
 
 // cacheRepository clones or updates the mirror for a repository and
 // returns its path.
+//
+// The mirror is always complete, whatever depth a job asks for. It is
+// the agent's copy of the remote rather than any one job's checkout: a
+// shallow cache would have to be deepened the first time a job named an
+// older tag, and deepening repeatedly costs more than never having
+// thrown the objects away.
 func (w *Worker) cacheRepository(ctx context.Context, job *jobContext) (string, error) {
 	remote := CloneURL(job.Repository.RemoteURL, job.Repository.Slug, w.opts.PreferHTTPS)
 	if remote == "" {
@@ -113,31 +138,174 @@ func (w *Worker) cacheRepository(ctx context.Context, job *jobContext) (string, 
 	return cache, nil
 }
 
-// checkout moves the work tree to the revision the job named, falling
-// back to its branch and then to whatever the mirror's HEAD points at.
-func (w *Worker) checkout(ctx context.Context, root string, job *jobContext) error {
-	candidates := []string{}
-	if job.Job.Revision != "" {
-		candidates = append(candidates, job.Job.Revision)
+// resolve turns the ref a job named into a commit.
+//
+// Resolution happens against the cache, where refs carry the names the
+// remote gives them, and it happens exactly once: the work tree is then
+// built around the sha, so a tag that moves between resolving it and
+// checking it out cannot split one job across two commits.
+//
+// A named ref that does not resolve is a failure, not an invitation to
+// build something else. Falling through to the default branch is how a
+// typo in a tag name turns into a green run of the wrong code.
+func (w *Worker) resolve(ctx context.Context, cache string, job *jobContext) (*Checkout, error) {
+	requested := strings.TrimSpace(job.Job.Ref)
+	if requested == "" {
+		return w.resolveDefault(ctx, cache, job)
 	}
-	if job.Job.Branch != "" && job.Job.Branch != "HEAD" {
-		candidates = append(candidates, "origin/"+job.Job.Branch, job.Job.Branch)
-	}
-	if job.Repository.DefaultBranch != "" {
-		candidates = append(candidates, "origin/"+job.Repository.DefaultBranch)
-	}
-	candidates = append(candidates, "HEAD")
 
-	var lastErr error
-	for _, ref := range candidates {
-		if out, err := w.git(ctx, root, "checkout", "--force", ref); err == nil {
-			return nil
-		} else {
-			lastErr = fmt.Errorf("checkout %s: %w\n%s", ref, err, out)
+	for _, candidate := range refCandidates(requested) {
+		sha := w.revision(ctx, cache, candidate)
+		if sha == "" {
+			continue
+		}
+		return &Checkout{Ref: requested, CommitSHA: sha, Branch: branchName(candidate)}, nil
+	}
+
+	// Naming the ref matters. "checkout failed" for a tag nobody pushed
+	// sends whoever reads it looking at the agent instead of at the tag.
+	return nil, fmt.Errorf("ref %q not found in %s", requested, job.Repository.Slug)
+}
+
+// resolveDefault picks what a job that named no ref should build: the
+// repository's default branch, or whatever the mirror's HEAD points at
+// when the server never learned one.
+func (w *Worker) resolveDefault(ctx context.Context, cache string, job *jobContext) (*Checkout, error) {
+	candidates := []string{}
+	if branch := strings.TrimSpace(job.Repository.DefaultBranch); branch != "" {
+		candidates = append(candidates, "refs/heads/"+branch)
+	}
+	if head, err := w.gitOutput(ctx, cache, "symbolic-ref", "--quiet", "HEAD"); err == nil && head != "" {
+		candidates = append(candidates, head)
+	}
+
+	for _, candidate := range candidates {
+		sha := w.revision(ctx, cache, candidate)
+		if sha == "" {
+			continue
+		}
+
+		branch := branchName(candidate)
+		ref := branch
+		if ref == "" {
+			ref = candidate
+		}
+		return &Checkout{Ref: ref, CommitSHA: sha, Branch: branch}, nil
+	}
+
+	return nil, fmt.Errorf("%s has no default branch to check out", job.Repository.Slug)
+}
+
+// revision resolves one candidate to a commit sha, or "" when the cache
+// has no such ref.
+func (w *Worker) revision(ctx context.Context, dir, candidate string) string {
+	sha, err := w.gitOutput(ctx, dir, "rev-parse", "--verify", "--quiet", candidate+"^{commit}")
+	if err != nil {
+		return ""
+	}
+	return sha
+}
+
+// refCandidates expands a ref into what it could name, in git's own
+// order: a fully qualified ref as given, then a tag, then a branch, then
+// anything else rev-parse understands — which is what lets a bare commit
+// sha work without being declared as one.
+func refCandidates(ref string) []string {
+	if strings.HasPrefix(ref, "refs/") {
+		return []string{ref}
+	}
+	return []string{"refs/tags/" + ref, "refs/heads/" + ref, ref}
+}
+
+// branchName returns the branch a candidate names, or "".
+func branchName(candidate string) string {
+	if branch, found := strings.CutPrefix(candidate, "refs/heads/"); found {
+		return branch
+	}
+	return ""
+}
+
+// cloneDepth clamps a requested depth. A negative depth is a bad payload
+// rather than an instruction, and 0 means the whole history.
+func cloneDepth(depth int64) int64 {
+	if depth < 0 {
+		return 0
+	}
+	return depth
+}
+
+// workTree builds the job's work tree from the cache, at one commit.
+//
+// Depth belongs here and never on the cache. The cache is shared by
+// every job for a repository, so one job asking for a single commit must
+// not leave the next one refetching history the agent had already paid
+// for; the work tree is thrown away when the job ends, so limiting it
+// costs nothing later.
+func (w *Worker) workTree(ctx context.Context, cache, root, sha string, depth int64) error {
+	if depth > 0 {
+		return w.shallowWorkTree(ctx, cache, root, sha, depth)
+	}
+	return w.fullWorkTree(ctx, cache, root, sha)
+}
+
+// fullWorkTree clones the whole cache into the work tree.
+func (w *Worker) fullWorkTree(ctx context.Context, cache, root, sha string) error {
+	// A local clone of the mirror is cheap: git hardlinks the objects.
+	if out, err := w.git(ctx, "", "clone", "--no-checkout", cache, root); err != nil {
+		return fmt.Errorf("clone work tree: %w\n%s", err, out)
+	}
+
+	// A clone takes branches and tags. A commit the mirror holds under
+	// anything else — refs/pull/*, say — is not in the clone, so fetch it
+	// rather than fail on a ref that demonstrably resolved a moment ago.
+	if w.revision(ctx, root, sha) == "" {
+		if out, err := w.git(ctx, root, "fetch", "--quiet", "--no-tags", "origin", sha); err != nil {
+			return fmt.Errorf("fetch %s: %w\n%s", sha, err, out)
 		}
 	}
 
-	return lastErr
+	return w.checkout(ctx, root, sha)
+}
+
+// shallowWorkTree builds a work tree holding depth commits of history.
+//
+// `git clone` ignores --depth for a local path — it hardlinks the whole
+// object store instead — so the shallow work tree is assembled by hand:
+// an empty repository, then a depth-limited fetch of the one commit that
+// was already resolved.
+func (w *Worker) shallowWorkTree(ctx context.Context, cache, root, sha string, depth int64) error {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return fmt.Errorf("create work tree: %w", err)
+	}
+	if out, err := w.git(ctx, root, "init", "--quiet"); err != nil {
+		return fmt.Errorf("init work tree: %w\n%s", err, out)
+	}
+	if out, err := w.git(ctx, root, "remote", "add", "origin", cache); err != nil {
+		return fmt.Errorf("add cache remote: %w\n%s", err, out)
+	}
+
+	// allowAnySHA1InWant lets the fetch name the commit rather than the
+	// ref it came from: the ref was resolved against this cache already,
+	// and resolving it a second time is a chance for it to have moved.
+	out, err := w.git(ctx, root,
+		"-c", "uploadpack.allowAnySHA1InWant=true",
+		"fetch", "--quiet", "--depth", strconv.FormatInt(depth, 10), "origin", sha)
+	if err != nil {
+		return fmt.Errorf("fetch %s at depth %d: %w\n%s", sha, depth, err, out)
+	}
+
+	return w.checkout(ctx, root, sha)
+}
+
+// checkout detaches the work tree at a commit.
+//
+// Detaching is deliberate: a job builds one commit, and leaving a branch
+// checked out would suggest the job has somewhere to push it back to.
+func (w *Worker) checkout(ctx context.Context, root, sha string) error {
+	if out, err := w.git(ctx, root, "checkout", "--force", "--detach", sha); err != nil {
+		return fmt.Errorf("checkout %s: %w\n%s", sha, err, out)
+	}
+	return nil
 }
 
 // cachePath turns a repository slug into a relative directory path.
@@ -179,8 +347,25 @@ func isSSHRemote(remoteURL string) bool {
 		(strings.Contains(remoteURL, "@") && strings.Contains(remoteURL, ":") && !strings.Contains(remoteURL, "://"))
 }
 
-// git runs a git command, returning its combined output.
+// git runs a git command, returning its combined output. It is for the
+// commands whose output is only ever read by a human diagnosing a
+// failure.
 func (w *Worker) git(ctx context.Context, dir string, args ...string) (string, error) {
+	out, err := w.gitCommand(ctx, dir, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// gitOutput runs a git command and returns its standard output alone.
+//
+// Combined output would fold a warning on stderr into a value the agent
+// is about to treat as a commit sha.
+func (w *Worker) gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	out, err := w.gitCommand(ctx, dir, args...).Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// gitCommand prepares a git invocation with the agent's environment.
+func (w *Worker) gitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
@@ -196,6 +381,5 @@ func (w *Worker) git(ctx context.Context, dir string, args ...string) (string, e
 	}
 	cmd.Env = append(env, "GIT_SSH_COMMAND="+sshCommand)
 
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	return cmd
 }

--- a/worker/repository_test.go
+++ b/worker/repository_test.go
@@ -87,6 +87,29 @@ func TestCachePath(t *testing.T) {
 	assert.Equal(t, "srv/git/demo.git", cachePath("/srv/git/demo"))
 }
 
+func TestRefCandidates(t *testing.T) {
+	// A tag beats a branch of the same name, which is git's own order.
+	assert.Equal(t, []string{"refs/tags/v1.0.0", "refs/heads/v1.0.0", "v1.0.0"}, refCandidates("v1.0.0"))
+
+	// A fully qualified ref is taken at its word, so refs/pull/7/head
+	// is not looked for under refs/tags first.
+	assert.Equal(t, []string{"refs/pull/7/head"}, refCandidates("refs/pull/7/head"))
+}
+
+func TestBranchName(t *testing.T) {
+	assert.Equal(t, "main", branchName("refs/heads/main"))
+	assert.Empty(t, branchName("refs/tags/v1.0.0"))
+	assert.Empty(t, branchName("0123456789abcdef"))
+}
+
+func TestCloneDepth(t *testing.T) {
+	assert.Equal(t, int64(0), cloneDepth(0))
+	assert.Equal(t, int64(1), cloneDepth(1))
+
+	// A negative depth is a bad payload rather than an instruction.
+	assert.Equal(t, int64(0), cloneDepth(-5))
+}
+
 func TestCleanWorkingDirectory(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/worker/run_test.go
+++ b/worker/run_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,13 +20,37 @@ import (
 	"github.com/titpetric/atkins/server/model"
 )
 
-// gitRepository builds a repository with one commit and returns its
-// path, usable as a clone remote.
-func gitRepository(t *testing.T) string {
+// testRepository is a git repository built for the checkout tests, and
+// the shas of the things a job can ask for.
+type testRepository struct {
+	// Path is the work tree, usable as a clone remote.
+	Path string
+
+	// First, Tagged and Head are the three commits on main, oldest
+	// first. Feature is the tip of the second branch.
+	First   string
+	Tagged  string
+	Head    string
+	Feature string
+}
+
+// The names a job can put in its ref field for this repository.
+const (
+	testTag    = "v1.0.0"
+	testBranch = "feature"
+)
+
+// gitRepository builds a repository with three commits on main, a tag
+// two commits back, and a second branch.
+//
+// Every commit writes a different marker.txt, so a test can tell which
+// commit ended up in the work tree by reading a file rather than by
+// trusting what the agent reported about itself.
+func gitRepository(t *testing.T) *testRepository {
 	t.Helper()
 
 	dir := t.TempDir()
-	run := func(args ...string) {
+	run := func(args ...string) string {
 		t.Helper()
 
 		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
@@ -35,16 +60,35 @@ func gitRepository(t *testing.T) string {
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(out))
+
+		return strings.TrimSpace(string(out))
+	}
+
+	commit := func(marker, message string) string {
+		t.Helper()
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "marker.txt"), []byte(marker+"\n"), 0o644))
+		run("add", ".")
+		run("commit", "-m", message)
+
+		return run("rev-parse", "HEAD")
 	}
 
 	run("init", "--initial-branch=main")
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "marker.txt"), []byte("in-sub\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("at-root\n"), 0o644))
-	run("add", ".")
-	run("commit", "-m", "initial")
 
-	return dir
+	repository := &testRepository{Path: dir}
+	repository.First = commit("first", "initial")
+	repository.Tagged = commit("tagged", "release")
+	run("tag", testTag)
+	repository.Head = commit("at-root", "after the release")
+
+	run("checkout", "-b", testBranch)
+	repository.Feature = commit("on-feature", "feature work")
+	run("checkout", "main")
+
+	return repository
 }
 
 // agentServer is a minimal stand-in for the queue endpoints an agent
@@ -56,6 +100,7 @@ type agentServer struct {
 	output     strings.Builder
 	status     client.JobStatusRequest
 	statusSeen bool
+	checkout   client.JobCheckoutRequest
 	heartbeats int
 }
 
@@ -93,6 +138,10 @@ func newAgentServer(t *testing.T, policy client.PolicyResponse) *agentServer {
 			fake.output.WriteString(req.Content)
 			w.WriteHeader(http.StatusNoContent)
 
+		case strings.HasSuffix(r.URL.Path, "/checkout"):
+			_ = json.NewDecoder(r.Body).Decode(&fake.checkout)
+			w.WriteHeader(http.StatusNoContent)
+
 		case strings.HasSuffix(r.URL.Path, "/heartbeat"):
 			fake.heartbeats++
 			w.WriteHeader(http.StatusNoContent)
@@ -120,6 +169,14 @@ func (f *agentServer) result() (string, client.JobStatusRequest) {
 	return f.output.String(), f.status
 }
 
+// checkedOut reports the ref and commit the agent recorded.
+func (f *agentServer) checkedOut() client.JobCheckoutRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.checkout
+}
+
 // testWorker enrols an agent against the fake server.
 func testWorker(t *testing.T, fake *agentServer) *Worker {
 	t.Helper()
@@ -140,7 +197,9 @@ func testWorker(t *testing.T, fake *agentServer) *Worker {
 	return worker
 }
 
-// job builds a jobContext for a repository path.
+// job builds a jobContext for a repository path. It names no ref, which
+// is the "run the default branch" case; tests that want something else
+// set Ref or CloneDepth on the result.
 func job(remote, workingDirectory, command string) *jobContext {
 	return &jobContext{
 		Job: &client.Job{
@@ -148,7 +207,6 @@ func job(remote, workingDirectory, command string) *jobContext {
 			RootID:           "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 			WorkingDirectory: workingDirectory,
 			Command:          command,
-			Branch:           "main",
 		},
 		Repository: &client.Repository{
 			ID:            "repo-1",
@@ -159,8 +217,17 @@ func job(remote, workingDirectory, command string) *jobContext {
 	}
 }
 
+// checkoutJob builds a job that names a ref, at an optional depth.
+func checkoutJob(remote, ref string, depth int64, command string) *jobContext {
+	job := job(remote, "", command)
+	job.Job.Ref = ref
+	job.Job.CloneDepth = depth
+
+	return job
+}
+
 func TestRunClonesAndExecutes(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -175,8 +242,171 @@ func TestRunClonesAndExecutes(t *testing.T) {
 	assert.DirExists(t, filepath.Join(worker.opts.DataDir, "repos", "local", "demo.git"))
 }
 
+func TestRunChecksOutWhatTheJobNamed(t *testing.T) {
+	repository := gitRepository(t)
+
+	tests := []struct {
+		name string
+		ref  string
+
+		// marker is the file content only that commit has, so the test
+		// reads the work tree rather than the agent's own account of it.
+		marker string
+		commit string
+		branch string
+	}{
+		{
+			name:   "no ref takes the default branch",
+			marker: "at-root",
+			commit: repository.Head,
+			branch: "main",
+		},
+		{
+			name:   "a tag",
+			ref:    testTag,
+			marker: "tagged",
+			commit: repository.Tagged,
+		},
+		{
+			name:   "a fully qualified tag ref",
+			ref:    "refs/tags/" + testTag,
+			marker: "tagged",
+			commit: repository.Tagged,
+		},
+		{
+			name:   "a commit sha",
+			ref:    repository.First,
+			marker: "first",
+			commit: repository.First,
+		},
+		{
+			name:   "an abbreviated commit sha",
+			ref:    repository.First[:10],
+			marker: "first",
+			commit: repository.First,
+		},
+		{
+			name:   "a branch",
+			ref:    testBranch,
+			marker: "on-feature",
+			commit: repository.Feature,
+			branch: testBranch,
+		},
+		{
+			name:   "a fully qualified branch ref",
+			ref:    "refs/heads/" + testBranch,
+			marker: "on-feature",
+			commit: repository.Feature,
+			branch: testBranch,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+			worker := testWorker(t, fake)
+
+			worker.run(t.Context(), checkoutJob(repository.Path, test.ref, 0, `cat marker.txt; echo "branch=$ATKINS_BRANCH"`))
+
+			output, status := fake.result()
+			require.Equal(t, client.StatusPassed, status.Status, output)
+			assert.Contains(t, output, test.marker)
+			assert.Contains(t, output, "branch="+test.branch+"\n")
+
+			// The commit is recorded, not just the ref: a tag moves, and
+			// "v1.0.0" alone does not say which code ran.
+			checkout := fake.checkedOut()
+			assert.Equal(t, test.commit, checkout.CommitSHA)
+			if test.ref != "" {
+				assert.Equal(t, test.ref, checkout.Ref)
+			} else {
+				assert.Equal(t, "main", checkout.Ref)
+			}
+		})
+	}
+}
+
+func TestRunFailsOnAMissingRef(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	worker.run(t.Context(), checkoutJob(remote, "v9.9.9", 0, "echo should-not-run"))
+
+	output, status := fake.result()
+	assert.Equal(t, client.StatusFailed, status.Status)
+	// Naming the ref is the whole point: a job that quietly built the
+	// default branch instead would be a green run of the wrong code.
+	assert.Contains(t, output, `ref "v9.9.9" not found in local/demo`)
+	assert.NotContains(t, output, "should-not-run")
+	assert.Empty(t, fake.checkedOut().CommitSHA)
+}
+
+func TestRunClonesShallowWhenAskedTo(t *testing.T) {
+	repository := gitRepository(t)
+
+	for _, depth := range []int64{1, 2} {
+		t.Run(fmt.Sprintf("depth %d", depth), func(t *testing.T) {
+			fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+			worker := testWorker(t, fake)
+
+			worker.run(t.Context(), checkoutJob(repository.Path, testTag, depth,
+				`cat marker.txt; git rev-list --count HEAD`))
+
+			output, status := fake.result()
+			require.Equal(t, client.StatusPassed, status.Status, output)
+			assert.Contains(t, output, "tagged")
+			assert.Contains(t, output, fmt.Sprintf("%d\n", depth))
+			assert.Equal(t, repository.Tagged, fake.checkedOut().CommitSHA)
+		})
+	}
+}
+
+func TestShallowJobLeavesTheCacheComplete(t *testing.T) {
+	repository := gitRepository(t)
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	worker.run(t.Context(), checkoutJob(repository.Path, testTag, 1, "true"))
+
+	// Depth is a property of the work tree, never of the cache: the
+	// cache is shared, and one job asking for a single commit must not
+	// cost the next one the history it already has.
+	cache := filepath.Join(worker.opts.DataDir, "repos", "local", "demo.git")
+	count, err := worker.gitOutput(t.Context(), cache, "rev-list", "--count", "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, "3", count)
+
+	// And a full job after a shallow one still gets the whole history.
+	worker.run(t.Context(), checkoutJob(repository.Path, "", 0, "git rev-list --count HEAD"))
+
+	output, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status, output)
+	assert.Contains(t, output, "3\n")
+}
+
+func TestRunExportsTheCheckoutEnvironment(t *testing.T) {
+	repository := gitRepository(t)
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	worker.run(t.Context(), checkoutJob(repository.Path, testTag, 0,
+		`echo "ref=$ATKINS_REF sha=$ATKINS_COMMIT_SHA revision=$ATKINS_REVISION branch=$ATKINS_BRANCH"`))
+
+	output, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status, output)
+	assert.Contains(t, output, "ref="+testTag)
+	assert.Contains(t, output, "sha="+repository.Tagged)
+	// ATKINS_REVISION keeps its name and now always holds a resolved
+	// commit, so a pipeline can pin an artefact even under a moving tag.
+	assert.Contains(t, output, "revision="+repository.Tagged)
+	// A tag is not a branch, and saying it was would be a lie a pipeline
+	// could act on.
+	assert.Contains(t, output, "branch=\n")
+}
+
 func TestRunUsesTheWorkingDirectory(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -190,7 +420,7 @@ func TestRunUsesTheWorkingDirectory(t *testing.T) {
 }
 
 func TestRunExportsTheJobEnvironment(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -207,7 +437,7 @@ func TestRunExportsTheJobEnvironment(t *testing.T) {
 }
 
 func TestRunReportsAFailingCommand(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -222,7 +452,7 @@ func TestRunReportsAFailingCommand(t *testing.T) {
 }
 
 func TestRunRefusesADisallowedRepository(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{
 		Policy:   model.PolicyAllowlist,
 		Patterns: []string{"github.com/titpetric/*"},
@@ -241,7 +471,7 @@ func TestRunRefusesADisallowedRepository(t *testing.T) {
 }
 
 func TestRunReportsAMissingWorkingDirectory(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -264,7 +494,7 @@ func TestRunReportsAnUnreachableRemote(t *testing.T) {
 }
 
 func TestRunCleansUpTheWorkTree(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 
@@ -277,7 +507,7 @@ func TestRunCleansUpTheWorkTree(t *testing.T) {
 }
 
 func TestRunTimesOut(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 	worker.opts.JobTimeout = 300 * time.Millisecond
@@ -303,7 +533,7 @@ func TestRunWithoutARepository(t *testing.T) {
 }
 
 func TestSecondJobFetchesTheCachedRepository(t *testing.T) {
-	remote := gitRepository(t)
+	remote := gitRepository(t).Path
 	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
 	worker := testWorker(t, fake)
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -203,6 +203,12 @@ func (w *Worker) run(ctx context.Context, job *jobContext) {
 		w.fail(ctx, job, err.Error())
 		return
 	}
+
+	// Recorded before the command runs, not with the outcome: a job that
+	// fails still has to be reproducible, and the tag it named may have
+	// moved by the time anyone reads the failure.
+	w.recordCheckout(ctx, job.Job.ID, workspace.Checkout)
+
 	defer func() {
 		if err := os.RemoveAll(workspace.Root); err != nil {
 			log.Printf("[agent] job %s: cleanup failed: %v", job.Job.ID, err)
@@ -249,6 +255,25 @@ func (w *Worker) report(ctx context.Context, jobID string, req client.JobStatusR
 
 	if err := w.client.ReportStatus(ctx, jobID, req); err != nil {
 		log.Printf("[agent] reporting job %s failed: %v", jobID, err)
+	}
+}
+
+// recordCheckout tells the server what the work tree ended up at.
+//
+// It tolerates failure like the log calls do: a job that ran is worth
+// more than the record of which commit it ran, and the agent has already
+// logged what it checked out.
+func (w *Worker) recordCheckout(ctx context.Context, jobID string, checkout Checkout) {
+	log.Printf("[agent] job %s: %s at %s", jobID, checkout.Ref, checkout.CommitSHA)
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), reportTimeout)
+	defer cancel()
+
+	if err := w.client.ReportCheckout(ctx, jobID, client.JobCheckoutRequest{
+		Ref:       checkout.Ref,
+		CommitSHA: checkout.CommitSHA,
+	}); err != nil {
+		log.Printf("[agent] recording the checkout of job %s failed: %v", jobID, err)
 	}
 }
 


### PR DESCRIPTION
Closes #30

A job now says what to check out in **one** field, and the agent records **what it actually built**. Clone depth is here too, but not where the issue put it.

```bash
curl -X POST "$SERVER/api/repository/$REPO/trigger" \
  -d '{"job": "release", "ref": "v1.2.3", "clone_depth": 1}'
```

## The field model: `ref` in, `commit_sha` out

The issue asked whether `revision`, `branch` and a new `ref` is one field too many. It is two too many. `branch` and `revision` were two columns for one decision — *what does the agent check out* — which is exactly why a tag had to travel in the branch field and worked only because the fallback chain happened to catch it.

So `job` loses both and gains three columns in `server/schema/job_checkout.up.sql`:

| Column | Meaning |
|---|---|
| `ref` | The request: a branch, a tag, a commit sha, or a fully qualified `refs/...` name |
| `commit_sha` | The answer: what that ref resolved to, written by the agent before the command runs |
| `clone_depth` | History the work tree carries; 0 is all of it |

A bare name is looked for as a tag first, then as a branch, then as anything `rev-parse` understands — git's own order, which is what makes `4f2a1c` work without being declared a sha. `refs/pull/7/head` is taken at its word.

The migration carries existing rows over (revision wins over branch, as the more specific of the two) and then drops the old columns. `atkins "$HOME/.atkins/skills/schema.yml" -w ./server migrate` regenerated `types.mig.go`, `schema.yml` and `schema/docs`.

**Deprecated, not removed, on the wire.** `branch` and `revision` are still accepted by `/api/dispatch` and `/api/repository/{id}/trigger` and folded into `ref`, so a trigger script written last week keeps working. The atkins client sends `ref` and thinks about nothing: it fills it with the commit it is sitting on, because a dispatched run belongs to the code in front of you rather than to whatever the branch has moved to by the time an agent claims the job.

## Where depth belongs, and why

**Depth is on the work tree. The cache stays a complete mirror, unconditionally.**

The cache is the agent's copy of the remote, shared by every job for that repository. Make it shallow and the first job that names an older tag has to deepen it; deepen repeatedly and you have paid more than if you had never discarded the objects. One job asking for a single commit must not cost the next one history the agent already had. `TestShallowJobLeavesTheCacheComplete` pins this: after a `clone_depth: 1` job the cache still has all three commits, and a full job after it still gets them.

The work tree is per-job and thrown away when the job ends, so limiting it costs nothing later. That makes it the only honest place for depth.

It is worth being clear about what a shallow work tree actually buys, because the issue's framing ("the agent mirrors the whole repository, which is the wrong default") suggests it is a network saving, and with a mirror cache it is not:

- It does **not** make the checkout faster. A full work tree is a local clone of the mirror, and git hardlinks the objects — very nearly free. A shallow one cannot use that path at all: `git clone` ignores `--depth` for a local path, so the shallow work tree is assembled by hand (`init`, `remote add`, `fetch --depth N <sha>`), which is a real pack transfer. Shallow is *slower* locally.
- What it buys is a **small `.git`**, which matters when the job packages the tree, copies it into a docker build context, or uploads it.

So `clone_depth` is opt-in, defaults to 0, and the documentation says to ask for it when the size of `.git` matters to the job, not to save the agent time. The network cost the issue is really pointing at is paid once per repository and amortised over every job afterwards; a blobless (`--filter=blob:none`) mirror is the option that would attack it without giving up refs, but promisor remotes plus a local clone that inherits them is a bigger change than this issue, and I left it alone.

## Other things I did differently

- **A missing ref fails the job.** Previously the checkout fell through revision → branch → default branch → `HEAD`, so a typo in a tag name produced a green run of the wrong code. Now a named ref is checked out or the job fails with `ref "v9.9.9" not found in github.com/titpetric/atkins`. The fallback survives only where there is nothing to fall back *from*: an empty ref means the default branch, resolved at run time.

  This has a visible consequence for `atkins` on a laptop: dispatching a commit you have not pushed now fails, naming it, instead of silently building the branch tip. That is the right way round, and the docs say so.

- **The ref is resolved once, against the mirror.** The work tree is then built around the sha, so a tag that moves between the resolve and the checkout cannot split one job across two commits.

- **The work tree is detached.** A job builds one commit; leaving a branch checked out would suggest it has somewhere to push it back to.

- **A new agent endpoint, `POST /api/job/{id}/checkout`.** The commit is recorded *before* the command runs rather than with the terminal status: a job that fails still has to be reproducible. It is guarded on the job running, so a late report from a swept agent cannot rewrite the run that replaced it.

- **A retry repeats the ref, not the commit.** A retried job pointed at a branch is asking for whatever that branch holds now. Pin the commit in the ref to get the same code twice — noted in the docs, since it is a defensible choice either way.

- **`ATKINS_REVISION` now always holds a resolved sha** (it used to hold whatever the client asked for), joined by `ATKINS_REF` and `ATKINS_COMMIT_SHA`. `ATKINS_BRANCH` is set only when the ref actually named a branch — saying a tag was a branch is a lie a pipeline could act on.

## Tests

`worker/run_test.go` builds a real repository with three commits on main, a tag two commits back and a second branch, each commit writing a different `marker.txt` so a test reads the work tree rather than trusting the agent's account of itself. It covers: the default branch, a tag, `refs/tags/...`, a full sha, an abbreviated sha, a branch, `refs/heads/...`, the recorded commit for each, a missing ref failing with the ref in the message, depth 1 and 2 producing exactly that many commits, the cache surviving a shallow job, and the exported environment.

`atkins test:simple` is green — 1195 tests. `atkins fmt` and `atkins test:docs` have been run.

## Verified live

`atkins up`, `atkins --register`, then triggers against `github.com/titpetric/atkins`:

```
{"status":"passed","ref":"v0.9.2","commit_sha":"71de74348e5d59ba61073886c31ce4b2dbfeff00","clone_depth":1}
  71de74348e5d59ba61073886c31ce4b2dbfeff00
  1                                          # rev-list --count, in the work tree

{"status":"failed","ref":"v9.9.9-nope","commit_sha":"","clone_depth":0}
  ref "v9.9.9-nope" not found in github.com/titpetric/atkins

{"status":"passed","ref":"main","commit_sha":"fa1be55f4ff526dd3cac2e24ab1eab896f1ea52b","clone_depth":0}
```

`v0.9.2` is `71de743` on the remote, so the tag resolved to the right commit. The cache after the depth-1 job still had all 230 commits on `main`. The job page shows Ref, Commit and Clone depth.

## One thing for the reviewer

`git describe --tags --exact-match` fails inside a `clone_depth: 1` job — a shallow fetch of a commit brings no tag refs with it, even the tag the job named. `ATKINS_REF` carries that name into the job instead, which is what a build normally wanted `git describe` for, and the documentation calls it out. Fetching the tag ref rather than the sha would fix it but would resolve the ref a second time, which is the race this deliberately closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
