### PR TITLE
server: job retention sweep and per-user visibility

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -274,8 +274,17 @@ func contentTypeOrDefault(value string) string {
 
 // JobURL is where a job is watched in a browser. It is the one thing
 // atkins prints when it hands a run to a server.
-func (c *Client) JobURL(jobID string) string {
-	return c.server + "/job/" + jobID
+//
+// A server that keeps jobs private hands back a view token with the
+// job, and it belongs in the URL: the page has no session to check, and
+// the whole point of the line atkins prints is that pasting it into a
+// browser opens the run. An empty token leaves the URL as it was.
+func (c *Client) JobURL(jobID, viewToken string) string {
+	url := c.server + "/job/" + jobID
+	if viewToken == "" {
+		return url
+	}
+	return url + "?t=" + viewToken
 }
 
 // Enrol trades the shared agent token for agent credentials.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -155,6 +155,7 @@ func TestDispatchAndJobURL(t *testing.T) {
 		RootID:         "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 		RepositorySlug: "github.com/titpetric/atkins",
 		Status:         "pending",
+		ViewToken:      "abcdefghijklmnopqrstuv",
 	})
 
 	c := client.New(fake.URL)
@@ -168,7 +169,13 @@ func TestDispatchAndJobURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "01ARZ3NDEKTSV4RRFFQ69G5FAV", response.JobID)
 
-	assert.Equal(t, fake.URL+"/job/01ARZ3NDEKTSV4RRFFQ69G5FAV", c.JobURL(response.JobID))
+	// The URL atkins prints carries the view token the server issued,
+	// because the page it opens has no session to authenticate with.
+	assert.Equal(t, fake.URL+"/job/01ARZ3NDEKTSV4RRFFQ69G5FAV?t=abcdefghijklmnopqrstuv",
+		c.JobURL(response.JobID, response.ViewToken))
+
+	// A public server issues no token, and the plain URL is what opens.
+	assert.Equal(t, fake.URL+"/job/01ARZ3NDEKTSV4RRFFQ69G5FAV", c.JobURL(response.JobID, ""))
 
 	// The dispatch call carried the access token.
 	last := fake.requests[len(fake.requests)-1]

--- a/client/dispatch.go
+++ b/client/dispatch.go
@@ -137,7 +137,7 @@ func Dispatch(ctx context.Context, opts DispatchOptions) *Dispatched {
 
 	return &Dispatched{
 		JobID:          response.JobID,
-		URL:            c.JobURL(response.JobID),
+		URL:            c.JobURL(response.JobID, response.ViewToken),
 		RepositorySlug: response.RepositorySlug,
 	}
 }

--- a/client/types.go
+++ b/client/types.go
@@ -74,6 +74,11 @@ type DispatchResponse struct {
 	RepositoryID   string `json:"repository_id"`
 	RepositorySlug string `json:"repository_slug"`
 	Status         string `json:"status"`
+
+	// ViewToken opens the job page in a browser without a session. A
+	// server that keeps jobs private returns one; a public one returns
+	// nothing and the plain job URL opens.
+	ViewToken string `json:"view_token,omitempty"`
 }
 
 // EnrolRequest is the body of POST /api/agent/enrol.

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type ServerConfig struct {
 	MaxJobDepth       int64         `yaml:"max_job_depth" json:"max_job_depth" env:"ATKINS_MAX_JOB_DEPTH"`
 	LeaseTTL          time.Duration `yaml:"lease_ttl" json:"lease_ttl" env:"ATKINS_LEASE_TTL"`
 	ReclaimInterval   time.Duration `yaml:"reclaim_interval" json:"reclaim_interval" env:"ATKINS_RECLAIM_INTERVAL"`
+	RetentionInterval time.Duration `yaml:"retention_interval" json:"retention_interval" env:"ATKINS_RETENTION_INTERVAL"`
 }
 
 // AgentConfig is the worker that runs jobs.

--- a/config/config.yml
+++ b/config/config.yml
@@ -74,6 +74,11 @@ server:
   # How often expired leases are swept back out of `running`.
   reclaim_interval: 1m
 
+  # How often job.retention and job.log_retention are applied. The
+  # windows themselves are settings an admin changes at runtime; this
+  # is only how often the server goes looking.
+  retention_interval: 1h
+
 # Settings for `atkins worker`, the CI/CD agent.
 agent:
   # Identity in job leases. Empty means the hostname.

--- a/config/validate.go
+++ b/config/validate.go
@@ -93,6 +93,9 @@ func (s *ServerConfig) applyDefaults(defaults ServerConfig) {
 	if s.ReclaimInterval < 0 {
 		s.ReclaimInterval = defaults.ReclaimInterval
 	}
+	if s.RetentionInterval < 0 {
+		s.RetentionInterval = defaults.RetentionInterval
+	}
 }
 
 // problems reports server values that cannot work.

--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -180,6 +180,11 @@ type DispatchResponse struct {
 	RepositoryID   string `json:"repository_id"`
 	RepositorySlug string `json:"repository_slug"`
 	Status         string `json:"status"`
+
+	// ViewToken opens the job page in a browser without a session. A
+	// server that keeps jobs private returns one; a public one returns
+	// nothing and the plain job URL opens.
+	ViewToken string `json:"view_token,omitempty"`
 }
 ```
 
@@ -525,7 +530,7 @@ var UserAgent = "atkins"
 - `func (*Client) Dispatch (ctx context.Context, req DispatchRequest) (*DispatchResponse, error)`
 - `func (*Client) Enrol (ctx context.Context, req EnrolRequest) (*Credential, error)`
 - `func (*Client) Heartbeat (ctx context.Context, jobID,agentID string) error`
-- `func (*Client) JobURL (jobID string) string`
+- `func (*Client) JobURL (jobID,viewToken string) string`
 - `func (*Client) Login (ctx context.Context, req LoginRequest) (*Credential, error)`
 - `func (*Client) Logout (ctx context.Context) error`
 - `func (*Client) Policy (ctx context.Context) (*PolicyResponse, error)`
@@ -815,8 +820,13 @@ func (*Client) Heartbeat(ctx context.Context, jobID, agentID string) error
 JobURL is where a job is watched in a browser. It is the one thing
 atkins prints when it hands a run to a server.
 
+A server that keeps jobs private hands back a view token with the
+job, and it belongs in the URL: the page has no session to check, and
+the whole point of the line atkins prints is that pasting it into a
+browser opens the run. An empty token leaves the URL as it was.
+
 ```go
-func (*Client) JobURL(jobID string) string
+func (*Client) JobURL(jobID, viewToken string) string
 ```
 
 ### Login

--- a/docs/api/atkins_config.md
+++ b/docs/api/atkins_config.md
@@ -140,6 +140,7 @@ type ServerConfig struct {
 	MaxJobDepth       int64         `yaml:"max_job_depth" json:"max_job_depth" env:"ATKINS_MAX_JOB_DEPTH"`
 	LeaseTTL          time.Duration `yaml:"lease_ttl" json:"lease_ttl" env:"ATKINS_LEASE_TTL"`
 	ReclaimInterval   time.Duration `yaml:"reclaim_interval" json:"reclaim_interval" env:"ATKINS_RECLAIM_INTERVAL"`
+	RetentionInterval time.Duration `yaml:"retention_interval" json:"retention_interval" env:"ATKINS_RETENTION_INTERVAL"`
 }
 ```
 

--- a/docs/api/atkins_server.md
+++ b/docs/api/atkins_server.md
@@ -38,7 +38,8 @@ type Module struct {
 	artefacts *storage.JobArtefactStorage
 	settings  *storage.SettingStorage
 
-	// reclaim is the background sweep of expired agent leases.
+	// cancel stops the background sweeps: expired agent leases, and
+	// retention. done waits for both.
 	cancel context.CancelFunc
 	done   sync.WaitGroup
 }
@@ -90,6 +91,14 @@ type Options struct {
 	// ReclaimInterval is how often expired leases are swept. Zero
 	// disables the sweep.
 	ReclaimInterval time.Duration
+
+	// RetentionInterval is how often job.retention and
+	// job.log_retention are applied. Zero disables the sweep. It is a
+	// start-up flag rather than a setting because it is a property of
+	// the machine — how much load it will take to keep the tables
+	// trimmed — while the windows themselves are policy an admin
+	// changes from the API.
+	RetentionInterval time.Duration
 }
 ```
 
@@ -183,7 +192,7 @@ func (*Module) Start(ctx context.Context) error
 
 ### Stop
 
-Stop halts the lease sweep and waits for it to finish.
+Stop halts the background sweeps and waits for them to finish.
 
 ```go
 func (*Module) Stop(context.Context) error

--- a/docs/api/atkins_server_api.md
+++ b/docs/api/atkins_server_api.md
@@ -126,6 +126,12 @@ type DispatchResponse struct {
 	RepositoryID   string `json:"repository_id"`
 	RepositorySlug string `json:"repository_slug"`
 	Status         string `json:"status"`
+
+	// ViewToken opens the job page in a browser without a session. It
+	// is present only while the instance keeps jobs private; a public
+	// one needs no token, and printing one there would put a secret in
+	// a URL that guards nothing.
+	ViewToken string `json:"view_token,omitempty"`
 }
 ```
 

--- a/docs/api/atkins_server_auth.md
+++ b/docs/api/atkins_server_auth.md
@@ -40,6 +40,15 @@ type JWT struct {
 }
 ```
 
+## Consts
+
+```go
+// ViewTokenLength is how many base64url characters of the digest a job
+// link carries: 22 characters is 132 bits, which is not guessable and
+// still fits on one terminal line next to a ULID.
+const ViewTokenLength = 22
+```
+
 ## Vars
 
 ```go
@@ -57,6 +66,8 @@ var (
 - `func (*JWT) Claims (token string) (*Claims, error)`
 - `func (*JWT) Create (userID,sessionID string, ttl time.Duration) (string, error)`
 - `func (*JWT) UserID (token string) (string, error)`
+- `func (*JWT) ValidViewToken (jobID,presented string) bool`
+- `func (*JWT) ViewToken (jobID string) string`
 
 ### NewJWT
 
@@ -89,4 +100,29 @@ UserID returns the user a token belongs to.
 
 ```go
 func (*JWT) UserID(token string) (string, error)
+```
+
+### ValidViewToken
+
+ValidViewToken reports whether presented is the view token for jobID.
+
+A server with no signing key validates nothing: it cannot mint a
+token either, so accepting one would be accepting anything.
+
+```go
+func (*JWT) ValidViewToken(jobID, presented string) bool
+```
+
+### ViewToken
+
+ViewToken returns the unguessable half of a job page URL.
+
+It is derived rather than stored: an HMAC of the job ID under the
+server's signing key. There is no column to migrate, nothing extra to
+leak from a database dump, and rotating the signing key invalidates
+every outstanding link at once — which is already the documented way
+to revoke access to an instance.
+
+```go
+func (*JWT) ViewToken(jobID string) string
 ```

--- a/docs/api/atkins_server_model.md
+++ b/docs/api/atkins_server_model.md
@@ -150,6 +150,11 @@ type JobStatus = string
 ```
 
 ```go
+// JobVisibility decides who may read a job and the output it captured.
+type JobVisibility = string
+```
+
+```go
 // Migrations generated for db table `migrations`.
 type Migrations struct {
 	// Project
@@ -515,9 +520,20 @@ const (
 	// heartbeat before the server reclaims it.
 	SettingJobLeaseTTL = "job.lease_ttl"
 
-	// SettingJobRetention is how long finished jobs and their output
-	// are kept. Zero keeps them forever.
+	// SettingJobRetention is how long a finished job's row is kept.
+	// Zero keeps it forever. Deleting a job takes its output with it.
 	SettingJobRetention = "job.retention"
+
+	// SettingJobLogRetention is how long a finished job's output is
+	// kept. Zero keeps it forever. It is separate from
+	// SettingJobRetention because output is the part that grows without
+	// bound, and an outcome is worth keeping long after the lines that
+	// produced it stop being interesting.
+	SettingJobLogRetention = "job.log_retention"
+
+	// SettingJobVisibility is "private" or "public": whether a job is
+	// readable only by the user who dispatched it, or by anyone.
+	SettingJobVisibility = "job.visibility"
 
 	// SettingArtefactMaxSize bounds one uploaded artefact.
 	SettingArtefactMaxSize = "artefact.max_size"
@@ -572,6 +588,23 @@ const (
 
 	// JobStatusCancelled is a job stopped before it settled.
 	JobStatusCancelled JobStatus = "cancelled"
+)
+```
+
+```go
+// Job visibility values.
+const (
+	// VisibilityPrivate is the default. Over the API a job is readable
+	// by the user whose dispatch created it (and by anything under that
+	// job's tree); admins and agents still see everything. The job page
+	// requires the per-job token atkins prints as part of the URL.
+	VisibilityPrivate JobVisibility = "private"
+
+	// VisibilityPublic is the single-team instance the CI/CD server was
+	// first written for: every authenticated user reads every job, and
+	// the job page opens for anyone holding the URL. It is a choice an
+	// admin makes, not the state an instance starts in.
+	VisibilityPublic JobVisibility = "public"
 )
 ```
 
@@ -782,7 +815,9 @@ var (
 - `func RepositorySlug (remoteURL string) string`
 - `func SettingDefinitions () []SettingDefinition`
 - `func TerminalJobStatus (status JobStatus) bool`
+- `func TerminalJobStatuses () []JobStatus`
 - `func ValidJobStatus (status JobStatus) bool`
+- `func ValidJobVisibility (visibility JobVisibility) bool`
 - `func ValidRepositoryPolicy (policy RepositoryPolicy) bool`
 - `func WithColumns (cols []string) QueryOption`
 - `func WithLimit (start,offset int) QueryOption`
@@ -1187,12 +1222,30 @@ TerminalJobStatus reports whether status is a settled state.
 func TerminalJobStatus(status JobStatus) bool
 ```
 
+### TerminalJobStatuses
+
+TerminalJobStatuses returns the states a job settles into. Retention
+sweeps use it: a job that has not settled is never old enough to
+delete, however long ago it was queued.
+
+```go
+func TerminalJobStatuses() []JobStatus
+```
+
 ### ValidJobStatus
 
 ValidJobStatus reports whether status is a known job status.
 
 ```go
 func ValidJobStatus(status JobStatus) bool
+```
+
+### ValidJobVisibility
+
+ValidJobVisibility reports whether visibility is a known value.
+
+```go
+func ValidJobVisibility(visibility JobVisibility) bool
 ```
 
 ### ValidRepositoryPolicy

--- a/docs/api/atkins_server_storage.md
+++ b/docs/api/atkins_server_storage.md
@@ -167,6 +167,12 @@ type ListFilter struct {
 	RootID       string
 	Status       model.JobStatus
 	Limit        int
+
+	// ViewerID restricts the listing to what one user may see: their
+	// own jobs, and everything under a job tree they started. Empty
+	// means the caller may see everything, which is what an admin, an
+	// agent and a public instance all are.
+	ViewerID string
 }
 ```
 
@@ -189,6 +195,46 @@ type RepositoryRuleStorage struct {
 // RepositoryStorage persists the git repositories the server has seen.
 type RepositoryStorage struct {
 	db *sqlx.DB
+}
+```
+
+```go
+// RetentionRequest is one retention pass.
+// The two windows are independent on purpose. Output is what grows
+// without bound, and it stops being interesting long before the outcome
+// does; an instance that keeps every job forever and every log line for
+// a month is the common case.
+type RetentionRequest struct {
+	// Jobs is how long a settled job's record is kept, measured from
+	// when it finished. Zero keeps job records forever.
+	Jobs time.Duration
+
+	// Logs is how long a settled job's captured output is kept. Zero
+	// keeps output forever.
+	Logs time.Duration
+
+	// Batch is how many rows one statement removes. Zero selects
+	// DefaultRetentionBatch.
+	Batch int
+
+	// MaxBatches bounds one pass. Zero selects DefaultRetentionBatches.
+	MaxBatches int
+}
+```
+
+```go
+// RetentionResult reports what a pass removed.
+type RetentionResult struct {
+	// Jobs is how many job records were deleted.
+	Jobs int64
+
+	// Logs is how many output rows were deleted, including those that
+	// went with a deleted job.
+	Logs int64
+
+	// Partial is set when the pass stopped at MaxBatches with work
+	// still to do. The next tick continues where this one stopped.
+	Partial bool
 }
 ```
 
@@ -357,6 +403,22 @@ const (
 )
 ```
 
+```go
+// Retention defaults. They bound one pass rather than the whole
+// backlog: the first sweep of an instance that has been running for a
+// year has millions of job_log rows to remove, and a DELETE that large
+// holds locks for minutes. A pass removes at most Batch × MaxBatches
+// rows of each kind and leaves the rest for the next tick, so a server
+// catching up stays a server.
+const (
+	// DefaultRetentionBatch is how many rows one DELETE removes.
+	DefaultRetentionBatch = 500
+
+	// DefaultRetentionBatches is how many batches one pass runs.
+	DefaultRetentionBatches = 20
+)
+```
+
 ## Function symbols
 
 - `func DB (ctx context.Context, name string) (*sqlx.DB, error)`
@@ -384,8 +446,10 @@ const (
 - `func (*JobStorage) Get (ctx context.Context, id string) (*model.Job, error)`
 - `func (*JobStorage) Heartbeat (ctx context.Context, jobID,agentID string) error`
 - `func (*JobStorage) List (ctx context.Context, filter ListFilter) ([]model.Job, error)`
+- `func (*JobStorage) Purge (ctx context.Context, req RetentionRequest) (RetentionResult, error)`
 - `func (*JobStorage) ReclaimExpired (ctx context.Context) (int64, error)`
 - `func (*JobStorage) RecordCheckout (ctx context.Context, jobID string, req CheckoutRequest) error`
+- `func (*JobStorage) VisibleTo (ctx context.Context, job *model.Job, userID string) (bool, error)`
 - `func (*RepositoryRuleStorage) Allowed (ctx context.Context, slug string) (bool, error)`
 - `func (*RepositoryRuleStorage) Create (ctx context.Context, userID string, req RuleRequest) (*model.RepositoryRule, error)`
 - `func (*RepositoryRuleStorage) Delete (ctx context.Context, id string) error`
@@ -428,6 +492,7 @@ const (
 - `func (*UserStorage) GetByEmail (ctx context.Context, email string) (*model.User, error)`
 - `func (*UserStorage) List (ctx context.Context) ([]model.User, error)`
 - `func (*UserStorage) SetFlags (ctx context.Context, id string, flags Flags) (*model.User, error)`
+- `func (RetentionResult) Empty () bool`
 
 ### DB
 
@@ -669,6 +734,20 @@ List returns jobs matching the filter, newest first.
 func (*JobStorage) List(ctx context.Context, filter ListFilter) ([]model.Job, error)
 ```
 
+### Purge
+
+Purge applies the retention windows and reports what it removed.
+
+Job records go first, because deleting a job takes its output with it
+and there is no point sweeping logs that are about to disappear along
+with their job. Neither window touches a job that has not settled: a
+pending job is not old, it is waiting, and a running job that has
+lost its agent is the lease sweep's problem, not this one's.
+
+```go
+func (*JobStorage) Purge(ctx context.Context, req RetentionRequest) (RetentionResult, error)
+```
+
 ### ReclaimExpired
 
 ReclaimExpired marks running jobs whose lease has lapsed as timed out
@@ -689,6 +768,18 @@ that replaced it.
 
 ```go
 func (*JobStorage) RecordCheckout(ctx context.Context, jobID string, req CheckoutRequest) error
+```
+
+### VisibleTo
+
+VisibleTo reports whether a user may read one job.
+
+It is the single-job form of ListFilter.ViewerID, and answers the
+same question: the job is theirs, or it belongs to a tree they
+started. Callers who may see everything should not call this.
+
+```go
+func (*JobStorage) VisibleTo(ctx context.Context, job *model.Job, userID string) (bool, error)
 ```
 
 ### Allowed
@@ -1068,4 +1159,12 @@ SetFlags updates a user's administrative state.
 
 ```go
 func (*UserStorage) SetFlags(ctx context.Context, id string, flags Flags) (*model.User, error)
+```
+
+### Empty
+
+Empty reports whether the pass deleted nothing at all.
+
+```go
+func (RetentionResult) Empty() bool
 ```

--- a/docs/api/atkins_server_web.md
+++ b/docs/api/atkins_server_web.md
@@ -10,9 +10,9 @@ Package web serves the browser-facing pages of the atkins CI/CD
 server.
 
 There is deliberately very little here. `atkins` prints one URL when
-it dispatches a job — `<server>/job/{ULID}` — and that page is where
-the run is watched: status, timing, the command, and the output the
-agent captured. Everything else lives behind the JSON API.
+it dispatches a job — `<server>/job/{ULID}?t=<token>` — and that page
+is where the run is watched: status, timing, the command, and the
+output the agent captured. Everything else lives behind the JSON API.
 
 ## Types
 
@@ -23,8 +23,29 @@ type Handlers struct {
 	jobLogs      *storage.JobLogStorage
 	artefacts    *storage.JobArtefactStorage
 	repositories *storage.RepositoryStorage
+	settings     *storage.SettingStorage
+
+	// tokens mints and checks the per-job view tokens. It holds the
+	// server's signing key, so a link stops working when the key is
+	// rotated.
+	tokens *auth.JWT
 
 	templates *template.Template
+}
+```
+
+```go
+// IndexPage is the view model for the front page.
+type IndexPage struct {
+	Jobs []model.Job
+
+	// Refresh is the auto-reload interval in seconds. Zero for a page
+	// that will not change on its own.
+	Refresh int
+
+	// Private is set when the listing is withheld, so the page can say
+	// why rather than looking like an instance nobody has ever used.
+	Private bool
 }
 ```
 
@@ -50,7 +71,20 @@ type Options struct {
 	JobLogStorage      *storage.JobLogStorage
 	JobArtefactStorage *storage.JobArtefactStorage
 	RepositoryStorage  *storage.RepositoryStorage
+	SettingStorage     *storage.SettingStorage
+
+	// SigningKey derives the per-job view tokens.
+	SigningKey string
 }
+```
+
+## Consts
+
+```go
+// ViewTokenParam is the query parameter carrying a job's view token.
+// One letter, because it rides along in a URL a human copies out of a
+// terminal.
+const ViewTokenParam = "t"
 ```
 
 ## Function symbols
@@ -81,6 +115,12 @@ func (*Handlers) Artefact(w http.ResponseWriter, r *http.Request)
 
 Index lists recent jobs.
 
+A private instance lists nothing: no per-job token can scope a
+listing and there is no session to scope it by, so the listing lives
+on /api/job where the caller is authenticated. The page still
+answers, and says why — it is the server's front door, and a health
+check probing it should find a server rather than a refusal.
+
 ```go
 func (*Handlers) Index(w http.ResponseWriter, r *http.Request)
 ```
@@ -97,16 +137,19 @@ func (*Handlers) Job(w http.ResponseWriter, r *http.Request)
 
 Mount registers the page routes.
 
-The pages are readable without a session. A job URL carries a ULID
-that is not enumerable in practice, and the point of printing one in
-a terminal is that pasting it into a browser just works. Run the
-server behind your own auth if the output is sensitive.
+No page here has a session to check: the browser reading them never
+logged in. What a private instance checks instead is the per-job view
+token in the URL atkins printed, which keeps the one thing that has
+to stay true — a pasted URL opens the job — without also handing the
+job to anyone who guesses a ULID.
+
 The artefact download shares that trust model rather than a weaker or
 a stronger one. A file a job produced is no more sensitive than the
-output that produced it, and a download link on a page that needs no
-session must not be a link that fails: a browser has no bearer token
-to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated door
-for scripts.
+output that produced it, so it is reachable on exactly the terms the
+page is: same token, same setting. A download link on a page a browser
+can open must not be a link that fails, and a browser has no bearer
+token to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated
+door for scripts.
 
 ```go
 func (*Handlers) Mount(r platform.Router)

--- a/docs/content/usage/ci-cd.md
+++ b/docs/content/usage/ci-cd.md
@@ -21,7 +21,7 @@ atkins          ─────────► /api/dispatch  ──┐
                            /api/job/{id}/log ◄─ streamed output
                            /api/job/{id}/artefact ◄ files it produced
                            /api/job/{id}/status ◄ terminal state
-browser ──► /job/{ULID}
+browser ──► /job/{ULID}?t=…
 ```
 
 ## Trying it
@@ -31,7 +31,7 @@ The repository ships a throwaway instance: a server and one agent, on port 3200.
 ```bash
 atkins up                                 # build and start
 atkins --register http://localhost:3200   # first account, becomes admin
-atkins                                    # prints http://localhost:3200/job/<ULID>
+atkins                                    # prints http://localhost:3200/job/<ULID>?t=<token>
 atkins down
 ```
 
@@ -90,6 +90,8 @@ Once logged in, `atkins` posts to `/api/dispatch` and prints the job URL:
 The server normalizes the remote URL into a `host/owner/name` slug, so `git@github.com:you/repo.git` and `https://github.com/you/repo` are one repository. Repositories are created on first sight; nothing has to be registered up front.
 
 The ref atkins sends is the **commit you are on**, not the branch you are on. A dispatched run belongs to the code in front of you, and a branch name would let the agent build whatever that branch had moved to by the time it claimed the job. The consequence is worth knowing: dispatching a commit you have not pushed fails, naming the ref it could not find, rather than quietly building the branch tip instead.
+
+The response carries the job's ID and, while the instance keeps jobs private, a `view_token` that opens its page in a browser. `atkins` prints the two as one URL; a script driving `/api/dispatch` or a trigger with `curl` builds it the same way.
 
 Delegation degrades to a local run rather than to an error. If the machine isn't logged in, isn't inside a git repository, or the server can't be reached, the pipeline runs here as it always did — with the reason on stderr.
 
@@ -262,9 +264,59 @@ A retry is a **new job** built from the finished one, not a reset: the previous 
 
 ## The job page
 
-`/job/{ULID}` is the URL atkins prints. It shows the status, the command, the repository, the ref the job asked for and the commit the agent resolved it to, timing, the exit code, the output the agent captured and the artefacts it uploaded, and it refreshes itself until the job settles. `/` lists recent jobs.
+`/job/{ULID}?t={token}` is the URL atkins prints. It shows the status, the command, the repository, the ref the job asked for and the commit the agent resolved it to, timing, the exit code, the output the agent captured and the artefacts it uploaded, and it refreshes itself until the job settles.
 
-The pages are readable without a session: a ULID is not enumerable in practice, and the point of printing a URL in a terminal is that pasting it into a browser works. Put the server behind your own auth if the output is sensitive.
+The page has no session to check — the browser reading it never logged in — so what a private instance checks instead is the token in the URL. It is an HMAC of the job ID under the server's signing key: nothing is stored, nothing extra leaks from a database dump, and rotating the signing key invalidates every outstanding link along with every token. Paste the whole line and the job opens; trim the query string and you get a 403 saying so. Links between jobs on the page — the parent, and the children a job dispatched — carry the token for the job they point at, so following the tree keeps working. So do the artefact download links: a file a job produced is reachable on exactly the terms its page is, no wider and no narrower.
+
+`/` lists recent jobs, and a private instance lists none: there is no token that could scope a listing and no session to scope it by. The page answers and says so — it is the front door, and a health check probing it should find a server. `GET /api/job` is the listing, and it is scoped to the caller.
+
+Both of those relax under `job.visibility`:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"value":"public"}' "$SERVER/api/admin/setting/job.visibility"
+```
+
+A public instance is the single-team one: every authenticated user reads every job over the API, the job page opens for anyone holding the URL, `/` lists everything, and no token is issued — a secret in a URL that guards nothing is a habit worth not forming. It is a choice an admin makes, not the state a server starts in, because job output routinely contains things nobody meant to publish.
+
+Whichever way it is set, the API scoping follows the same rule:
+
+| Caller        | Sees                                                     |
+|---------------|----------------------------------------------------------|
+| admin         | every job                                                |
+| agent         | every job — a worker operates on the whole queue         |
+| user, private | their own jobs, and everything under a tree they started |
+| user, public  | every job                                                |
+
+"Everything under a tree they started" matters because a pipeline that clears `ATKINS_NO_DISPATCH` queues its children under the *agent's* credentials. Scoping on the dispatching user alone would hide a fan-out from the person who started it, so the root of the job tree decides too.
+
+A job somebody may not read is reported as `404`, not `403`: "not yours" and "not here" have to look the same, or the endpoint tells a stranger which job IDs exist. The same check governs `retry` and `cancel` — a job you may not read is one you may not stop.
+
+## Retention
+
+An instance that runs for a year grows `job` and `job_log` without bound, and `job_log` is the one that hurts: it holds every line every build printed. Two windows bound it, and they are separate on purpose — output stops being interesting long before an outcome does:
+
+```bash
+# Keep captured output for a week.
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"value":"168h"}' "$SERVER/api/admin/setting/job.log_retention"
+
+# Keep the job records themselves for a year.
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"value":"8760h"}' "$SERVER/api/admin/setting/job.retention"
+```
+
+`job.log_retention` deletes the output of a finished job and leaves the job: the page still says what ran, when, and whether it passed. `job.retention` deletes the record, and takes the output with it. `0` on either keeps that half forever, which is what `job.retention` defaults to.
+
+Both windows are measured from when a job **finished**. A job that has not settled is never swept, however long ago it was queued — a pending job is not old, it is waiting, and a running job whose agent died is the lease sweep's problem.
+
+Deletion happens in bounded batches, up to 500 rows at a time and 20 batches per pass, and a pass that runs out of batches leaves the rest for the next one. The first sweep of an instance that has been accumulating for a year is therefore a series of small deletes spread over a few passes rather than one that holds a table for minutes. The log says when a pass had more to do:
+
+```text
+[atkins] retention removed 0 job(s) and 10000 output row(s), more to come
+```
+
+How often the server looks is `server.retention_interval` (default `1h`), a start-up setting rather than a runtime one: the windows are policy, the cadence is a property of the machine. `0` turns the sweep off entirely.
 
 Artefact downloads from the page — `/job/{ULID}/artefact/{ULID}` — are on the same terms, because a browser has no bearer token to offer and a download link that fails is not a link. `GET /api/job/{id}/artefact/{id}` is the authenticated door, and it is the one a script should use. A file a job produced is served as an attachment with `X-Content-Type-Options: nosniff`, so an artefact named `report.html` is something to save rather than something that runs in the server's origin.
 
@@ -400,16 +452,18 @@ which rewrites `git@host:owner/repo.git` to `https://host/owner/repo.git` before
 
 Runtime configuration an admin can change without a restart:
 
-| Setting              | Default | Purpose                                             |
-|----------------------|---------|-----------------------------------------------------|
-| `repository.policy`  | `open`  | `open`, or `allowlist` to gate on rules             |
-| `registration.open`  | `false` | Let anyone register                                 |
-| `job.max_depth`      | `3`     | How deep a job may dispatch children                |
-| `job.lease_ttl`      | `15m`   | How long an agent may hold a job                    |
-| `job.retention`      | `0`     | How long finished jobs are kept; 0 is forever       |
-| `artefact.max_size`  | `32MB`  | Largest single artefact an agent may upload         |
-| `artefact.max_count` | `50`    | How many artefacts one job may keep                 |
-| `artefact.retention` | `0`     | How long artefact bytes are kept; 0 follows the job |
+| Setting              | Default   | Purpose                                                       |
+|----------------------|-----------|---------------------------------------------------------------|
+| `repository.policy`  | `open`    | `open`, or `allowlist` to gate on rules                       |
+| `registration.open`  | `false`   | Let anyone register                                           |
+| `job.max_depth`      | `3`       | How deep a job may dispatch children                          |
+| `job.lease_ttl`      | `15m`     | How long an agent may hold a job                              |
+| `job.retention`      | `0`       | How long a finished job's record is kept; 0 is forever        |
+| `job.log_retention`  | `720h`    | How long a finished job's output is kept; 0 is forever        |
+| `job.visibility`     | `private` | `private` scopes jobs to who dispatched them; `public` shares |
+| `artefact.max_size`  | `32MB`    | Largest single artefact an agent may upload                   |
+| `artefact.max_count` | `50`      | How many artefacts one job may keep                           |
+| `artefact.retention` | `0`       | How long artefact bytes are kept; 0 follows the job           |
 
 ```bash
 curl -sS -H "Authorization: Bearer $TOKEN" "$SERVER/api/admin/setting" |
@@ -444,8 +498,8 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/dispatch`                | POST            | user   | Record a job, returns its ID           |
 | `/api/repository`              | GET             | user   | List known repositories                |
 | `/api/repository/{id}/trigger` | POST            | user   | Queue a job by name, with params       |
-| `/api/job`                     | GET             | user   | List jobs                              |
-| `/api/job/{id}`                | GET             | user   | Read one job                           |
+| `/api/job`                     | GET             | user   | List jobs the caller may see           |
+| `/api/job/{id}`                | GET             | user   | Read one job the caller may see        |
 | `/api/job/{id}/log`            | GET             | user   | Read captured output                   |
 | `/api/job/{id}/artefact`       | GET             | user   | List the files a job produced          |
 | `/api/job/{id}/artefact/{id}`  | GET             | user   | Download one artefact                  |

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ it.
 
 ```text
 server/
-├── server.go        module lifecycle, route assembly, lease sweep
+├── server.go        module lifecycle, route assembly, background sweeps
 ├── options.go       options, built from the config package
 ├── api/             JSON handlers: decode, validate, map status, encode
 │   ├── user.go      register, login, refresh, logout, whoami
@@ -114,16 +114,37 @@ worst moment to need a redeploy.
 ## Lifecycle
 
 `Start` connects, migrates, wires storage and handlers, prepares the
-artefact root, and starts the sweep. `Mount` registers routes. `Stop`
-cancels the sweep and waits for it.
-
-The sweep is the reason an agent can die without stranding a job: a
-`running` job whose `lease_expires_at` has passed is moved to `timeout`
-and can be retried. It carries the artefact retention pass too, which
-reads its setting on every tick rather than at start-up.
+artefact root, and starts two background sweeps. `Mount` registers
+routes. `Stop` cancels both and waits for them.
 
 A root the server cannot create is fatal at start-up rather than a
 surprise on the first job that produces a file.
+
+The lease sweep is the reason an agent can die without stranding a job:
+a `running` job whose `lease_expires_at` has passed is moved to
+`timeout` and can be retried. It carries the artefact retention pass
+too, which reads its setting on every tick rather than at start-up.
+
+The retention sweep applies `job.retention` and `job.log_retention`. It
+is a second ticker rather than another statement in the first, because
+the two have nothing in common but a timer: reclaiming is one cheap
+UPDATE that has to happen within a lease of an agent dying, and
+retention walks two tables about as often as a log file is worth
+rotating. Its cadence is `Options.RetentionInterval`, a start-up flag,
+while the windows are settings — the cadence is a property of the
+machine, the windows are policy.
+
+`JobStorage.Purge` deletes in bounded batches and stops after
+`DefaultRetentionBatches` of them, reporting `Partial` so the next tick
+knows there is more. A first sweep of an instance that has been running
+for a year is therefore a series of small deletes rather than one that
+holds `job_log` for minutes. The batch for expired output is selected
+from `job_log` joined to `job`, not from `job`: selecting jobs and
+deleting their logs would keep re-reading jobs whose output was already
+gone, and a large backlog would never be worked through.
+
+Neither window touches a job that has not settled. A pending job is not
+old, it is waiting.
 
 ## Authentication and roles
 
@@ -168,6 +189,33 @@ Settings are typed and validated against a registry in
 `model/setting.go`, cached in memory by `storage.SettingStorage` because
 they are read on the dispatch path, and fall back to a registry default
 so the table is empty on a fresh instance.
+
+## Visibility
+
+`job.visibility` is `private` or `public`, and it governs two surfaces.
+
+Over the API, `private` narrows job reads to the caller: their own jobs,
+and everything under a job tree they started. The tree half is not
+decoration — a pipeline that clears `ATKINS_NO_DISPATCH` queues its
+children under the agent's credentials, so scoping on `user_id` alone
+would hide a fan-out from the person who started it. Admins and agents
+are exempt: an admin is what the flag is for, and an agent works the
+whole queue. A job the caller may not read is a 404, because "not
+yours" and "not here" must look the same.
+
+The pages have no session to check, so `private` checks a per-job token
+in the URL instead: `auth.JWT.ViewToken` is an HMAC of the job ID under
+the signing key. Deriving it rather than storing it means no column to
+migrate, nothing extra in a database dump, and one way to revoke every
+outstanding link — rotate the signing key, which already revokes every
+access token. The token rides in the URL because the requirement it has
+to keep meeting is that atkins prints one line a human pastes into a
+browser.
+
+Under `private` the index page lists nothing: no token can scope a
+listing and there is no session to scope it by, so `GET /api/job` is
+the listing. The page still answers — it is the front door, and the
+compose health check probes it.
 
 ## Deploy keys
 

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"testing"
 
@@ -427,9 +428,39 @@ func TestJobPageRenders(t *testing.T) {
 	admin := register(t, url)
 
 	job := dispatch(t, url, admin.Token, "atkins test:build", "")
+	require.NotEmpty(t, job.ViewToken)
 
 	// The page atkins prints is readable without a session: pasting the
-	// URL into a browser has to just work.
+	// whole URL into a browser has to just work.
+	response, err := http.Get(url + "/job/" + job.JobID + "?t=" + job.ViewToken)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	// Without the token it does not, however good the ULID guess was.
+	response, err = http.Get(url + "/job/" + job.JobID)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+
+	response, err = http.Get(url + "/job/01ARZ3NDEKTSV4RRFFQ69G5FAV?t=" + job.ViewToken)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+}
+
+func TestJobPageOnAPublicInstance(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	setSetting(t, url, admin.Token, model.SettingJobVisibility, model.VisibilityPublic)
+
+	// A public instance issues no token: there is nothing for one to
+	// guard, and a secret in a URL that guards nothing is a habit worth
+	// not forming.
+	job := dispatch(t, url, admin.Token, "atkins test:build", "")
+	assert.Empty(t, job.ViewToken)
+
 	response, err := http.Get(url + "/job/" + job.JobID)
 	require.NoError(t, err)
 	defer response.Body.Close()
@@ -440,8 +471,29 @@ func TestJobPageRenders(t *testing.T) {
 	defer response.Body.Close()
 	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 
+	// The index is the listing a public instance is for.
 	response, err = http.Get(url + "/")
 	require.NoError(t, err)
 	defer response.Body.Close()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
+}
+
+func TestJobListingPageIsPrivateByDefault(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	dispatch(t, url, admin.Token, "atkins build", "")
+
+	// There is no token that could scope a listing and no session to
+	// scope it by, so a private instance lists nothing — while still
+	// answering, because this is the front door a health check probes.
+	response, err := http.Get(url + "/")
+	require.NoError(t, err)
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "atkins build")
+	assert.Contains(t, string(body), "private")
 }

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -10,6 +10,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	"net/http"
 	"time"
@@ -108,6 +109,68 @@ func (s *Handlers) registrationOpen() bool {
 		return true
 	}
 	return s.allowRegistration
+}
+
+// jobScope returns the user id job reads should be narrowed to, or an
+// empty string for a caller who may see every job.
+//
+// Admins see everything because that is what the flag is for, and
+// agents because a worker operates on the whole queue. Everyone else
+// sees their own jobs unless the instance has been made public, which
+// is the single-team mode the server started out in.
+func (s *Handlers) jobScope(user *model.User) string {
+	if user == nil {
+		return ""
+	}
+	if user.IsAdmin || user.IsAgent {
+		return ""
+	}
+	if s.settings != nil && s.settings.Get(model.SettingJobVisibility) == model.VisibilityPublic {
+		return ""
+	}
+	return user.ID
+}
+
+// readableJob loads a job the caller is allowed to read.
+//
+// A job the caller may not see is reported as missing rather than as
+// forbidden: "not yours" and "not here" should look the same, or the
+// endpoint tells a stranger which job IDs exist.
+func (s *Handlers) readableJob(r *http.Request, user *model.User, jobID string) (*model.Job, error) {
+	job, err := s.jobs.Get(r.Context(), jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, requestError(http.StatusNotFound, errJobNotFound)
+		}
+		return nil, err
+	}
+
+	scope := s.jobScope(user)
+	if scope == "" {
+		return job, nil
+	}
+
+	visible, err := s.jobs.VisibleTo(r.Context(), job, scope)
+	if err != nil {
+		return nil, err
+	}
+	if !visible {
+		return nil, requestError(http.StatusNotFound, errJobNotFound)
+	}
+
+	return job, nil
+}
+
+// errJobNotFound covers both "no such job" and "not yours".
+var errJobNotFound = errors.New("job not found")
+
+// viewToken returns the token that opens a job page without a session,
+// or an empty string on an instance whose pages are public anyway.
+func (s *Handlers) viewToken(jobID string) string {
+	if s.settings != nil && s.settings.Get(model.SettingJobVisibility) == model.VisibilityPublic {
+		return ""
+	}
+	return s.jwt.ViewToken(jobID)
 }
 
 // respond writes err as JSON, or does nothing when the handler already

--- a/server/api/dispatch.go
+++ b/server/api/dispatch.go
@@ -91,6 +91,12 @@ type DispatchResponse struct {
 	RepositoryID   string `json:"repository_id"`
 	RepositorySlug string `json:"repository_slug"`
 	Status         string `json:"status"`
+
+	// ViewToken opens the job page in a browser without a session. It
+	// is present only while the instance keeps jobs private; a public
+	// one needs no token, and printing one there would put a secret in
+	// a URL that guards nothing.
+	ViewToken string `json:"view_token,omitempty"`
 }
 
 // JobStatusRequest is the body of /api/job/{jobID}/status.
@@ -208,7 +214,17 @@ func (s *Handlers) dispatch(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	platform.JSON(w, r, http.StatusCreated, DispatchResponse{
+	platform.JSON(w, r, http.StatusCreated, s.dispatchResponse(job, repository))
+	return nil
+}
+
+// dispatchResponse describes a queued job to whoever queued it.
+//
+// Dispatch, trigger and retry all answer with the same thing, because
+// from the caller's side they are the same act: a job now exists and
+// here is where to watch it.
+func (s *Handlers) dispatchResponse(job *model.Job, repository *model.Repository) DispatchResponse {
+	return DispatchResponse{
 		JobID:          job.ID,
 		ParentID:       job.ParentID,
 		RootID:         job.RootID,
@@ -216,8 +232,8 @@ func (s *Handlers) dispatch(w http.ResponseWriter, r *http.Request) error {
 		RepositoryID:   repository.ID,
 		RepositorySlug: repository.Slug,
 		Status:         job.Status,
-	})
-	return nil
+		ViewToken:      s.viewToken(job.ID),
+	}
 }
 
 // ListRepositories returns the repositories the server knows about.
@@ -250,15 +266,13 @@ func (s *Handlers) GetJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) getJob(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
 		return err
 	}
 
-	job, err := s.jobs.Get(r.Context(), platform.URLParam(r, "jobID"))
+	job, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return requestError(http.StatusNotFound, errors.New("job not found"))
-		}
 		return err
 	}
 
@@ -272,7 +286,8 @@ func (s *Handlers) ListJobs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) listJobs(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
 		return err
 	}
 
@@ -280,6 +295,7 @@ func (s *Handlers) listJobs(w http.ResponseWriter, r *http.Request) error {
 		RepositoryID: platform.QueryParam(r, "repository_id"),
 		RootID:       platform.QueryParam(r, "root_id"),
 		Status:       platform.QueryParam(r, "status"),
+		ViewerID:     s.jobScope(user),
 	}
 	if limit, err := strconv.Atoi(platform.QueryParam(r, "limit")); err == nil {
 		filter.Limit = limit

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -59,11 +59,20 @@ func (s *Handlers) GetJobLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) getJobLog(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
 		return err
 	}
 
-	entries, err := s.jobLogs.List(r.Context(), platform.URLParam(r, "jobID"))
+	// Output is the sensitive half of a job, so the job is loaded and
+	// checked before its lines are handed over — reading a log must not
+	// be a way around the scoping on reading a job.
+	job, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
+	if err != nil {
+		return err
+	}
+
+	entries, err := s.jobLogs.List(r.Context(), job.ID)
 	if err != nil {
 		return err
 	}

--- a/server/api/trigger.go
+++ b/server/api/trigger.go
@@ -133,15 +133,7 @@ func (s *Handlers) trigger(w http.ResponseWriter, r *http.Request) error {
 		return mapJobCreateError(err)
 	}
 
-	platform.JSON(w, r, http.StatusCreated, DispatchResponse{
-		JobID:          job.ID,
-		ParentID:       job.ParentID,
-		RootID:         job.RootID,
-		Depth:          job.Depth,
-		RepositoryID:   repository.ID,
-		RepositorySlug: repository.Slug,
-		Status:         job.Status,
-	})
+	platform.JSON(w, r, http.StatusCreated, s.dispatchResponse(job, repository))
 	return nil
 }
 
@@ -160,11 +152,8 @@ func (s *Handlers) retryJob(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	previous, err := s.jobs.Get(r.Context(), platform.URLParam(r, "jobID"))
+	previous, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return requestError(http.StatusNotFound, errors.New("job not found"))
-		}
 		return err
 	}
 
@@ -217,15 +206,7 @@ func (s *Handlers) retryJob(w http.ResponseWriter, r *http.Request) error {
 		return mapJobCreateError(err)
 	}
 
-	platform.JSON(w, r, http.StatusCreated, DispatchResponse{
-		JobID:          job.ID,
-		ParentID:       job.ParentID,
-		RootID:         job.RootID,
-		Depth:          job.Depth,
-		RepositoryID:   repository.ID,
-		RepositorySlug: repository.Slug,
-		Status:         job.Status,
-	})
+	platform.JSON(w, r, http.StatusCreated, s.dispatchResponse(job, repository))
 	return nil
 }
 
@@ -235,11 +216,19 @@ func (s *Handlers) CancelJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) cancelJob(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
 		return err
 	}
 
-	job, err := s.jobs.Finish(r.Context(), platform.URLParam(r, "jobID"), storage.StatusRequest{
+	// Cancelling is a write, but the check is the same one reading uses:
+	// a job somebody may not read is a job they may not stop.
+	target, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
+	if err != nil {
+		return err
+	}
+
+	job, err := s.jobs.Finish(r.Context(), target.ID, storage.StatusRequest{
 		Status:   model.JobStatusCancelled,
 		ExitCode: 1,
 		Error:    "cancelled",

--- a/server/artefact_test.go
+++ b/server/artefact_test.go
@@ -167,19 +167,24 @@ func TestArtefactAppearsOnTheJobPage(t *testing.T) {
 	}, &stored)
 	require.Equal(t, http.StatusCreated, status)
 
-	status, page, _ := fetch(t, url+"/job/"+job.JobID, "")
+	status, page, _ := fetch(t, url+"/job/"+job.JobID+"?t="+job.ViewToken, "")
 	require.Equal(t, http.StatusOK, status)
 	assert.Contains(t, string(page), "coverage.txt")
 
 	// The link on the page has to work in a browser, which carries no
-	// bearer token: it is governed by the same unguessable job URL the
-	// page itself is.
+	// bearer token: it is governed by the same view token the page
+	// itself is, so the link the page renders carries one.
 	download := "/job/" + job.JobID + "/artefact/" + stored.ID
 	assert.Contains(t, string(page), download)
 
-	status, body, _ := fetch(t, url+download, "")
+	status, body, _ := fetch(t, url+download+"?t="+job.ViewToken, "")
 	require.Equal(t, http.StatusOK, status)
 	assert.Equal(t, content, body)
+
+	// And no wider than the page: without the token the bytes are not
+	// served, or a private job's artefacts would be public.
+	status, _, _ = fetch(t, url+download, "")
+	assert.Equal(t, http.StatusForbidden, status)
 }
 
 func TestArtefactUploadIsAgentOnly(t *testing.T) {

--- a/server/auth/view.go
+++ b/server/auth/view.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+)
+
+// ViewTokenLength is how many base64url characters of the digest a job
+// link carries: 22 characters is 132 bits, which is not guessable and
+// still fits on one terminal line next to a ULID.
+const ViewTokenLength = 22
+
+// viewTokenDomain separates view tokens from anything else the signing
+// key is ever used for, so a token minted here can never be mistaken
+// for a token minted elsewhere under the same secret.
+const viewTokenDomain = "atkins:job-view:"
+
+// ViewToken returns the unguessable half of a job page URL.
+//
+// It is derived rather than stored: an HMAC of the job ID under the
+// server's signing key. There is no column to migrate, nothing extra to
+// leak from a database dump, and rotating the signing key invalidates
+// every outstanding link at once — which is already the documented way
+// to revoke access to an instance.
+func (j *JWT) ViewToken(jobID string) string {
+	if j.secret == "" || jobID == "" {
+		return ""
+	}
+
+	mac := hmac.New(sha256.New, []byte(j.secret))
+	mac.Write([]byte(viewTokenDomain + jobID))
+
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))[:ViewTokenLength]
+}
+
+// ValidViewToken reports whether presented is the view token for jobID.
+//
+// A server with no signing key validates nothing: it cannot mint a
+// token either, so accepting one would be accepting anything.
+func (j *JWT) ValidViewToken(jobID, presented string) bool {
+	expected := j.ViewToken(jobID)
+	if expected == "" || presented == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(presented)) == 1
+}

--- a/server/auth/view_test.go
+++ b/server/auth/view_test.go
@@ -1,0 +1,43 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/titpetric/atkins/server/auth"
+)
+
+func TestViewToken(t *testing.T) {
+	jwt := auth.NewJWT("secret")
+
+	token := jwt.ViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	assert.Len(t, token, auth.ViewTokenLength)
+
+	// Deriving rather than storing means the same job always yields the
+	// same link, so a URL printed last week still opens.
+	assert.Equal(t, token, jwt.ViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV"))
+
+	// One job's token opens that job and nothing else.
+	assert.NotEqual(t, token, jwt.ViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAW"))
+	assert.True(t, jwt.ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV", token))
+	assert.False(t, jwt.ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAW", token))
+
+	// Rotating the signing key invalidates every outstanding link,
+	// which is already the documented way to revoke an instance.
+	assert.False(t, auth.NewJWT("rotated").ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV", token))
+}
+
+func TestViewTokenRefusesEmptyInput(t *testing.T) {
+	jwt := auth.NewJWT("secret")
+
+	assert.Empty(t, jwt.ViewToken(""))
+	assert.False(t, jwt.ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV", ""))
+
+	// A server with no signing key mints nothing, so it must accept
+	// nothing: an empty expectation would match an empty presentation.
+	unsigned := auth.NewJWT("")
+	assert.Empty(t, unsigned.ViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV"))
+	assert.False(t, unsigned.ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV", ""))
+	assert.False(t, unsigned.ValidViewToken("01ARZ3NDEKTSV4RRFFQ69G5FAV", "anything"))
+}

--- a/server/model/job.go
+++ b/server/model/job.go
@@ -52,6 +52,15 @@ var terminalJobStatuses = []JobStatus{
 	JobStatusCancelled,
 }
 
+// TerminalJobStatuses returns the states a job settles into. Retention
+// sweeps use it: a job that has not settled is never old enough to
+// delete, however long ago it was queued.
+func TerminalJobStatuses() []JobStatus {
+	statuses := make([]JobStatus, len(terminalJobStatuses))
+	copy(statuses, terminalJobStatuses)
+	return statuses
+}
+
 // ValidJobStatus reports whether status is a known job status.
 func ValidJobStatus(status JobStatus) bool {
 	return slices.Contains(jobStatuses, status)

--- a/server/model/setting.go
+++ b/server/model/setting.go
@@ -25,9 +25,20 @@ const (
 	// heartbeat before the server reclaims it.
 	SettingJobLeaseTTL = "job.lease_ttl"
 
-	// SettingJobRetention is how long finished jobs and their output
-	// are kept. Zero keeps them forever.
+	// SettingJobRetention is how long a finished job's row is kept.
+	// Zero keeps it forever. Deleting a job takes its output with it.
 	SettingJobRetention = "job.retention"
+
+	// SettingJobLogRetention is how long a finished job's output is
+	// kept. Zero keeps it forever. It is separate from
+	// SettingJobRetention because output is the part that grows without
+	// bound, and an outcome is worth keeping long after the lines that
+	// produced it stop being interesting.
+	SettingJobLogRetention = "job.log_retention"
+
+	// SettingJobVisibility is "private" or "public": whether a job is
+	// readable only by the user who dispatched it, or by anyone.
+	SettingJobVisibility = "job.visibility"
 
 	// SettingArtefactMaxSize bounds one uploaded artefact.
 	SettingArtefactMaxSize = "artefact.max_size"
@@ -99,7 +110,20 @@ var settingDefinitions = []SettingDefinition{
 		Name:        SettingJobRetention,
 		Kind:        KindDuration,
 		Default:     "0",
-		Description: "How long finished jobs are kept. 0 keeps them forever.",
+		Description: "How long a finished job's record is kept. 0 keeps it forever. Deleting a job deletes its output too.",
+	},
+	{
+		Name:        SettingJobLogRetention,
+		Kind:        KindDuration,
+		Default:     "720h",
+		Description: "How long a finished job's captured output is kept. 0 keeps it forever; the job's outcome is kept either way.",
+	},
+	{
+		Name:        SettingJobVisibility,
+		Kind:        KindEnum,
+		Default:     VisibilityPrivate,
+		Values:      []string{VisibilityPrivate, VisibilityPublic},
+		Description: "Whether a job is readable only by the user who dispatched it, or by anyone with the URL.",
 	},
 	{
 		Name:        SettingArtefactMaxSize,

--- a/server/model/visibility.go
+++ b/server/model/visibility.go
@@ -1,0 +1,24 @@
+package model
+
+// JobVisibility decides who may read a job and the output it captured.
+type JobVisibility = string
+
+// Job visibility values.
+const (
+	// VisibilityPrivate is the default. Over the API a job is readable
+	// by the user whose dispatch created it (and by anything under that
+	// job's tree); admins and agents still see everything. The job page
+	// requires the per-job token atkins prints as part of the URL.
+	VisibilityPrivate JobVisibility = "private"
+
+	// VisibilityPublic is the single-team instance the CI/CD server was
+	// first written for: every authenticated user reads every job, and
+	// the job page opens for anyone holding the URL. It is a choice an
+	// admin makes, not the state an instance starts in.
+	VisibilityPublic JobVisibility = "public"
+)
+
+// ValidJobVisibility reports whether visibility is a known value.
+func ValidJobVisibility(visibility JobVisibility) bool {
+	return visibility == VisibilityPrivate || visibility == VisibilityPublic
+}

--- a/server/options.go
+++ b/server/options.go
@@ -52,6 +52,14 @@ type Options struct {
 	// ReclaimInterval is how often expired leases are swept. Zero
 	// disables the sweep.
 	ReclaimInterval time.Duration
+
+	// RetentionInterval is how often job.retention and
+	// job.log_retention are applied. Zero disables the sweep. It is a
+	// start-up flag rather than a setting because it is a property of
+	// the machine — how much load it will take to keep the tables
+	// trimmed — while the windows themselves are policy an admin
+	// changes from the API.
+	RetentionInterval time.Duration
 }
 
 // Environment variable names, kept here because error messages point at
@@ -79,6 +87,7 @@ func FromConfig(cfg config.ServerConfig) *Options {
 		MaxJobDepth:       cfg.MaxJobDepth,
 		LeaseTTL:          cfg.LeaseTTL,
 		ReclaimInterval:   cfg.ReclaimInterval,
+		RetentionInterval: cfg.RetentionInterval,
 	}
 }
 

--- a/server/retention_test.go
+++ b/server/retention_test.go
@@ -1,0 +1,105 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// finish settles a job as an agent would.
+func finish(t *testing.T, url, agentToken, jobID string, status model.JobStatus) {
+	t.Helper()
+
+	code := call(t, http.MethodPost, url+"/api/job/"+jobID+"/status", agentToken, map[string]any{
+		"status": status,
+	}, nil)
+	require.Equal(t, http.StatusOK, code)
+}
+
+// logCount reads how many output rows a job still has.
+func logCount(t *testing.T, url, token, jobID string) int {
+	t.Helper()
+
+	var entries []map[string]any
+	status := call(t, http.MethodGet, url+"/api/job/"+jobID+"/log", token, nil, &entries)
+	require.Equal(t, http.StatusOK, status)
+
+	return len(entries)
+}
+
+func TestRetentionSweepDropsOutputAndKeepsTheJob(t *testing.T) {
+	// A sweep on a real ticker: this is the wiring the module owns —
+	// the timer, the settings read on every pass, and the storage call.
+	url := testServerWith(t, func(opts *server.Options) {
+		opts.RetentionInterval = 20 * time.Millisecond
+	})
+
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins build", "")
+
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", agent.Token, map[string]string{
+		"content": "hello\n",
+	}, nil)
+	require.Equal(t, http.StatusNoContent, status)
+
+	// A job still running is never old enough to sweep, whatever the
+	// window says.
+	setSetting(t, url, admin.Token, model.SettingJobLogRetention, "1ns")
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, logCount(t, url, admin.Token, job.JobID))
+
+	finish(t, url, agent.Token, job.JobID, model.JobStatusPassed)
+
+	require.Eventually(t, func() bool {
+		return logCount(t, url, admin.Token, job.JobID) == 0
+	}, 5*time.Second, 20*time.Millisecond, "output was not swept")
+
+	// The outcome outlives the output: that is the whole point of two
+	// windows rather than one.
+	var stored map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+job.JobID, admin.Token, nil, &stored)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, model.JobStatusPassed, stored["status"])
+
+	// Until job.retention says otherwise.
+	setSetting(t, url, admin.Token, model.SettingJobRetention, "1ns")
+
+	require.Eventually(t, func() bool {
+		return call(t, http.MethodGet, url+"/api/job/"+job.JobID, admin.Token, nil, nil) == http.StatusNotFound
+	}, 5*time.Second, 20*time.Millisecond, "job record was not swept")
+}
+
+func TestRetentionKeepsEverythingByDefault(t *testing.T) {
+	url := testServerWith(t, func(opts *server.Options) {
+		opts.RetentionInterval = 20 * time.Millisecond
+	})
+
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins build", "")
+
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", agent.Token, map[string]string{
+		"content": "hello\n",
+	}, nil)
+	require.Equal(t, http.StatusNoContent, status)
+
+	finish(t, url, agent.Token, job.JobID, model.JobStatusFailed)
+
+	// job.retention defaults to keeping records forever, and
+	// job.log_retention to a month. Neither touches a job that finished
+	// a moment ago, however often the sweep runs.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 1, logCount(t, url, admin.Token, job.JobID))
+	assert.Equal(t, http.StatusOK, call(t, http.MethodGet, url+"/api/job/"+job.JobID, admin.Token, nil, nil))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -50,7 +50,8 @@ type Module struct {
 	artefacts *storage.JobArtefactStorage
 	settings  *storage.SettingStorage
 
-	// reclaim is the background sweep of expired agent leases.
+	// cancel stops the background sweeps: expired agent leases, and
+	// retention. done waits for both.
 	cancel context.CancelFunc
 	done   sync.WaitGroup
 }
@@ -146,12 +147,20 @@ func (m *Module) Start(ctx context.Context) error {
 		JobLogStorage:      jobLogs,
 		JobArtefactStorage: m.artefacts,
 		RepositoryStorage:  repositories,
+		SettingStorage:     settings,
+		SigningKey:         m.opts.SigningKey,
 	})
 	if err != nil {
 		return err
 	}
 
-	m.startReclaim(ctx)
+	// The sweeps outlive the start context; they are bound to the
+	// module lifecycle and cancelled from Stop.
+	sweeps, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	m.cancel = cancel
+
+	m.startReclaim(sweeps)
+	m.startRetention(sweeps)
 
 	return nil
 }
@@ -163,7 +172,7 @@ func (m *Module) Mount(_ context.Context, r platform.Router) error {
 	return nil
 }
 
-// Stop halts the lease sweep and waits for it to finish.
+// Stop halts the background sweeps and waits for them to finish.
 func (m *Module) Stop(context.Context) error {
 	if m.cancel != nil {
 		m.cancel()
@@ -179,20 +188,72 @@ func (m *Module) Stop(context.Context) error {
 // amount of tidying on a timer — and because a server with one
 // background goroutine is easier to reason about than one with two.
 func (m *Module) startReclaim(ctx context.Context) {
-	if m.opts.ReclaimInterval <= 0 {
+	m.sweep(ctx, m.opts.ReclaimInterval, func(ctx context.Context) error {
+		reclaimed, err := m.jobs.ReclaimExpired(ctx)
+		if err != nil {
+			return err
+		}
+		if reclaimed > 0 {
+			log.Printf("[atkins] reclaimed %d job(s) from expired agent leases", reclaimed)
+		}
+		return nil
+	})
+}
+
+// startRetention applies job.retention and job.log_retention on a
+// ticker of its own.
+//
+// It is a separate sweep from the lease reclaim rather than another
+// statement inside it, because the two have nothing in common but a
+// timer: reclaiming is one cheap UPDATE that has to happen within a
+// lease of the agent dying, while retention walks two tables and is
+// worth doing about as often as a log file is worth rotating.
+//
+// The windows are read from the settings on every pass, so an admin
+// changing them takes effect at the next tick rather than at the next
+// restart. Passing zero for both makes the pass a no-op, which is what
+// an instance that keeps everything forever wants.
+func (m *Module) startRetention(ctx context.Context) {
+	m.sweep(ctx, m.opts.RetentionInterval, func(ctx context.Context) error {
+		result, err := m.jobs.Purge(ctx, storage.RetentionRequest{
+			Jobs: m.settings.Duration(model.SettingJobRetention),
+			Logs: m.settings.Duration(model.SettingJobLogRetention),
+		})
+
+		// A pass that failed halfway still deleted what it deleted, so
+		// report the count before the error.
+		if !result.Empty() {
+			log.Printf("[atkins] retention removed %d job(s) and %d output row(s)%s",
+				result.Jobs, result.Logs, partially(result.Partial))
+		}
+
+		return err
+	})
+}
+
+// partially annotates a retention pass that stopped short of the end of
+// its backlog, so an operator watching the log can tell a server that
+// is catching up from one that is done.
+func partially(partial bool) string {
+	if partial {
+		return ", more to come"
+	}
+	return ""
+}
+
+// sweep runs work on a ticker until the module stops. A non-positive
+// interval disables it, which is how the module tests keep background
+// writes out of their assertions.
+func (m *Module) sweep(ctx context.Context, interval time.Duration, work func(context.Context) error) {
+	if interval <= 0 {
 		return
 	}
-
-	// The sweep outlives the start context; it is bound to the module
-	// lifecycle and cancelled from Stop.
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	m.cancel = cancel
 
 	m.done.Add(1)
 	go func() {
 		defer m.done.Done()
 
-		ticker := time.NewTicker(m.opts.ReclaimInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		for {
@@ -200,13 +261,8 @@ func (m *Module) startReclaim(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				reclaimed, err := m.jobs.ReclaimExpired(ctx)
-				if err != nil {
+				if err := work(ctx); err != nil {
 					telemetry.CaptureError(ctx, err)
-					continue
-				}
-				if reclaimed > 0 {
-					log.Printf("[atkins] reclaimed %d job(s) from expired agent leases", reclaimed)
 				}
 
 				m.pruneArtefacts(ctx)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,8 +36,6 @@ const testAgentToken = "test-agent-token"
 // sqlite a 10 connection pool, and every connection to an in-memory
 // sqlite database is a separate, empty database.
 func testServer(t *testing.T) string {
-	t.Helper()
-
 	return testServerWith(t, nil)
 }
 
@@ -65,6 +63,7 @@ func testServerWith(t *testing.T, configure func(*server.Options)) string {
 	// first register call in each test exercises.
 	opts.AllowRegistration = false
 	opts.ReclaimInterval = 0
+	opts.RetentionInterval = 0
 
 	if configure != nil {
 		configure(opts)
@@ -134,6 +133,7 @@ type dispatchResponse struct {
 	RepositoryID   string `json:"repository_id"`
 	RepositorySlug string `json:"repository_slug"`
 	Status         string `json:"status"`
+	ViewToken      string `json:"view_token"`
 }
 
 // register creates the bootstrap user and returns its tokens.

--- a/server/storage/job.go
+++ b/server/storage/job.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -332,6 +333,12 @@ type ListFilter struct {
 	RootID       string
 	Status       model.JobStatus
 	Limit        int
+
+	// ViewerID restricts the listing to what one user may see: their
+	// own jobs, and everything under a job tree they started. Empty
+	// means the caller may see everything, which is what an admin, an
+	// agent and a public instance all are.
+	ViewerID string
 }
 
 // List returns jobs matching the filter, newest first.
@@ -358,6 +365,15 @@ func (s *JobStorage) List(ctx context.Context, filter ListFilter) ([]model.Job, 
 		where = append(where, "status = ?")
 		args = append(args, filter.Status)
 	}
+	if filter.ViewerID != "" {
+		// A job's owner is whoever dispatched it, and a job dispatched
+		// from inside a running pipeline belongs to the agent's
+		// account rather than to the human who started the pipeline.
+		// Scoping on user_id alone would therefore hide a user's own
+		// fan-out from them, so the root of the tree decides too.
+		where = append(where, `(user_id = ? OR root_id IN (SELECT id FROM `+model.JobTable+` WHERE user_id = ?))`)
+		args = append(args, filter.ViewerID, filter.ViewerID)
+	}
 
 	limit := filter.Limit
 	if limit <= 0 {
@@ -368,6 +384,38 @@ func (s *JobStorage) List(ctx context.Context, filter ListFilter) ([]model.Job, 
 	query := `SELECT * FROM ` + model.JobTable + ` WHERE ` + strings.Join(where, " AND ") + `
 		ORDER BY created_at DESC LIMIT ?`
 	return client(s.db).Select[model.Job](ctx, query, args...)
+}
+
+// VisibleTo reports whether a user may read one job.
+//
+// It is the single-job form of ListFilter.ViewerID, and answers the
+// same question: the job is theirs, or it belongs to a tree they
+// started. Callers who may see everything should not call this.
+func (s *JobStorage) VisibleTo(ctx context.Context, job *model.Job, userID string) (bool, error) {
+	if job == nil || userID == "" {
+		return false, nil
+	}
+	if job.UserID == userID {
+		return true, nil
+	}
+
+	// A root job has already been checked by its own user_id.
+	if job.RootID == "" || job.RootID == job.ID {
+		return false, nil
+	}
+
+	root, err := s.Get(ctx, job.RootID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// The root has been swept by retention. Whatever the child
+			// belonged to is gone; fall back to the child's own owner,
+			// which has already said no.
+			return false, nil
+		}
+		return false, err
+	}
+
+	return root.UserID == userID, nil
 }
 
 // agentAcceptsJob reports whether an agent advertising the given labels

--- a/server/storage/retention.go
+++ b/server/storage/retention.go
@@ -1,0 +1,288 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/titpetric/platform/pkg/telemetry"
+
+	"github.com/titpetric/atkins/server/model"
+)
+
+// Retention defaults. They bound one pass rather than the whole
+// backlog: the first sweep of an instance that has been running for a
+// year has millions of job_log rows to remove, and a DELETE that large
+// holds locks for minutes. A pass removes at most Batch × MaxBatches
+// rows of each kind and leaves the rest for the next tick, so a server
+// catching up stays a server.
+const (
+	// DefaultRetentionBatch is how many rows one DELETE removes.
+	DefaultRetentionBatch = 500
+
+	// DefaultRetentionBatches is how many batches one pass runs.
+	DefaultRetentionBatches = 20
+)
+
+// RetentionRequest is one retention pass.
+//
+// The two windows are independent on purpose. Output is what grows
+// without bound, and it stops being interesting long before the outcome
+// does; an instance that keeps every job forever and every log line for
+// a month is the common case.
+type RetentionRequest struct {
+	// Jobs is how long a settled job's record is kept, measured from
+	// when it finished. Zero keeps job records forever.
+	Jobs time.Duration
+
+	// Logs is how long a settled job's captured output is kept. Zero
+	// keeps output forever.
+	Logs time.Duration
+
+	// Batch is how many rows one statement removes. Zero selects
+	// DefaultRetentionBatch.
+	Batch int
+
+	// MaxBatches bounds one pass. Zero selects DefaultRetentionBatches.
+	MaxBatches int
+}
+
+// RetentionResult reports what a pass removed.
+type RetentionResult struct {
+	// Jobs is how many job records were deleted.
+	Jobs int64
+
+	// Logs is how many output rows were deleted, including those that
+	// went with a deleted job.
+	Logs int64
+
+	// Partial is set when the pass stopped at MaxBatches with work
+	// still to do. The next tick continues where this one stopped.
+	Partial bool
+}
+
+// Empty reports whether the pass deleted nothing at all.
+func (r RetentionResult) Empty() bool {
+	return r.Jobs == 0 && r.Logs == 0
+}
+
+// withDefaults fills the bounds a caller left at zero.
+func (r RetentionRequest) withDefaults() RetentionRequest {
+	if r.Batch <= 0 {
+		r.Batch = DefaultRetentionBatch
+	}
+	if r.MaxBatches <= 0 {
+		r.MaxBatches = DefaultRetentionBatches
+	}
+	return r
+}
+
+// Purge applies the retention windows and reports what it removed.
+//
+// Job records go first, because deleting a job takes its output with it
+// and there is no point sweeping logs that are about to disappear along
+// with their job. Neither window touches a job that has not settled: a
+// pending job is not old, it is waiting, and a running job that has
+// lost its agent is the lease sweep's problem, not this one's.
+func (s *JobStorage) Purge(ctx context.Context, req RetentionRequest) (RetentionResult, error) {
+	ctx, span := telemetry.StartAuto(ctx, s.Purge)
+	defer span.End()
+
+	req = req.withDefaults()
+	now := time.Now()
+
+	var result RetentionResult
+
+	if req.Jobs > 0 {
+		jobs, logs, partial, err := s.purgeJobs(ctx, now.Add(-req.Jobs), req)
+		result.Jobs += jobs
+		result.Logs += logs
+		result.Partial = result.Partial || partial
+		if err != nil {
+			return result, err
+		}
+	}
+
+	if req.Logs > 0 {
+		logs, partial, err := s.purgeJobLogs(ctx, now.Add(-req.Logs), req)
+		result.Logs += logs
+		result.Partial = result.Partial || partial
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+// purgeJobs deletes settled jobs that finished before the cutoff, with
+// their output, in batches.
+//
+// Progress is guaranteed: every selected row is deleted, so the next
+// batch selects rows the previous one did not see.
+func (s *JobStorage) purgeJobs(ctx context.Context, cutoff time.Time, req RetentionRequest) (int64, int64, bool, error) {
+	var jobs, logs int64
+
+	for range req.MaxBatches {
+		ids, err := s.settledJobIDs(ctx, cutoff, req.Batch)
+		if err != nil {
+			return jobs, logs, false, err
+		}
+		if len(ids) == 0 {
+			return jobs, logs, false, nil
+		}
+
+		removed, err := s.deleteJobs(ctx, ids)
+		if err != nil {
+			return jobs, logs, false, err
+		}
+
+		jobs += int64(len(ids))
+		logs += removed
+
+		// A short batch means the cutoff has been reached.
+		if len(ids) < req.Batch {
+			return jobs, logs, false, nil
+		}
+	}
+
+	return jobs, logs, true, nil
+}
+
+// purgeJobLogs deletes the output of settled jobs that finished before
+// the cutoff, leaving the job records themselves alone.
+//
+// The batch is selected from job_log rather than from job so that every
+// pass makes progress. Selecting jobs and deleting their logs would
+// keep re-reading the same jobs once their output was gone, and an
+// instance with a large backlog would never reach the end of it.
+func (s *JobStorage) purgeJobLogs(ctx context.Context, cutoff time.Time, req RetentionRequest) (int64, bool, error) {
+	var deleted int64
+
+	for range req.MaxBatches {
+		ids, err := s.expiredLogIDs(ctx, cutoff, req.Batch)
+		if err != nil {
+			return deleted, false, err
+		}
+		if len(ids) == 0 {
+			return deleted, false, nil
+		}
+
+		query := `DELETE FROM ` + model.JobLogTable + ` WHERE id IN (` + placeholders(len(ids)) + `)`
+		if err := client(s.db).Exec(ctx, query, arguments(ids)...); err != nil {
+			return deleted, false, fmt.Errorf("delete job logs: %w", err)
+		}
+
+		deleted += int64(len(ids))
+
+		if len(ids) < req.Batch {
+			return deleted, false, nil
+		}
+	}
+
+	return deleted, true, nil
+}
+
+// idRow scans a bare id column.
+type idRow struct {
+	ID string `db:"id"`
+}
+
+// settledJobIDs returns up to limit settled jobs that finished before
+// the cutoff, oldest first.
+func (s *JobStorage) settledJobIDs(ctx context.Context, cutoff time.Time, limit int) ([]string, error) {
+	terminal := model.TerminalJobStatuses()
+
+	query := `SELECT id FROM ` + model.JobTable + `
+		WHERE status IN (` + placeholders(len(terminal)) + `)
+		  AND finished_at IS NOT NULL AND finished_at < ?
+		ORDER BY finished_at ASC LIMIT ?`
+
+	args := append(arguments(terminal), cutoff, limit)
+	rows, err := client(s.db).Select[idRow](ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("select expired jobs: %w", err)
+	}
+
+	return identifiers(rows), nil
+}
+
+// expiredLogIDs returns up to limit output rows belonging to settled
+// jobs that finished before the cutoff.
+func (s *JobStorage) expiredLogIDs(ctx context.Context, cutoff time.Time, limit int) ([]string, error) {
+	terminal := model.TerminalJobStatuses()
+
+	query := `SELECT ` + model.JobLogTable + `.id FROM ` + model.JobLogTable + `
+		INNER JOIN ` + model.JobTable + ` ON ` + model.JobTable + `.id = ` + model.JobLogTable + `.job_id
+		WHERE ` + model.JobTable + `.status IN (` + placeholders(len(terminal)) + `)
+		  AND ` + model.JobTable + `.finished_at IS NOT NULL
+		  AND ` + model.JobTable + `.finished_at < ?
+		LIMIT ?`
+
+	args := append(arguments(terminal), cutoff, limit)
+	rows, err := client(s.db).Select[idRow](ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("select expired job logs: %w", err)
+	}
+
+	return identifiers(rows), nil
+}
+
+// deleteJobs removes jobs and their output, and reports how many output
+// rows went with them.
+//
+// One transaction per batch: a job record that outlives its output is a
+// page that renders, and output that outlives its job is a row nothing
+// will ever read again or clean up.
+func (s *JobStorage) deleteJobs(ctx context.Context, ids []string) (int64, error) {
+	db := client(s.db)
+	if err := db.Begin(ctx); err != nil {
+		return 0, fmt.Errorf("begin job purge: %w", err)
+	}
+	defer db.Rollback()
+
+	args := arguments(ids)
+	list := placeholders(len(ids))
+
+	if err := db.Exec(ctx, `DELETE FROM `+model.JobLogTable+` WHERE job_id IN (`+list+`)`, args...); err != nil {
+		return 0, fmt.Errorf("delete job output: %w", err)
+	}
+	logs := db.RowsAffected()
+
+	if err := db.Exec(ctx, `DELETE FROM `+model.JobTable+` WHERE id IN (`+list+`)`, args...); err != nil {
+		return 0, fmt.Errorf("delete jobs: %w", err)
+	}
+
+	if err := db.Commit(); err != nil {
+		return 0, fmt.Errorf("commit job purge: %w", err)
+	}
+
+	return logs, nil
+}
+
+// placeholders renders an IN list of n bind parameters.
+func placeholders(n int) string {
+	if n <= 0 {
+		return "NULL"
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+// arguments widens a string slice into query arguments.
+func arguments(values []string) []any {
+	args := make([]any, 0, len(values))
+	for _, value := range values {
+		args = append(args, value)
+	}
+	return args
+}
+
+// identifiers pulls the ids out of scanned rows.
+func identifiers(rows []idRow) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	return ids
+}

--- a/server/storage/retention_test.go
+++ b/server/storage/retention_test.go
@@ -1,0 +1,315 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/titpetric/platform/pkg/drivers"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/titpetric/platform"
+	"github.com/titpetric/platform/pkg/ulid"
+
+	"github.com/titpetric/atkins/server/model"
+	"github.com/titpetric/atkins/server/schema"
+)
+
+// connectionSeq hands each test a database of its own.
+var connectionSeq atomic.Int64
+
+// testStorage returns a migrated, throwaway database and a JobStorage
+// over it.
+//
+// A file rather than :memory: because the platform gives sqlite a
+// connection pool, and every connection to an in-memory sqlite database
+// is a separate, empty database.
+func testStorage(t *testing.T) (*sqlx.DB, *JobStorage) {
+	t.Helper()
+
+	connection := "atkins_retention_" + strconv.Itoa(int(connectionSeq.Add(1)))
+	dsn := "sqlite://file:" + filepath.Join(t.TempDir(), "atkins.db")
+	t.Setenv("PLATFORM_DB_"+strings.ToUpper(connection), dsn)
+	platform.SetupConnections(os.Environ())
+
+	db, err := DB(t.Context(), connection)
+	require.NoError(t, err)
+	require.NoError(t, Migrate(t.Context(), db, schema.Migrations()))
+
+	return db, NewJobStorage(db, 0, 0)
+}
+
+// seedJob writes one job with the given status and finish time, plus
+// logs chunks of output.
+//
+// It writes rows rather than driving Create and Finish because
+// retention is about the passage of time, and the only way to have a
+// job that finished a week ago is to say so.
+func seedJob(t *testing.T, db *sqlx.DB, status model.JobStatus, finished time.Time, logs int) string {
+	t.Helper()
+
+	job := &model.Job{
+		ID:           ulid.String(),
+		RepositoryID: "repository",
+		UserID:       "user",
+		Command:      "atkins build",
+		Status:       status,
+	}
+	job.RootID = job.ID
+	job.SetCreatedAt(finished)
+	job.SetUpdatedAt(finished)
+	if model.TerminalJobStatus(status) {
+		job.SetStartedAt(finished)
+		job.SetFinishedAt(finished)
+	}
+
+	require.NoError(t, client(db).Insert(t.Context(), model.JobTable, job))
+
+	for seq := range logs {
+		entry := &model.JobLog{
+			ID:      ulid.String(),
+			JobID:   job.ID,
+			Seq:     int64(seq),
+			Stream:  StreamOutput,
+			Content: "line\n",
+		}
+		entry.SetCreatedAt(finished)
+		require.NoError(t, client(db).Insert(t.Context(), model.JobLogTable, entry))
+	}
+
+	return job.ID
+}
+
+// countRows counts what is left in a table.
+func countRows(t *testing.T, db *sqlx.DB, table string) int64 {
+	t.Helper()
+
+	result, err := client(db).Get[struct {
+		Total int64 `db:"total"`
+	}](t.Context(), `SELECT COUNT(*) AS total FROM `+table)
+	require.NoError(t, err)
+
+	return result.Total
+}
+
+// countLogs counts the output rows left for one job.
+func countLogs(t *testing.T, db *sqlx.DB, jobID string) int64 {
+	t.Helper()
+
+	result, err := client(db).Get[struct {
+		Total int64 `db:"total"`
+	}](t.Context(), `SELECT COUNT(*) AS total FROM `+model.JobLogTable+` WHERE job_id = ?`, jobID)
+	require.NoError(t, err)
+
+	return result.Total
+}
+
+func TestPurgeDropsOutputAndKeepsTheOutcome(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	now := time.Now()
+	old := seedJob(t, db, model.JobStatusFailed, now.Add(-48*time.Hour), 3)
+	recent := seedJob(t, db, model.JobStatusPassed, now.Add(-1*time.Hour), 2)
+
+	result, err := jobs.Purge(t.Context(), RetentionRequest{Logs: 24 * time.Hour})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(3), result.Logs)
+	assert.Equal(t, int64(0), result.Jobs)
+	assert.False(t, result.Partial)
+
+	// The job that lost its output kept its outcome, which is the whole
+	// argument for two windows rather than one.
+	assert.Equal(t, int64(2), countRows(t, db, model.JobTable))
+	assert.Equal(t, int64(0), countLogs(t, db, old))
+	assert.Equal(t, int64(2), countLogs(t, db, recent))
+
+	stored, err := jobs.Get(t.Context(), old)
+	require.NoError(t, err)
+	assert.Equal(t, model.JobStatusFailed, stored.Status)
+}
+
+func TestPurgeDeletesJobsWithTheirOutput(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	now := time.Now()
+	old := seedJob(t, db, model.JobStatusPassed, now.Add(-48*time.Hour), 4)
+	recent := seedJob(t, db, model.JobStatusPassed, now.Add(-1*time.Hour), 2)
+
+	result, err := jobs.Purge(t.Context(), RetentionRequest{Jobs: 24 * time.Hour})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), result.Jobs)
+	assert.Equal(t, int64(4), result.Logs)
+
+	// Output never outlives the job it belongs to: nothing would ever
+	// read it again, and nothing would ever clean it up.
+	assert.Equal(t, int64(1), countRows(t, db, model.JobTable))
+	assert.Equal(t, int64(2), countRows(t, db, model.JobLogTable))
+	assert.Equal(t, int64(0), countLogs(t, db, old))
+	assert.Equal(t, int64(2), countLogs(t, db, recent))
+}
+
+func TestPurgeLeavesUnsettledJobsAlone(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	// A job that has not settled is not old, it is waiting — however
+	// long ago it was queued.
+	ancient := time.Now().Add(-365 * 24 * time.Hour)
+	seedJob(t, db, model.JobStatusPending, ancient, 1)
+	seedJob(t, db, model.JobStatusRunning, ancient, 1)
+
+	result, err := jobs.Purge(t.Context(), RetentionRequest{
+		Jobs: time.Minute,
+		Logs: time.Minute,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, result.Empty())
+	assert.Equal(t, int64(2), countRows(t, db, model.JobTable))
+	assert.Equal(t, int64(2), countRows(t, db, model.JobLogTable))
+}
+
+func TestPurgeWithoutWindowsDeletesNothing(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	seedJob(t, db, model.JobStatusPassed, time.Now().Add(-365*24*time.Hour), 2)
+
+	// Both windows default to keeping everything forever, and a sweep
+	// on a server that never configured one must be a no-op.
+	result, err := jobs.Purge(t.Context(), RetentionRequest{})
+	require.NoError(t, err)
+
+	assert.True(t, result.Empty())
+	assert.Equal(t, int64(1), countRows(t, db, model.JobTable))
+	assert.Equal(t, int64(2), countRows(t, db, model.JobLogTable))
+}
+
+func TestPurgeBatchesJobs(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	expired := time.Now().Add(-48 * time.Hour)
+	for range 25 {
+		seedJob(t, db, model.JobStatusPassed, expired, 1)
+	}
+
+	request := RetentionRequest{Jobs: 24 * time.Hour, Batch: 5, MaxBatches: 2}
+
+	// One pass removes Batch × MaxBatches rows and stops, so a first
+	// sweep of a year-old instance is a series of small deletes rather
+	// than one that holds the table for minutes.
+	first, err := jobs.Purge(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), first.Jobs)
+	assert.Equal(t, int64(10), first.Logs)
+	assert.True(t, first.Partial)
+	assert.Equal(t, int64(15), countRows(t, db, model.JobTable))
+
+	// Each further pass picks up where the last one stopped.
+	var passes int
+	for countRows(t, db, model.JobTable) > 0 {
+		passes++
+		require.Less(t, passes, 10, "retention is not making progress")
+
+		_, err := jobs.Purge(t.Context(), request)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(0), countRows(t, db, model.JobLogTable))
+
+	// And the pass that finishes the backlog says so.
+	last, err := jobs.Purge(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, last.Empty())
+	assert.False(t, last.Partial)
+}
+
+func TestPurgeBatchesLogs(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	// One job with a lot of output is the shape that hurts: job_log is
+	// where an instance grows, not job.
+	job := seedJob(t, db, model.JobStatusFailed, time.Now().Add(-48*time.Hour), 25)
+
+	request := RetentionRequest{Logs: 24 * time.Hour, Batch: 5, MaxBatches: 2}
+
+	first, err := jobs.Purge(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), first.Logs)
+	assert.True(t, first.Partial)
+	assert.Equal(t, int64(15), countLogs(t, db, job))
+
+	// The batch is taken from job_log rather than from job, so a second
+	// pass over a job whose output is partly gone still makes progress
+	// instead of re-reading the same job forever.
+	second, err := jobs.Purge(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), second.Logs)
+	assert.Equal(t, int64(5), countLogs(t, db, job))
+
+	third, err := jobs.Purge(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), third.Logs)
+	assert.False(t, third.Partial)
+
+	// The job itself is untouched throughout.
+	assert.Equal(t, int64(1), countRows(t, db, model.JobTable))
+}
+
+func TestVisibleTo(t *testing.T) {
+	db, jobs := testStorage(t)
+
+	root := seedJob(t, db, model.JobStatusPassed, time.Now(), 0)
+
+	// A child dispatched from inside a running pipeline belongs to the
+	// agent's account, not to the human who started the run. It is
+	// still theirs to read.
+	child := &model.Job{
+		ID:           ulid.String(),
+		ParentID:     root,
+		RootID:       root,
+		Depth:        1,
+		RepositoryID: "repository",
+		UserID:       "agent",
+		Command:      "atkins analyzeTag",
+		Status:       model.JobStatusPassed,
+	}
+	child.SetCreatedAt(time.Now())
+	require.NoError(t, client(db).Insert(t.Context(), model.JobTable, child))
+
+	stored, err := jobs.Get(t.Context(), root)
+	require.NoError(t, err)
+
+	visible, err := jobs.VisibleTo(t.Context(), stored, "user")
+	require.NoError(t, err)
+	assert.True(t, visible)
+
+	visible, err = jobs.VisibleTo(t.Context(), stored, "stranger")
+	require.NoError(t, err)
+	assert.False(t, visible)
+
+	visible, err = jobs.VisibleTo(t.Context(), child, "user")
+	require.NoError(t, err)
+	assert.True(t, visible, "a user must see the jobs their own run dispatched")
+
+	visible, err = jobs.VisibleTo(t.Context(), child, "stranger")
+	require.NoError(t, err)
+	assert.False(t, visible)
+
+	// Nothing is visible to nobody.
+	visible, err = jobs.VisibleTo(t.Context(), stored, "")
+	require.NoError(t, err)
+	assert.False(t, visible)
+}
+
+func TestPlaceholders(t *testing.T) {
+	assert.Equal(t, "NULL", placeholders(0))
+	assert.Equal(t, "?", placeholders(1))
+	assert.Equal(t, "?,?,?", placeholders(3))
+}

--- a/server/visibility_test.go
+++ b/server/visibility_test.go
@@ -1,0 +1,177 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server/model"
+)
+
+// registerUser opens registration and creates one ordinary account.
+func registerUser(t *testing.T, url, adminToken, email, username string) tokenResponse {
+	t.Helper()
+
+	setSetting(t, url, adminToken, model.SettingRegistrationOpen, "true")
+
+	var user tokenResponse
+	status := call(t, http.MethodPost, url+"/api/user/register", "", map[string]string{
+		"email":    email,
+		"username": username,
+		"password": "correct-horse",
+	}, &user)
+	require.Equal(t, http.StatusCreated, status)
+
+	return user
+}
+
+// jobIDs pulls the ids out of a job listing.
+func jobIDs(jobs []map[string]any) []string {
+	ids := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		id, _ := job["id"].(string)
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// listJobs reads /api/job as one caller.
+func listJobs(t *testing.T, url, token string) []map[string]any {
+	t.Helper()
+
+	var jobs []map[string]any
+	status := call(t, http.MethodGet, url+"/api/job", token, nil, &jobs)
+	require.Equal(t, http.StatusOK, status)
+
+	return jobs
+}
+
+func TestJobsAreScopedToTheUserWhoDispatchedThem(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	mine := dispatch(t, url, dev.Token, "atkins mine", "")
+	theirs := dispatch(t, url, admin.Token, "atkins theirs", "")
+
+	// A listing shows the caller their own runs and nothing else. Job
+	// output routinely contains things nobody meant to publish.
+	assert.Equal(t, []string{mine.JobID}, jobIDs(listJobs(t, url, dev.Token)))
+
+	// Someone else's job is reported as missing rather than forbidden:
+	// "not yours" and "not here" must look the same, or the endpoint
+	// tells a stranger which jobs exist.
+	for _, path := range []string{
+		"/api/job/" + theirs.JobID,
+		"/api/job/" + theirs.JobID + "/log",
+	} {
+		status := call(t, http.MethodGet, url+path, dev.Token, nil, nil)
+		assert.Equal(t, http.StatusNotFound, status, path)
+	}
+
+	// Acting on it is refused the same way. Reading and writing are one
+	// question here: a job you may not read is one you may not stop.
+	status := call(t, http.MethodPost, url+"/api/job/"+theirs.JobID+"/cancel", dev.Token, nil, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+theirs.JobID+"/retry", dev.Token, nil, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+
+	// An admin sees the instance, which is what the flag is for.
+	assert.Len(t, listJobs(t, url, admin.Token), 2)
+
+	status = call(t, http.MethodGet, url+"/api/job/"+mine.JobID, admin.Token, nil, nil)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestAgentsSeeEveryJob(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	dispatch(t, url, dev.Token, "atkins mine", "")
+	dispatch(t, url, admin.Token, "atkins theirs", "")
+
+	// An agent works the whole queue, so scoping it to "its own" jobs
+	// would leave it unable to see the work it is there to run.
+	agent := enrol(t, url, "agent-1")
+	assert.Len(t, listJobs(t, url, agent.Token), 2)
+}
+
+func TestUserSeesTheJobsTheirOwnRunDispatched(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+	other := registerUser(t, url, admin.Token, "other@example.com", "other")
+
+	parent := dispatch(t, url, dev.Token, "atkins analyze", "")
+
+	// A pipeline that clears ATKINS_NO_DISPATCH queues children under
+	// the agent's own credentials, so the child's user_id is not the
+	// human's. Scoping on user_id alone would hide a fan-out from the
+	// person who started it.
+	agent := enrol(t, url, "agent-1")
+	child := dispatch(t, url, agent.Token, "atkins analyzeTag", parent.JobID)
+	require.Equal(t, parent.RootID, child.RootID)
+
+	status := call(t, http.MethodGet, url+"/api/job/"+child.JobID, dev.Token, nil, nil)
+	assert.Equal(t, http.StatusOK, status)
+
+	assert.ElementsMatch(t, []string{parent.JobID, child.JobID}, jobIDs(listJobs(t, url, dev.Token)))
+
+	// The tree is not visible to somebody outside it.
+	status = call(t, http.MethodGet, url+"/api/job/"+child.JobID, other.Token, nil, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+
+	assert.Empty(t, listJobs(t, url, other.Token))
+}
+
+func TestPublicVisibilityRestoresTheSharedView(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	theirs := dispatch(t, url, admin.Token, "atkins theirs", "")
+	dispatch(t, url, dev.Token, "atkins mine", "")
+
+	// One team on one instance can have the shared view back, and it is
+	// a decision an admin makes rather than the state a server starts
+	// in.
+	setSetting(t, url, admin.Token, model.SettingJobVisibility, model.VisibilityPublic)
+
+	assert.Len(t, listJobs(t, url, dev.Token), 2)
+
+	status := call(t, http.MethodGet, url+"/api/job/"+theirs.JobID, dev.Token, nil, nil)
+	assert.Equal(t, http.StatusOK, status)
+
+	// And it goes back without a restart, because it is a setting.
+	status = call(t, http.MethodDelete, url+"/api/admin/setting/"+model.SettingJobVisibility, admin.Token, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+
+	status = call(t, http.MethodGet, url+"/api/job/"+theirs.JobID, dev.Token, nil, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestJobLogIsScopedLikeTheJob(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins build", "")
+
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", agent.Token, map[string]string{
+		"content": "AWS_SECRET_ACCESS_KEY=hunter2\n",
+	}, nil)
+	require.Equal(t, http.StatusNoContent, status)
+
+	status = call(t, http.MethodGet, url+"/api/job/"+job.JobID+"/log", dev.Token, nil, nil)
+	require.Equal(t, http.StatusNotFound, status)
+
+	var entries []map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+job.JobID+"/log", admin.Token, nil, &entries)
+	require.Equal(t, http.StatusOK, status)
+	assert.Len(t, entries, 1)
+}

--- a/server/web/templates/index.html
+++ b/server/web/templates/index.html
@@ -20,12 +20,18 @@
     </tr>
     {{range .Jobs}}
     <tr>
-      <th class="mono"><a href="/job/{{.ID}}">{{.Command}}</a></th>
+      <th class="mono"><a href="{{joblink .ID}}">{{.Command}}</a></th>
       <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
       <td class="muted">{{stamp .CreatedAt}}</td>
     </tr>
     {{end}}
   </table>
+  {{else if .Private}}
+  <p class="muted">
+    Job listings are private on this server. Open a job with the URL
+    <span class="mono">atkins</span> printed, or list your own over
+    <span class="mono">/api/job</span>.
+  </p>
   {{else}}
   <p class="muted">
     Nothing dispatched yet. Attach a machine with

--- a/server/web/templates/job.html
+++ b/server/web/templates/job.html
@@ -8,7 +8,7 @@
 <body>
   <header>
     <h1><span class="mono">{{.Job.Command}}</span></h1>
-    <p class="muted mono">{{.Job.ID}} · <a href="/">all jobs</a></p>
+    <p class="muted mono">{{.Job.ID}}{{if listing}} · <a href="/">all jobs</a>{{end}}</p>
   </header>
 
   <p>
@@ -72,7 +72,7 @@
     {{if .Job.ParentID}}
     <tr>
       <th>Parent job</th>
-      <td class="mono"><a href="/job/{{.Job.ParentID}}">{{.Job.ParentID}}</a></td>
+      <td class="mono"><a href="{{joblink .Job.ParentID}}">{{.Job.ParentID}}</a></td>
     </tr>
     {{end}}
   </table>
@@ -95,7 +95,7 @@
     <tr><th>File</th><td>Size</td><td>Type</td></tr>
     {{range .Artefacts}}
     <tr>
-      <th class="mono"><a href="/job/{{.JobID}}/artefact/{{.ID}}">{{.Path}}</a></th>
+      <th class="mono"><a href="{{artefactlink .JobID .ID}}">{{.Path}}</a></th>
       <td>{{filesize .Size}}</td>
       <td class="mono">{{.ContentType}}</td>
     </tr>
@@ -109,7 +109,7 @@
     <tr><th>Job</th><td>Status</td></tr>
     {{range .Children}}
     <tr>
-      <th class="mono"><a href="/job/{{.ID}}">{{.Command}}</a></th>
+      <th class="mono"><a href="{{joblink .ID}}">{{.Command}}</a></th>
       <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
     </tr>
     {{end}}

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -2,9 +2,9 @@
 // server.
 //
 // There is deliberately very little here. `atkins` prints one URL when
-// it dispatches a job — `<server>/job/{ULID}` — and that page is where
-// the run is watched: status, timing, the command, and the output the
-// agent captured. Everything else lives behind the JSON API.
+// it dispatches a job — `<server>/job/{ULID}?t=<token>` — and that page
+// is where the run is watched: status, timing, the command, and the
+// output the agent captured. Everything else lives behind the JSON API.
 package web
 
 import (
@@ -18,9 +18,15 @@ import (
 	"github.com/titpetric/platform"
 
 	"github.com/titpetric/atkins/server/api"
+	"github.com/titpetric/atkins/server/auth"
 	"github.com/titpetric/atkins/server/model"
 	"github.com/titpetric/atkins/server/storage"
 )
+
+// ViewTokenParam is the query parameter carrying a job's view token.
+// One letter, because it rides along in a URL a human copies out of a
+// terminal.
+const ViewTokenParam = "t"
 
 // Handlers serves the HTML pages.
 type Handlers struct {
@@ -28,6 +34,12 @@ type Handlers struct {
 	jobLogs      *storage.JobLogStorage
 	artefacts    *storage.JobArtefactStorage
 	repositories *storage.RepositoryStorage
+	settings     *storage.SettingStorage
+
+	// tokens mints and checks the per-job view tokens. It holds the
+	// server's signing key, so a link stops working when the key is
+	// rotated.
+	tokens *auth.JWT
 
 	templates *template.Template
 }
@@ -38,40 +50,65 @@ type Options struct {
 	JobLogStorage      *storage.JobLogStorage
 	JobArtefactStorage *storage.JobArtefactStorage
 	RepositoryStorage  *storage.RepositoryStorage
+	SettingStorage     *storage.SettingStorage
+
+	// SigningKey derives the per-job view tokens.
+	SigningKey string
 }
 
 // NewHandlers returns Handlers with the page templates parsed.
 func NewHandlers(opts Options) (*Handlers, error) {
-	templates, err := template.New("").Funcs(functions()).ParseFS(files, "templates/*.html")
-	if err != nil {
-		return nil, err
-	}
-
-	return &Handlers{
+	handlers := &Handlers{
 		jobs:         opts.JobStorage,
 		jobLogs:      opts.JobLogStorage,
 		artefacts:    opts.JobArtefactStorage,
 		repositories: opts.RepositoryStorage,
-		templates:    templates,
-	}, nil
+		settings:     opts.SettingStorage,
+		tokens:       auth.NewJWT(opts.SigningKey),
+	}
+
+	// The link helper is bound to these handlers rather than to the
+	// package: whether a link needs a token is a runtime setting, and
+	// the closure reads it when the page renders.
+	templates, err := template.New("").Funcs(handlers.functions()).ParseFS(files, "templates/*.html")
+	if err != nil {
+		return nil, err
+	}
+	handlers.templates = templates
+
+	return handlers, nil
 }
 
 // Mount registers the page routes.
 //
-// The pages are readable without a session. A job URL carries a ULID
-// that is not enumerable in practice, and the point of printing one in
-// a terminal is that pasting it into a browser just works. Run the
-// server behind your own auth if the output is sensitive.
+// No page here has a session to check: the browser reading them never
+// logged in. What a private instance checks instead is the per-job view
+// token in the URL atkins printed, which keeps the one thing that has
+// to stay true — a pasted URL opens the job — without also handing the
+// job to anyone who guesses a ULID.
+//
 // The artefact download shares that trust model rather than a weaker or
 // a stronger one. A file a job produced is no more sensitive than the
-// output that produced it, and a download link on a page that needs no
-// session must not be a link that fails: a browser has no bearer token
-// to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated door
-// for scripts.
+// output that produced it, so it is reachable on exactly the terms the
+// page is: same token, same setting. A download link on a page a browser
+// can open must not be a link that fails, and a browser has no bearer
+// token to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated
+// door for scripts.
 func (h *Handlers) Mount(r platform.Router) {
 	r.Get("/", h.Index)
 	r.Get("/job/{jobID}", h.Job)
 	r.Get("/job/{jobID}/artefact/{artefactID}", h.Artefact)
+}
+
+// public reports whether the pages are open to anyone holding a URL.
+//
+// A nil setting store means the module has not wired one, and the safe
+// reading of "no configuration" is the private one.
+func (h *Handlers) public() bool {
+	if h.settings == nil {
+		return false
+	}
+	return h.settings.Get(model.SettingJobVisibility) == model.VisibilityPublic
 }
 
 // JobPage is the view model for the job page.
@@ -87,25 +124,56 @@ type JobPage struct {
 	Refresh int
 }
 
+// IndexPage is the view model for the front page.
+type IndexPage struct {
+	Jobs []model.Job
+
+	// Refresh is the auto-reload interval in seconds. Zero for a page
+	// that will not change on its own.
+	Refresh int
+
+	// Private is set when the listing is withheld, so the page can say
+	// why rather than looking like an instance nobody has ever used.
+	Private bool
+}
+
 // Index lists recent jobs.
+//
+// A private instance lists nothing: no per-job token can scope a
+// listing and there is no session to scope it by, so the listing lives
+// on /api/job where the caller is authenticated. The page still
+// answers, and says why — it is the server's front door, and a health
+// check probing it should find a server rather than a refusal.
 func (h *Handlers) Index(w http.ResponseWriter, r *http.Request) {
+	if !h.public() {
+		h.render(w, r, "index.html", IndexPage{Private: true})
+		return
+	}
+
 	jobs, err := h.jobs.List(r.Context(), storage.ListFilter{Limit: 50})
 	if err != nil {
 		h.fail(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
-	h.render(w, r, "index.html", struct {
-		Jobs    []model.Job
-		Refresh int
-	}{Jobs: jobs, Refresh: 5})
+	h.render(w, r, "index.html", IndexPage{Jobs: jobs, Refresh: 5})
 }
 
 // Job renders one job: its status, the command, and captured output.
 func (h *Handlers) Job(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	job, err := h.jobs.Get(ctx, platform.URLParam(r, "jobID"))
+	jobID := platform.URLParam(r, "jobID")
+
+	// The token is checked before the job is loaded, so a wrong one
+	// tells a caller nothing about whether the job exists.
+	if !h.public() && !h.tokens.ValidViewToken(jobID, platform.QueryParam(r, ViewTokenParam)) {
+		h.fail(w, r, http.StatusForbidden,
+			errors.New("this job link is missing its access token; use the whole URL atkins printed"))
+		return
+	}
+
+	job, err := h.jobs.Get(ctx, jobID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			h.fail(w, r, http.StatusNotFound, errors.New("no such job"))
@@ -141,7 +209,19 @@ func (h *Handlers) Job(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) Artefact(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	artefact, err := h.artefacts.Get(ctx, platform.URLParam(r, "jobID"), platform.URLParam(r, "artefactID"))
+	jobID := platform.URLParam(r, "jobID")
+
+	// The same gate as the page that links here. A download reachable
+	// without the token would make the artefacts of a private job
+	// public, which is a stranger place to leave them than the output
+	// they came from.
+	if !h.public() && !h.tokens.ValidViewToken(jobID, platform.QueryParam(r, ViewTokenParam)) {
+		h.fail(w, r, http.StatusForbidden,
+			errors.New("this download link is missing its access token; open the job page it belongs to"))
+		return
+	}
+
+	artefact, err := h.artefacts.Get(ctx, jobID, platform.URLParam(r, "artefactID"))
 	if err != nil {
 		h.fail(w, r, http.StatusNotFound, errors.New("no such artefact"))
 		return
@@ -191,12 +271,33 @@ func (h *Handlers) fail(w http.ResponseWriter, r *http.Request, status int, err 
 }
 
 // functions are the template helpers.
-func functions() template.FuncMap {
+func (h *Handlers) functions() template.FuncMap {
 	return template.FuncMap{
-		"stamp":    stamp,
-		"duration": duration,
-		"filesize": filesize,
+		"stamp":        stamp,
+		"duration":     duration,
+		"filesize":     filesize,
+		"joblink":      h.jobLink,
+		"artefactlink": h.artefactLink,
+		"listing":      h.public,
 	}
+}
+
+// artefactLink is where an artefact downloads from, token and all.
+//
+// It carries the token of the job the artefact belongs to, so a
+// download is reachable exactly when the page listing it is.
+func (h *Handlers) artefactLink(jobID, artefactID string) string {
+	link := "/job/" + jobID + "/artefact/" + artefactID
+	if h.public() {
+		return link
+	}
+
+	token := h.tokens.ViewToken(jobID)
+	if token == "" {
+		return link
+	}
+
+	return link + "?" + ViewTokenParam + "=" + token
 }
 
 // filesize renders a byte count the way a person reads one.
@@ -216,6 +317,25 @@ func filesize(size int64) string {
 	}
 
 	return fmt.Sprintf("%.1f PB", value/unit)
+}
+
+// jobLink is where a job page lives, token and all.
+//
+// Every link a page renders goes through here, so following a parent or
+// a child from a job you were given a link to keeps working: each hop
+// carries the token for the job it points at, and never the token for
+// the job it came from.
+func (h *Handlers) jobLink(jobID string) string {
+	if h.public() {
+		return "/job/" + jobID
+	}
+
+	token := h.tokens.ViewToken(jobID)
+	if token == "" {
+		return "/job/" + jobID
+	}
+
+	return "/job/" + jobID + "?" + ViewTokenParam + "=" + token
 }
 
 // stamp formats a nullable timestamp.


### PR DESCRIPTION
Closes #29

`job.retention` existed in the setting registry and nothing swept it, and every authenticated user could read every job. Both are fixed here, and both turned on a judgement call.

## What retention deletes

**Two windows, not one.** Keeping an outcome while dropping its output is what people actually want, so the two are separate settings:

| Setting             | Default | Deletes                                            |
|---------------------|---------|----------------------------------------------------|
| `job.log_retention` | `720h`  | A finished job's captured output. The job stays.   |
| `job.retention`     | `0`     | The job record, and its output with it. `0` = forever. |

`job_log` is the table that grows without bound — it holds every line every build ever printed — and a build log stops being interesting long before "did the nightly pass on the 3rd?" does. Dropping output while keeping the record means the page still says what ran, when, on which revision, and whether it passed; only the lines are gone. Deleting the record has to take the output with it, or `job_log` accumulates rows nothing will ever read again and nothing will ever clean up.

**The one behaviour change to be aware of:** `job.log_retention` defaults to 30 days rather than to `0`. A feature whose defaults do nothing does not fix "a long-lived instance grows without bound", and 30 days of build logs is the ordinary expectation (GitHub Actions keeps 90). `0` restores the old forever. If you would rather ship it off by default, it is one string in `server/model/setting.go`.

**Both windows are measured from `finished_at`, and never touch an unsettled job.** A pending job is not old, it is waiting, and a `running` job whose agent died is the lease sweep's problem — it becomes `timeout` first, and is swept later like anything else.

## The batching

Taken seriously, because the first pass on a year-old instance is the one that hurts:

- 500 rows per `DELETE`, 20 batches per pass. A pass that runs out of batches returns `Partial` and leaves the rest for the next tick, so catching up is spread over hours instead of holding `job_log` for minutes.
- Job deletion is one transaction per batch: a record that outlives its output renders a broken page, and output that outlives its record is a leak.
- The batch of expired output is selected from `job_log` **joined to** `job`, not from `job`. Selecting jobs and deleting their logs would keep re-reading jobs whose output was already gone, and an instance with a real backlog would never work through it. Selecting the rows that are about to be deleted guarantees progress. `TestPurgeBatchesLogs` is the regression test.
- The sweep is a **second ticker**, not another statement in the lease sweep. They share nothing but a timer: reclaiming is one cheap `UPDATE` that must happen within a lease of an agent dying, retention walks two tables about as often as a log file is worth rotating. Cadence is `server.retention_interval` (new, `1h`), a start-up setting — the windows are policy an admin changes at runtime, the cadence is a property of the machine. `0` disables it.

## What happens to `GET /job/{ULID}`

**A per-job token in the URL, on by default, with the old open behaviour one setting away.**

The constraint was that `atkins` prints exactly one URL and a human pastes it. That rules out requiring a session: there is no browser login on this server, and building one — login page, cookies, CSRF — is a much larger change than this issue, and would still break the paste. So the page authenticates the *link* rather than the reader:

```
http://localhost:3200/job/01M03A582ZG0GQXAJ4F76SV0GA?t=MW6AakaPjSyDcJyDupJn_V
```

Still one URL. Still pastes. The token is an HMAC of the job ID under the server's signing key, **derived rather than stored** — no column to migrate, nothing extra to leak from a database dump, and rotating the signing key invalidates every outstanding link at once, which is already the documented way to revoke an instance. Links between jobs on the page carry the token for the job they point at, so following a parent or a child keeps working.

The honest trade-off: a token in a URL lands in browser history, in a chat paste, in a proxy log. It is a bearer secret and it is not a session. What it replaces is a bare ULID, which was *also* a bearer secret and had the same exposure with none of the revocation — so this is strictly better than what it replaces, and strictly weaker than a real login. Anyone who needs more should still run the server behind their own auth, and the docs still say so.

## Where I went beyond the issue

- **Scoping is by job *tree*, not by `user_id`.** The issue says "scoped to the caller". Taken literally that is wrong in practice: the fan-out pattern documented in `ci-cd.md` clears `ATKINS_NO_DISPATCH`, so a pipeline's children are dispatched with the *agent's* credentials and carry the agent's `user_id`. Scoping on `user_id` alone would hide a user's own fan-out from them. A job is visible if it is yours **or** it belongs to a tree rooted in a job of yours.
- **`GET /api/job/{id}`, `/log`, `/retry` and `/cancel` are scoped too**, not just the listing. A log endpoint that ignores the scoping on the job is not a scoped API, and a job you may not read is one you may not stop.
- **Refusals are `404`, not `403`.** "Not yours" and "not here" have to look the same, or the endpoint enumerates job IDs for anyone with an account.
- **One setting, not two.** The issue suggests putting both the retention window and the visibility rule in the registry. Visibility became a single `job.visibility` (`private` | `public`) governing both the API scoping and the page, because they are one decision — an instance where the page is open to anyone with a URL gains nothing from scoping the API, and the two drifting apart is a footgun. `public` is exactly the single-team behaviour #27 documented.
- **The index page answers instead of refusing.** My first cut returned `403` for `/` on a private instance. That breaks `compose.yml`, whose healthcheck probes `/` — the server never becomes healthy and the agent never starts. It now returns `200` with an empty listing and a line explaining where the listing went. Caught by bringing the instance up, which is the argument for doing so.
- **Agents see everything.** A worker operates on the whole queue; scoping it to "its own" jobs would be nonsense.

## Tests

1189 pass. New:

- `server/storage/retention_test.go` — against a real migrated sqlite database, because retention is about the passage of time and the only way to have a job that finished a week ago is to write one. Covers: output dropped while the outcome survives, records deleted with their output, unsettled jobs left alone however old, no-op without windows, job batching stops at the bound and resumes, log batching keeps making progress across passes, and `VisibleTo` on a tree.
- `server/retention_test.go` — the module's own ticker, end to end: a running job is not swept, a settled one loses its output, its record survives, and then `job.retention` takes it.
- `server/visibility_test.go` — a non-admin cannot list, read, log, retry or cancel another user's job; an admin can; an agent sees everything; a user sees the children their own run dispatched and a third party sees neither; `public` restores the shared view and resetting the setting takes it away again without a restart.
- `server/auth/view_test.go` — tokens are stable per job, differ between jobs, and stop verifying when the signing key rotates.
- `server/admin_test.go` — the job page with, without and with a wrong token; the public instance; the private index.

## Verified live

`atkins up`, `atkins --register`, then a real dispatch:

- the client printed one tokenised URL; the page returned `200` with the token and `403` without it or with a wrong one; `/` returned `200` and listed nothing;
- a second, non-admin account saw only its own job and got `404` on the admin's job, its log and its cancel; the admin saw both;
- with `retention_interval` at 5s and `job.log_retention` at `1s`, the output disappeared and the outcome stayed, then `job.retention` removed the record, with the pending job untouched throughout:

```text
[atkins] retention removed 0 job(s) and 1 output row(s)
[atkins] retention removed 1 job(s) and 0 output row(s)
```

- flipping `job.visibility` to `public` made the bare URL open, stopped the token being issued, and put the listing back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
