### PR TITLE
server: artefact storage for job outputs

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -20,6 +20,10 @@ ATKINS_ALLOW_REGISTRATION=false
 # away with the container, which is what a test instance should do.
 PLATFORM_DB_DEFAULT=sqlite://file:/app/data/atkins.db
 
+# Artefact bytes go beside the database, for the same reason: they are
+# state, and this instance's state is disposable.
+ATKINS_ARTEFACT_DIR=/app/data/artefacts
+
 # Server tuning.
 ATKINS_LEASE_TTL=5m
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /coverage
 /bin
+/artefacts
 atkins.log
 atkins
 /*.test

--- a/client/artefact_test.go
+++ b/client/artefact_test.go
@@ -1,0 +1,166 @@
+package client_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/client"
+)
+
+// artefactServer captures one artefact upload, body and all.
+//
+// It is separate from fakeServer because that one decodes every request
+// as JSON, and an artefact request body is a file.
+type artefactServer struct {
+	*httptest.Server
+
+	Path        string
+	Query       string
+	ContentType string
+	Checksum    string
+	Auth        string
+	Content     []byte
+
+	// status is what the upload endpoint answers with.
+	status int
+}
+
+func newArtefactServer(t *testing.T) *artefactServer {
+	t.Helper()
+
+	fake := &artefactServer{status: http.StatusCreated}
+
+	fake.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/user/login" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokens("access"))
+			return
+		}
+
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]client.Artefact{{ID: "artefact-1", Path: "scan.json", Size: 2}})
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+
+		fake.Path = r.URL.Path
+		fake.Query = r.URL.RawQuery
+		fake.ContentType = r.Header.Get("Content-Type")
+		fake.Checksum = r.Header.Get(client.HeaderArtefactChecksum)
+		fake.Auth = r.Header.Get("Authorization")
+		fake.Content = body
+
+		if fake.status >= http.StatusBadRequest {
+			http.Error(w, `{"error":{"code":413,"message":"artefact is larger than artefact.max_size"}}`, fake.status)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(client.Artefact{
+			ID:   "artefact-1",
+			Path: r.URL.Query().Get("path"),
+			Size: int64(len(body)),
+		})
+	}))
+	t.Cleanup(fake.Close)
+
+	t.Setenv("ATKINS_CREDENTIALS", filepath.Join(t.TempDir(), "credentials.json"))
+
+	return fake
+}
+
+// loggedIn returns a client with a stored credential.
+func loggedIn(t *testing.T, server string) *client.Client {
+	t.Helper()
+
+	c := client.New(server)
+	_, err := c.Login(t.Context(), client.LoginRequest{Email: "ci@example.com"})
+	require.NoError(t, err)
+
+	return c
+}
+
+func TestUploadArtefactSendsTheFile(t *testing.T) {
+	fake := newArtefactServer(t)
+	c := loggedIn(t, fake.URL)
+
+	artefact, err := c.UploadArtefact(t.Context(), "job-1", client.ArtefactUpload{
+		Path:        "reports/scan.json",
+		ContentType: "application/json",
+		Checksum:    "abc123",
+		Content:     strings.NewReader(`{"ok":true}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "artefact-1", artefact.ID)
+
+	assert.Equal(t, "/api/job/job-1/artefact", fake.Path)
+	// The name is a query parameter, and it is escaped: a path with a
+	// space or a plus in it has to survive the trip.
+	assert.Equal(t, "path=reports%2Fscan.json", fake.Query)
+	assert.Equal(t, "application/json", fake.ContentType)
+	assert.Equal(t, "abc123", fake.Checksum)
+	assert.Equal(t, "Bearer access", fake.Auth)
+	assert.JSONEq(t, `{"ok":true}`, string(fake.Content))
+}
+
+func TestUploadArtefactDefaultsTheContentType(t *testing.T) {
+	fake := newArtefactServer(t)
+	c := loggedIn(t, fake.URL)
+
+	_, err := c.UploadArtefact(t.Context(), "job-1", client.ArtefactUpload{
+		Path:    "core.dump",
+		Content: strings.NewReader("binary"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "application/octet-stream", fake.ContentType)
+}
+
+func TestUploadArtefactReportsARefusal(t *testing.T) {
+	fake := newArtefactServer(t)
+	fake.status = http.StatusRequestEntityTooLarge
+
+	c := loggedIn(t, fake.URL)
+
+	_, err := c.UploadArtefact(t.Context(), "job-1", client.ArtefactUpload{
+		Path:    "core.dump",
+		Content: strings.NewReader("too much"),
+	})
+	require.Error(t, err)
+
+	var apiErr *client.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Error(), "artefact.max_size")
+}
+
+func TestUploadArtefactWithoutCredentials(t *testing.T) {
+	fake := newArtefactServer(t)
+
+	_, err := client.New(fake.URL).UploadArtefact(t.Context(), "job-1", client.ArtefactUpload{
+		Path:    "scan.json",
+		Content: strings.NewReader("{}"),
+	})
+	assert.ErrorIs(t, err, client.ErrNotLoggedIn)
+}
+
+func TestArtefactsLists(t *testing.T) {
+	fake := newArtefactServer(t)
+	c := loggedIn(t, fake.URL)
+
+	listed, err := c.Artefacts(t.Context(), "job-1")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, "scan.json", listed[0].Path)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -42,6 +43,11 @@ type Client struct {
 // DefaultTimeout bounds a single API call. Dispatch happens on the hot
 // path of every atkins run, so it must never hang a build.
 const DefaultTimeout = 10 * time.Second
+
+// UploadTimeout bounds one artefact transfer. It is generous because an
+// artefact is measured in megabytes rather than in fields, and nothing
+// is waiting on it: the job has already finished by the time it runs.
+const UploadTimeout = 5 * time.Minute
 
 // New returns an unauthenticated client for a server. It is what the
 // login and register flows use before a credential exists.
@@ -202,6 +208,70 @@ func (c *Client) AppendLog(ctx context.Context, jobID, stream, content string) e
 	}, nil, true)
 }
 
+// UploadArtefact pushes one file a job produced.
+//
+// The body is the file itself. A multipart envelope would buy nothing
+// here: there is one part, and the two fields around it fit in a query
+// parameter and a header.
+func (c *Client) UploadArtefact(ctx context.Context, jobID string, upload ArtefactUpload) (*Artefact, error) {
+	authorization, err := c.authorization(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	target := c.server + "/api/job/" + jobID + "/artefact?path=" + url.QueryEscape(upload.Path)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target, upload.Content)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Content-Type", contentTypeOrDefault(upload.ContentType))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", UserAgent)
+	request.Header.Set("Authorization", authorization)
+	if upload.Checksum != "" {
+		request.Header.Set(HeaderArtefactChecksum, upload.Checksum)
+	}
+
+	// Not c.http: its timeout is sized for the dispatch call on the hot
+	// path of every run, and a 32MB artefact on a slow link is not that
+	// request.
+	response, err := (&http.Client{Timeout: UploadTimeout}).Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode >= http.StatusBadRequest {
+		return nil, decodeAPIError(response)
+	}
+
+	var artefact Artefact
+	if err := json.NewDecoder(response.Body).Decode(&artefact); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return &artefact, nil
+}
+
+// Artefacts lists the files a job produced.
+func (c *Client) Artefacts(ctx context.Context, jobID string) ([]Artefact, error) {
+	var artefacts []Artefact
+	if err := c.do(ctx, http.MethodGet, "/api/job/"+jobID+"/artefact", nil, &artefacts, true); err != nil {
+		return nil, err
+	}
+	return artefacts, nil
+}
+
+// contentTypeOrDefault falls back to the media type the server would
+// have picked anyway.
+func contentTypeOrDefault(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "application/octet-stream"
+	}
+	return value
+}
+
 // JobURL is where a job is watched in a browser. It is the one thing
 // atkins prints when it hands a run to a server.
 func (c *Client) JobURL(jobID string) string {
@@ -280,6 +350,24 @@ func (e *APIError) Error() string {
 	return e.Message
 }
 
+// authorization returns the Authorization header for an authenticated
+// call, refreshing the access token first when it is close to expiring.
+//
+// Every authenticated request goes through here, including the ones
+// that don't carry JSON, so a long-running agent uploading artefacts
+// renews on exactly the same terms as one appending log lines.
+func (c *Client) authorization(ctx context.Context) (string, error) {
+	if c.credential == nil {
+		return "", ErrNotLoggedIn
+	}
+	if c.credential.Expired() {
+		if err := c.Refresh(ctx); err != nil {
+			return "", fmt.Errorf("refresh token: %w", err)
+		}
+	}
+	return "Bearer " + c.credential.Token, nil
+}
+
 // do performs a JSON request, discarding the response status.
 func (c *Client) do(ctx context.Context, method, path string, payload, target any, authenticated bool) error {
 	_, err := c.doStatus(ctx, method, path, payload, target, authenticated)
@@ -294,15 +382,13 @@ func (c *Client) doStatus(ctx context.Context, method, path string, payload, tar
 		return 0, errors.New("no server configured")
 	}
 
+	var authorization string
 	if authenticated {
-		if c.credential == nil {
-			return 0, ErrNotLoggedIn
+		header, err := c.authorization(ctx)
+		if err != nil {
+			return 0, err
 		}
-		if c.credential.Expired() {
-			if err := c.Refresh(ctx); err != nil {
-				return 0, fmt.Errorf("refresh token: %w", err)
-			}
-		}
+		authorization = header
 	}
 
 	var body io.Reader
@@ -321,8 +407,8 @@ func (c *Client) doStatus(ctx context.Context, method, path string, payload, tar
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("User-Agent", UserAgent)
-	if authenticated {
-		request.Header.Set("Authorization", "Bearer "+c.credential.Token)
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
 	}
 
 	response, err := c.http.Do(request)

--- a/client/dispatch.go
+++ b/client/dispatch.go
@@ -25,6 +25,16 @@ const (
 	// EnvJobParams is the JSON object the job was dispatched with.
 	EnvJobParams = "ATKINS_JOB_PARAMS"
 
+	// EnvArtefacts is a directory the job copies files into to have
+	// them kept. Whatever is in it when the command exits is uploaded
+	// and attached to the job.
+	//
+	// It is the declaration that needs no schema: a pipeline says what
+	// it wants kept by putting it somewhere, which works for any
+	// command in any language without atkins having to parse its
+	// output or its configuration.
+	EnvArtefacts = "ATKINS_ARTEFACTS"
+
 	// EnvServer selects which logged-in server to dispatch to when a
 	// machine has credentials for more than one.
 	EnvServer = "ATKINS_SERVER"

--- a/client/types.go
+++ b/client/types.go
@@ -1,5 +1,7 @@
 package client
 
+import "io"
+
 // The payload types below mirror github.com/titpetric/atkins/server/api.
 // They are re-declared rather than imported so the atkins CLI links
 // against net/http alone; importing the server package would pull the
@@ -60,6 +62,7 @@ type DispatchRequest struct {
 	ParentID         string            `json:"parent_id,omitempty"`
 	Labels           []string          `json:"labels,omitempty"`
 	Params           map[string]any    `json:"params,omitempty"`
+	Artefacts        []string          `json:"artefacts,omitempty"`
 }
 
 // DispatchResponse is returned by POST /api/dispatch.
@@ -139,6 +142,10 @@ type Job struct {
 	Labels           string `json:"labels"`
 	Params           string `json:"params"`
 	Status           string `json:"status"`
+
+	// ArtefactPaths are the comma separated globs the agent collects
+	// after the command exits.
+	ArtefactPaths string `json:"artefact_paths"`
 }
 
 // JobCheckoutRequest is the body of POST /api/job/{jobID}/checkout: what
@@ -147,6 +154,41 @@ type JobCheckoutRequest struct {
 	Ref       string `json:"ref"`
 	CommitSHA string `json:"commit_sha"`
 }
+
+// Artefact mirrors api.ArtefactView: one file a job produced.
+type Artefact struct {
+	ID          string `json:"id"`
+	JobID       string `json:"job_id"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	Checksum    string `json:"checksum"`
+	CreatedAt   string `json:"created_at"`
+	URL         string `json:"url"`
+}
+
+// ArtefactUpload is one file being pushed to the server.
+type ArtefactUpload struct {
+	// Path is the name the pipeline gave the file, relative to the
+	// directory the job ran in.
+	Path string
+
+	// ContentType is the media type, guessed from the extension.
+	ContentType string
+
+	// Checksum is the SHA256 the agent computed while reading the
+	// file. The server compares it against what arrives, so a
+	// truncated upload is refused rather than stored.
+	Checksum string
+
+	// Content is the file. It is streamed rather than buffered: an
+	// artefact is as large as the server's limit allows.
+	Content io.Reader
+}
+
+// HeaderArtefactChecksum carries ArtefactUpload.Checksum, mirroring
+// server/api.
+const HeaderArtefactChecksum = "X-Atkins-Checksum"
 
 // JobLogRequest is the body of POST /api/job/{jobID}/log.
 type JobLogRequest struct {

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,11 @@ type ServerConfig struct {
 	// AgentToken is the shared secret agents enrol with.
 	AgentToken string `yaml:"agent_token" json:"agent_token" env:"ATKINS_AGENT_TOKEN"`
 
+	// ArtefactDir is the root the bytes of job artefacts are written
+	// under. The database records what an artefact is; this is where
+	// the file itself goes.
+	ArtefactDir string `yaml:"artefact_dir" json:"artefact_dir" env:"ATKINS_ARTEFACT_DIR"`
+
 	AllowRegistration bool          `yaml:"allow_registration" json:"allow_registration" env:"ATKINS_ALLOW_REGISTRATION"`
 	TokenTTL          time.Duration `yaml:"token_ttl" json:"token_ttl" env:"ATKINS_TOKEN_TTL"`
 	SessionTTL        time.Duration `yaml:"session_ttl" json:"session_ttl" env:"ATKINS_SESSION_TTL"`

--- a/config/config.yml
+++ b/config/config.yml
@@ -49,6 +49,11 @@ server:
   # join.
   agent_token: ""
 
+  # Where the bytes of job artefacts are stored. A relative path is
+  # resolved against the server's working directory, beside the
+  # database.
+  artefact_dir: "artefacts"
+
   # Let anyone register. The first human account on an empty instance
   # is always allowed regardless.
   allow_registration: false

--- a/config/validate.go
+++ b/config/validate.go
@@ -75,6 +75,9 @@ func (s *ServerConfig) applyDefaults(defaults ServerConfig) {
 	if s.Connection == "" {
 		s.Connection = defaults.Connection
 	}
+	if s.ArtefactDir == "" {
+		s.ArtefactDir = defaults.ArtefactDir
+	}
 	if s.TokenTTL <= 0 {
 		s.TokenTTL = defaults.TokenTTL
 	}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,6 +23,7 @@
 - [github.com/titpetric/atkins/server](./atkins_server.md)
 - [github.com/titpetric/atkins/server/api](./atkins_server_api.md)
 - [github.com/titpetric/atkins/server/auth](./atkins_server_auth.md)
+- [github.com/titpetric/atkins/server/blob](./atkins_server_blob.md)
 - [github.com/titpetric/atkins/server/model](./atkins_server_model.md)
 - [github.com/titpetric/atkins/server/schema](./atkins_server_schema.md)
 - [github.com/titpetric/atkins/server/storage](./atkins_server_storage.md)

--- a/docs/api/atkins.md
+++ b/docs/api/atkins.md
@@ -53,6 +53,9 @@ type ServerOptions struct {
 	// mysql://user:pass@tcp(host)/atkins.
 	Database string
 
+	// ArtefactDir is where the bytes of job artefacts are stored.
+	ArtefactDir string
+
 	// SigningKey signs access tokens. Required.
 	SigningKey string
 

--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -40,6 +40,41 @@ type AgentSSHKey struct {
 ```
 
 ```go
+// Artefact mirrors api.ArtefactView: one file a job produced.
+type Artefact struct {
+	ID          string `json:"id"`
+	JobID       string `json:"job_id"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	Checksum    string `json:"checksum"`
+	CreatedAt   string `json:"created_at"`
+	URL         string `json:"url"`
+}
+```
+
+```go
+// ArtefactUpload is one file being pushed to the server.
+type ArtefactUpload struct {
+	// Path is the name the pipeline gave the file, relative to the
+	// directory the job ran in.
+	Path string
+
+	// ContentType is the media type, guessed from the extension.
+	ContentType string
+
+	// Checksum is the SHA256 the agent computed while reading the
+	// file. The server compares it against what arrives, so a
+	// truncated upload is refused rather than stored.
+	Checksum string
+
+	// Content is the file. It is streamed rather than buffered: an
+	// artefact is as large as the server's limit allows.
+	Content io.Reader
+}
+```
+
+```go
 // Checkout is what the client reports about the working copy a run
 // happens in. It is the whole of what the server needs to reproduce the
 // run elsewhere: which repository, where inside it, at what revision.
@@ -131,6 +166,7 @@ type DispatchRequest struct {
 	ParentID         string            `json:"parent_id,omitempty"`
 	Labels           []string          `json:"labels,omitempty"`
 	Params           map[string]any    `json:"params,omitempty"`
+	Artefacts        []string          `json:"artefacts,omitempty"`
 }
 ```
 
@@ -189,6 +225,10 @@ type Job struct {
 	Labels           string `json:"labels"`
 	Params           string `json:"params"`
 	Status           string `json:"status"`
+
+	// ArtefactPaths are the comma separated globs the agent collects
+	// after the command exits.
+	ArtefactPaths string `json:"artefact_paths"`
 }
 ```
 
@@ -327,9 +367,22 @@ const DefaultTimeout = 10 * time.Second
 ```
 
 ```go
+// HeaderArtefactChecksum carries ArtefactUpload.Checksum, mirroring
+// server/api.
+const HeaderArtefactChecksum = "X-Atkins-Checksum"
+```
+
+```go
 // MinPasswordLength mirrors what the server accepts, so a typo is
 // caught at the prompt rather than after a round trip.
 const MinPasswordLength = 8
+```
+
+```go
+// UploadTimeout bounds one artefact transfer. It is generous because an
+// artefact is measured in megabytes rather than in fields, and nothing
+// is waiting on it: the job has already finished by the time it runs.
+const UploadTimeout = 5 * time.Minute
 ```
 
 ```go
@@ -349,6 +402,16 @@ const (
 
 	// EnvJobParams is the JSON object the job was dispatched with.
 	EnvJobParams = "ATKINS_JOB_PARAMS"
+
+	// EnvArtefacts is a directory the job copies files into to have
+	// them kept. Whatever is in it when the command exits is uploaded
+	// and attached to the job.
+	//
+	// It is the declaration that needs no schema: a pipeline says what
+	// it wants kept by putting it somewhere, which works for any
+	// command in any language without atkins having to parse its
+	// output or its configuration.
+	EnvArtefacts = "ATKINS_ARTEFACTS"
 
 	// EnvServer selects which logged-in server to dispatch to when a
 	// machine has credentials for more than one.
@@ -457,6 +520,7 @@ var UserAgent = "atkins"
 - `func (*APIError) Error () string`
 - `func (*Checkout) Payload () RepositoryPayload`
 - `func (*Client) AppendLog (ctx context.Context, jobID,stream,content string) error`
+- `func (*Client) Artefacts (ctx context.Context, jobID string) ([]Artefact, error)`
 - `func (*Client) Claim (ctx context.Context, agentID string, labels []string) (*ClaimResponse, error)`
 - `func (*Client) Dispatch (ctx context.Context, req DispatchRequest) (*DispatchResponse, error)`
 - `func (*Client) Enrol (ctx context.Context, req EnrolRequest) (*Credential, error)`
@@ -471,6 +535,7 @@ var UserAgent = "atkins"
 - `func (*Client) ReportStatus (ctx context.Context, jobID string, req JobStatusRequest) error`
 - `func (*Client) SSHKeys (ctx context.Context) ([]AgentSSHKey, error)`
 - `func (*Client) Server () string`
+- `func (*Client) UploadArtefact (ctx context.Context, jobID string, upload ArtefactUpload) (*Artefact, error)`
 - `func (*Client) Username () string`
 - `func (*Credential) Expired () bool`
 - `func (*Prompter) Line (label,env string) (string, error)`
@@ -699,6 +764,14 @@ AppendLog records a chunk of job output.
 func (*Client) AppendLog(ctx context.Context, jobID, stream, content string) error
 ```
 
+### Artefacts
+
+Artefacts lists the files a job produced.
+
+```go
+func (*Client) Artefacts(ctx context.Context, jobID string) ([]Artefact, error)
+```
+
 ### Claim
 
 Claim leases the oldest pending job this agent can run.
@@ -821,6 +894,18 @@ Server returns the server URL the client talks to.
 
 ```go
 func (*Client) Server() string
+```
+
+### UploadArtefact
+
+UploadArtefact pushes one file a job produced.
+
+The body is the file itself. A multipart envelope would buy nothing
+here: there is one part, and the two fields around it fit in a query
+parameter and a header.
+
+```go
+func (*Client) UploadArtefact(ctx context.Context, jobID string, upload ArtefactUpload) (*Artefact, error)
 ```
 
 ### Username

--- a/docs/api/atkins_config.md
+++ b/docs/api/atkins_config.md
@@ -129,6 +129,11 @@ type ServerConfig struct {
 	// AgentToken is the shared secret agents enrol with.
 	AgentToken string `yaml:"agent_token" json:"agent_token" env:"ATKINS_AGENT_TOKEN"`
 
+	// ArtefactDir is the root the bytes of job artefacts are written
+	// under. The database records what an artefact is; this is where
+	// the file itself goes.
+	ArtefactDir string `yaml:"artefact_dir" json:"artefact_dir" env:"ATKINS_ARTEFACT_DIR"`
+
 	AllowRegistration bool          `yaml:"allow_registration" json:"allow_registration" env:"ATKINS_ALLOW_REGISTRATION"`
 	TokenTTL          time.Duration `yaml:"token_ttl" json:"token_ttl" env:"ATKINS_TOKEN_TTL"`
 	SessionTTL        time.Duration `yaml:"session_ttl" json:"session_ttl" env:"ATKINS_SESSION_TTL"`

--- a/docs/api/atkins_server.md
+++ b/docs/api/atkins_server.md
@@ -34,7 +34,9 @@ type Module struct {
 	api  *api.Handlers
 	web  *web.Handlers
 
-	jobs *storage.JobStorage
+	jobs      *storage.JobStorage
+	artefacts *storage.JobArtefactStorage
+	settings  *storage.SettingStorage
 
 	// reclaim is the background sweep of expired agent leases.
 	cancel context.CancelFunc
@@ -62,6 +64,10 @@ type Options struct {
 	// PLATFORM_DB_ATKINS, falling back to PLATFORM_DB_DEFAULT).
 	Connection string
 
+	// ArtefactDir is the root the bytes of job artefacts are written
+	// under. Empty selects DefaultArtefactDir.
+	ArtefactDir string
+
 	// TokenTTL is the access token lifetime.
 	TokenTTL time.Duration
 
@@ -88,6 +94,13 @@ type Options struct {
 ```
 
 ## Consts
+
+```go
+// DefaultArtefactDir is where artefact bytes go when nothing says
+// otherwise: beside the database, which is where the rest of a small
+// instance's state already lives.
+const DefaultArtefactDir = "artefacts"
+```
 
 ```go
 // Name is the module name, and the name of the database connection the

--- a/docs/api/atkins_server_api.md
+++ b/docs/api/atkins_server_api.md
@@ -31,6 +31,28 @@ type AgentSSHKey struct {
 ```
 
 ```go
+// ArtefactView is how an artefact is described over the API.
+// It is a projection rather than the row: `storage_key` says where the
+// bytes sit on the server, and that is the server's business. The rule
+// is the same one SSHKeyView follows — the projection is the guard, not
+// a `json:"-"` somebody has to remember to add to a new column.
+type ArtefactView struct {
+	ID          string `json:"id"`
+	JobID       string `json:"job_id"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	Checksum    string `json:"checksum"`
+	AgentID     string `json:"agent_id,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+
+	// URL is where the bytes are, so a caller that listed artefacts
+	// does not have to know how to build the path.
+	URL string `json:"url"`
+}
+```
+
+```go
 // ClaimRequest is the body of /api/job/claim.
 type ClaimRequest struct {
 	// AgentID identifies the worker taking the lease.
@@ -84,6 +106,10 @@ type DispatchRequest struct {
 	// CloneDepth limits the history of the work tree the agent builds.
 	// 0, the default, is the whole history.
 	CloneDepth int64 `json:"clone_depth"`
+
+	// Artefacts are glob patterns the agent collects after the command
+	// exits, relative to the directory it ran in.
+	Artefacts []string `json:"artefacts"`
 }
 ```
 
@@ -136,6 +162,7 @@ type Handlers struct {
 	repositories *storage.RepositoryStorage
 	jobs         *storage.JobStorage
 	jobLogs      *storage.JobLogStorage
+	artefacts    *storage.JobArtefactStorage
 	rules        *storage.RepositoryRuleStorage
 	settings     *storage.SettingStorage
 	sshKeys      *storage.SSHKeyStorage
@@ -225,6 +252,7 @@ type Options struct {
 	RepositoryStorage     *storage.RepositoryStorage
 	JobStorage            *storage.JobStorage
 	JobLogStorage         *storage.JobLogStorage
+	JobArtefactStorage    *storage.JobArtefactStorage
 	RepositoryRuleStorage *storage.RepositoryRuleStorage
 	SettingStorage        *storage.SettingStorage
 	SSHKeyStorage         *storage.SSHKeyStorage
@@ -360,6 +388,11 @@ type TriggerRequest struct {
 
 	Labels []string `json:"labels"`
 
+	// Artefacts are glob patterns the agent collects after the command
+	// exits. This is what lets a cron collect `coverage/*.json` from a
+	// pipeline that knows nothing about artefacts.
+	Artefacts []string `json:"artefacts"`
+
 	// ParentID records the job that triggered this one.
 	ParentID string `json:"parent_id"`
 }
@@ -399,9 +432,18 @@ type WhoamiResponse struct {
 const DefaultTokenTTL = time.Hour
 ```
 
+```go
+// HeaderArtefactChecksum carries the SHA256 the agent computed while
+// reading the file. It is optional; when present the server compares it
+// against what actually arrived, so a truncated upload is a 400 rather
+// than an artefact nobody can use.
+const HeaderArtefactChecksum = "X-Atkins-Checksum"
+```
+
 ## Function symbols
 
 - `func NewHandlers (opts Options) *Handlers`
+- `func WriteArtefact (w http.ResponseWriter, artefact *model.JobArtefact, contents io.Reader)`
 - `func (*Handlers) AgentPolicy (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) AgentSSHKeys (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) AppendJobLog (w http.ResponseWriter, r *http.Request)`
@@ -412,12 +454,14 @@ const DefaultTokenTTL = time.Hour
 - `func (*Handlers) DeleteRule (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) DeleteSSHKey (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Dispatch (w http.ResponseWriter, r *http.Request)`
+- `func (*Handlers) DownloadArtefact (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Enrol (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) GetJob (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) GetJobLog (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) JobCheckout (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) JobHeartbeat (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) JobStatus (w http.ResponseWriter, r *http.Request)`
+- `func (*Handlers) ListArtefacts (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) ListJobs (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) ListRepositories (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) ListRules (w http.ResponseWriter, r *http.Request)`
@@ -438,6 +482,7 @@ const DefaultTokenTTL = time.Hour
 - `func (*Handlers) UpdateSSHKey (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) UpdateSetting (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) UpdateUser (w http.ResponseWriter, r *http.Request)`
+- `func (*Handlers) UploadArtefact (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Whoami (w http.ResponseWriter, r *http.Request)`
 - `func (*RequestError) Error () string`
 - `func (*RequestError) Unwrap () error`
@@ -449,6 +494,17 @@ NewHandlers returns Handlers configured from opts.
 
 ```go
 func NewHandlers(opts Options) *Handlers
+```
+
+### WriteArtefact
+
+WriteArtefact streams an artefact as a download.
+
+The web package serves the same bytes from the job page, and a
+difference between the two responses would only ever be a bug.
+
+```go
+func WriteArtefact(w http.ResponseWriter, artefact *model.JobArtefact, contents io.Reader)
 ```
 
 ### AgentPolicy
@@ -534,6 +590,18 @@ Dispatch records a job for the caller's repository and returns its ID.
 func (*Handlers) Dispatch(w http.ResponseWriter, r *http.Request)
 ```
 
+### DownloadArtefact
+
+DownloadArtefact writes the bytes of one artefact.
+
+This is the authenticated way to read an artefact, and the one a
+script should use. The job page has an unauthenticated route of its
+own, on the same terms as the output it shows.
+
+```go
+func (*Handlers) DownloadArtefact(w http.ResponseWriter, r *http.Request)
+```
+
 ### Enrol
 
 Enrol exchanges the shared enrolment token for agent credentials.
@@ -585,6 +653,14 @@ JobStatus settles a job into a terminal state.
 
 ```go
 func (*Handlers) JobStatus(w http.ResponseWriter, r *http.Request)
+```
+
+### ListArtefacts
+
+ListArtefacts returns the artefacts a job produced.
+
+```go
+func (*Handlers) ListArtefacts(w http.ResponseWriter, r *http.Request)
 ```
 
 ### ListJobs
@@ -756,6 +832,21 @@ UpdateUser changes a user's administrative flags.
 
 ```go
 func (*Handlers) UpdateUser(w http.ResponseWriter, r *http.Request)
+```
+
+### UploadArtefact
+
+UploadArtefact stores a file a job produced.
+
+The body is the file itself rather than a multipart form: an artefact
+is bytes, and a raw body streams from the agent's disk to the
+server's without either side building an envelope around it. The
+name, the media type and the checksum are small enough to be
+metadata, and travel as the `path` query parameter, `Content-Type`
+and `X-Atkins-Checksum`.
+
+```go
+func (*Handlers) UploadArtefact(w http.ResponseWriter, r *http.Request)
 ```
 
 ### Whoami

--- a/docs/api/atkins_server_blob.md
+++ b/docs/api/atkins_server_blob.md
@@ -1,0 +1,158 @@
+# Package ./server/blob
+
+```go
+import (
+	"github.com/titpetric/atkins/server/blob"
+}
+```
+
+Package blob stores the bytes of job artefacts.
+
+The database records what an artefact is — which job produced it,
+what the pipeline called it, how big it is and what it hashes to.
+This package holds the bytes themselves, addressed by an opaque key
+that the row carries.
+
+Splitting the two is the whole point. A row is small and worth
+keeping; bytes are large and are the thing that fills a disk. It also
+means the only thing an object store backend has to implement is this
+interface: Put, Open, Remove against a key namespace, with no SQL and
+no HTTP handler anywhere near it.
+
+## Types
+
+```go
+// Dir stores blobs as files under a root directory.
+// It is the right first backend and probably the right one for most
+// installs: the server already keeps its database on a disk, artefacts
+// are written once and read rarely, and a directory is something an
+// operator can back up, rsync or point a webserver at without asking
+// anybody for a bucket.
+type Dir struct {
+	root string
+}
+```
+
+```go
+// Result describes what a Put wrote.
+type Result struct {
+	// Size is the number of bytes stored.
+	Size int64
+
+	// Checksum is the SHA256 of those bytes, in lower case hex. It is
+	// computed while writing rather than by reading the file back,
+	// which would double the I/O for no extra confidence.
+	Checksum string
+}
+```
+
+```go
+// Store holds artefact bytes under opaque keys.
+// A key is a slash separated path in the store's own namespace, not a
+// filesystem path and not the name the pipeline used. Callers build it;
+// the store only refuses one it cannot address safely.
+type Store interface {
+	// Put writes r under key, stopping at limit bytes, and reports what
+	// was written. A limit of zero or less is unbounded.
+	//
+	// Nothing is readable under key until the write completes, so a
+	// failed or oversized upload never leaves half an artefact behind.
+	Put(ctx context.Context, key string, r io.Reader, limit int64) (Result, error)
+
+	// Open returns the bytes stored under key.
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
+
+	// Remove deletes the bytes stored under key. Removing a key that
+	// isn't there is not an error: retention has to be idempotent.
+	Remove(ctx context.Context, key string) error
+}
+```
+
+## Vars
+
+```go
+// Errors returned by a Store.
+var (
+	// ErrTooLarge is returned when the reader had more to give than the
+	// limit allowed.
+	ErrTooLarge = errors.New("blob exceeds the maximum size")
+
+	// ErrInvalidKey is returned for a key that cannot address a blob.
+	ErrInvalidKey = errors.New("invalid blob key")
+)
+```
+
+## Function symbols
+
+- `func Key (jobID,artefactID string) string`
+- `func NewDir (root string) *Dir`
+- `func (*Dir) Open (_ context.Context, key string) (io.ReadCloser, error)`
+- `func (*Dir) Prepare () error`
+- `func (*Dir) Put (_ context.Context, key string, r io.Reader, limit int64) (Result, error)`
+- `func (*Dir) Remove (_ context.Context, key string) error`
+- `func (*Dir) Root () string`
+
+### Key
+
+Key builds the key an artefact's bytes live under.
+
+Grouping by job means retention can drop a job's bytes as a
+directory, and it keeps a single flat directory from growing to a
+million entries on a busy instance.
+
+```go
+func Key(jobID, artefactID string) string
+```
+
+### NewDir
+
+NewDir returns a Store writing under root.
+
+```go
+func NewDir(root string) *Dir
+```
+
+### Open
+
+Open returns the stored bytes.
+
+```go
+func (*Dir) Open(_ context.Context, key string) (io.ReadCloser, error)
+```
+
+### Prepare
+
+Prepare creates the root directory.
+
+The server calls this at start-up: a root it cannot write to should
+stop the process with a clear error, not surface as a failed upload
+on the first job that produces a file.
+
+```go
+func (*Dir) Prepare() error
+```
+
+### Put
+
+Put streams r into the store, hashing as it goes.
+
+```go
+func (*Dir) Put(_ context.Context, key string, r io.Reader, limit int64) (Result, error)
+```
+
+### Remove
+
+Remove deletes the stored bytes, and the job directory with them once
+it is empty.
+
+```go
+func (*Dir) Remove(_ context.Context, key string) error
+```
+
+### Root
+
+Root returns the directory blobs are written under.
+
+```go
+func (*Dir) Root() string
+```

--- a/docs/api/atkins_server_model.md
+++ b/docs/api/atkins_server_model.md
@@ -68,6 +68,9 @@ type Job struct {
 	// Updated At
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at"`
 
+	// Artefact Paths
+	ArtefactPaths string `db:"artefact_paths" json:"artefact_paths"`
+
 	// Ref
 	Ref string `db:"ref" json:"ref"`
 
@@ -76,6 +79,42 @@ type Job struct {
 
 	// Clone Depth
 	CloneDepth int64 `db:"clone_depth" json:"clone_depth"`
+}
+```
+
+```go
+// JobArtefact generated for db table `job_artefact`.
+// Job Artefact.
+type JobArtefact struct {
+	// ID
+	ID string `db:"id" json:"id"`
+
+	// Job ID
+	JobID string `db:"job_id" json:"job_id"`
+
+	// Path
+	Path string `db:"path" json:"path"`
+
+	// Storage Key
+	StorageKey string `db:"storage_key" json:"storage_key"`
+
+	// Size
+	Size int64 `db:"size" json:"size"`
+
+	// Content Type
+	ContentType string `db:"content_type" json:"content_type"`
+
+	// Checksum
+	Checksum string `db:"checksum" json:"checksum"`
+
+	// Agent ID
+	AgentID string `db:"agent_id" json:"agent_id"`
+
+	// Created At
+	CreatedAt *time.Time `db:"created_at" json:"created_at"`
+
+	// Deleted At
+	DeletedAt *time.Time `db:"deleted_at" json:"deleted_at"`
 }
 ```
 
@@ -381,6 +420,17 @@ type User struct {
 ## Consts
 
 ```go
+// DefaultContentType is what an artefact is served as when the agent
+// could not tell what it uploaded.
+const DefaultContentType = "application/octet-stream"
+```
+
+```go
+// JobArtefactTable is the name of the table in the DB.
+const JobArtefactTable = "`job_artefact`"
+```
+
+```go
 // JobLogTable is the name of the table in the DB.
 const JobLogTable = "`job_log`"
 ```
@@ -388,6 +438,13 @@ const JobLogTable = "`job_log`"
 ```go
 // JobTable is the name of the table in the DB.
 const JobTable = "`job`"
+```
+
+```go
+// MaxArtefactPathLength bounds the name an artefact is stored under.
+// The value is a path, not prose; anything longer is a mistake or an
+// attempt to fill a column.
+const MaxArtefactPathLength = 512
 ```
 
 ```go
@@ -433,6 +490,10 @@ const (
 	KindInt      SettingKind = "int"
 	KindDuration SettingKind = "duration"
 	KindEnum     SettingKind = "enum"
+
+	// KindBytes is a size, written the way an operator thinks about
+	// one: 32MB rather than 33554432.
+	KindBytes SettingKind = "bytes"
 )
 ```
 
@@ -457,6 +518,33 @@ const (
 	// SettingJobRetention is how long finished jobs and their output
 	// are kept. Zero keeps them forever.
 	SettingJobRetention = "job.retention"
+
+	// SettingArtefactMaxSize bounds one uploaded artefact.
+	SettingArtefactMaxSize = "artefact.max_size"
+
+	// SettingArtefactMaxCount bounds how many artefacts one job may
+	// keep.
+	SettingArtefactMaxCount = "artefact.max_count"
+
+	// SettingArtefactRetention is how long artefact bytes are kept.
+	// Zero follows job.retention.
+	SettingArtefactRetention = "artefact.retention"
+)
+```
+
+```go
+// Repository policy values.
+const (
+	// PolicyOpen builds any repository a logged-in user dispatches.
+	// It is the default: a personal instance has no third party to
+	// defend against, and requiring a rule before the first run would
+	// make the tool feel broken.
+	PolicyOpen RepositoryPolicy = "open"
+
+	// PolicyAllowlist builds only repositories matching an active
+	// rule. With no rules configured, nothing runs — which is the
+	// point of turning it on.
+	PolicyAllowlist RepositoryPolicy = "allowlist"
 )
 ```
 
@@ -487,27 +575,21 @@ const (
 )
 ```
 
-```go
-// Repository policy values.
-const (
-	// PolicyOpen builds any repository a logged-in user dispatches.
-	// It is the default: a personal instance has no third party to
-	// defend against, and requiring a rule before the first run would
-	// make the tool feel broken.
-	PolicyOpen RepositoryPolicy = "open"
-
-	// PolicyAllowlist builds only repositories matching an active
-	// rule. With no rules configured, nothing runs — which is the
-	// point of turning it on.
-	PolicyAllowlist RepositoryPolicy = "allowlist"
-)
-```
-
 ## Vars
 
 ```go
+// JobArtefactFields is a list of all columns in the DB table.
+var JobArtefactFields = []string{"id", "job_id", "path", "storage_key", "size", "content_type", "checksum", "agent_id", "created_at", "deleted_at"}
+```
+
+```go
+// JobArtefactPrimaryFields are the primary key fields in the DB table.
+var JobArtefactPrimaryFields = []string{"id"}
+```
+
+```go
 // JobFields is a list of all columns in the DB table.
-var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "ref", "commit_sha", "clone_depth"}
+var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "artefact_paths", "ref", "commit_sha", "clone_depth"}
 ```
 
 ```go
@@ -654,6 +736,28 @@ var (
 	// usable private key.
 	ErrInvalidSSHKey = errors.New("not a usable ssh private key")
 
+	// ErrInvalidArtefactPath is returned when an upload names a file
+	// that could not be inside the job's directory.
+	ErrInvalidArtefactPath = errors.New("artefact path must be relative to the job directory")
+
+	// ErrArtefactTooLarge is returned when an upload runs past
+	// artefact.max_size. The bytes written so far are discarded.
+	ErrArtefactTooLarge = errors.New("artefact is larger than artefact.max_size")
+
+	// ErrTooManyArtefacts is returned when a job has already stored
+	// artefact.max_count files. It is the per-job backstop against a
+	// pipeline that uploads in a loop.
+	ErrTooManyArtefacts = errors.New("job has reached artefact.max_count")
+
+	// ErrChecksumMismatch is returned when the bytes received do not
+	// hash to the checksum the agent declared, which means the upload
+	// was truncated or altered in flight.
+	ErrChecksumMismatch = errors.New("artefact checksum does not match the uploaded bytes")
+
+	// ErrArtefactNotFound is returned when an artefact does not exist,
+	// belongs to another job, or has been swept by retention.
+	ErrArtefactNotFound = errors.New("artefact not found")
+
 	// ErrForbidden is returned when a user is authenticated but not
 	// permitted to perform the action.
 	ErrForbidden = errors.New("insufficient permissions")
@@ -666,8 +770,15 @@ var (
 
 ## Function symbols
 
+- `func ArtefactContentType (value string) string`
+- `func ArtefactPath (value string) string`
+- `func ArtefactPattern (value string) string`
+- `func ArtefactPatterns (value string) []string`
+- `func JoinArtefactPatterns (patterns []string) string`
 - `func LookupSetting (name string) (SettingDefinition, bool)`
+- `func MatchArtefactPath (pattern,value string) bool`
 - `func MatchRepository (pattern,slug string) bool`
+- `func ParseBytes (value string) (int64, error)`
 - `func RepositorySlug (remoteURL string) string`
 - `func SettingDefinitions () []SettingDefinition`
 - `func TerminalJobStatus (status JobStatus) bool`
@@ -681,6 +792,7 @@ var (
 - `func WithWhere (clause string) QueryOption`
 - `func (*Job) Delete (opts ...QueryOption) string`
 - `func (*Job) GetAgentID () string`
+- `func (*Job) GetArtefactPaths () string`
 - `func (*Job) GetCloneDepth () int64`
 - `func (*Job) GetCommand () string`
 - `func (*Job) GetCommitSha () string`
@@ -706,6 +818,7 @@ var (
 - `func (*Job) IsTerminal () bool`
 - `func (*Job) Select (opts ...QueryOption) string`
 - `func (*Job) SetAgentID (val string)`
+- `func (*Job) SetArtefactPaths (val string)`
 - `func (*Job) SetCloneDepth (val int64)`
 - `func (*Job) SetCommand (val string)`
 - `func (*Job) SetCommitSha (val string)`
@@ -728,6 +841,30 @@ var (
 - `func (*Job) SetUserID (val string)`
 - `func (*Job) SetWorkingDirectory (val string)`
 - `func (*Job) Update (opts ...QueryOption) string`
+- `func (*JobArtefact) Delete (opts ...QueryOption) string`
+- `func (*JobArtefact) GetAgentID () string`
+- `func (*JobArtefact) GetChecksum () string`
+- `func (*JobArtefact) GetContentType () string`
+- `func (*JobArtefact) GetCreatedAt () *time.Time`
+- `func (*JobArtefact) GetDeletedAt () *time.Time`
+- `func (*JobArtefact) GetID () string`
+- `func (*JobArtefact) GetJobID () string`
+- `func (*JobArtefact) GetPath () string`
+- `func (*JobArtefact) GetSize () int64`
+- `func (*JobArtefact) GetStorageKey () string`
+- `func (*JobArtefact) Insert (opts ...QueryOption) string`
+- `func (*JobArtefact) Select (opts ...QueryOption) string`
+- `func (*JobArtefact) SetAgentID (val string)`
+- `func (*JobArtefact) SetChecksum (val string)`
+- `func (*JobArtefact) SetContentType (val string)`
+- `func (*JobArtefact) SetCreatedAt (stamp time.Time)`
+- `func (*JobArtefact) SetDeletedAt (stamp time.Time)`
+- `func (*JobArtefact) SetID (val string)`
+- `func (*JobArtefact) SetJobID (val string)`
+- `func (*JobArtefact) SetPath (val string)`
+- `func (*JobArtefact) SetSize (val int64)`
+- `func (*JobArtefact) SetStorageKey (val string)`
+- `func (*JobArtefact) Update (opts ...QueryOption) string`
 - `func (*JobLog) Delete (opts ...QueryOption) string`
 - `func (*JobLog) GetContent () string`
 - `func (*JobLog) GetCreatedAt () *time.Time`
@@ -903,12 +1040,90 @@ var (
 - `func (*User) Update (opts ...QueryOption) string`
 - `func (SettingDefinition) ValidateSetting (value string) error`
 
+### ArtefactContentType
+
+ArtefactContentType sanitizes a client-declared media type.
+
+It is echoed back on download, so a header the agent invented must
+not be able to carry a newline into the response.
+
+```go
+func ArtefactContentType(value string) string
+```
+
+### ArtefactPath
+
+ArtefactPath normalizes the name a pipeline gave a file into a clean
+path relative to the directory the job ran in, or "" when the name
+cannot mean that.
+
+This is the same decision cleanWorkingDirectory makes, and it is made
+here for the same reason: the value arrives over the network and ends
+up addressing bytes on the server's disk. An absolute path or a `..`
+escape is rejected outright rather than repaired, because a caller
+asking for `../../etc/passwd` should be told no, not quietly handed
+`etc/passwd`.
+
+```go
+func ArtefactPath(value string) string
+```
+
+### ArtefactPattern
+
+ArtefactPattern normalizes one collection glob, or returns "".
+
+A pattern is a path with `*` and `**` in it, so it is held to exactly
+the same rules as a path: relative, no `..`, no leading separator.
+
+```go
+func ArtefactPattern(value string) string
+```
+
+### ArtefactPatterns
+
+ArtefactPatterns parses the comma separated artefact_paths column
+into the globs an agent should collect, dropping anything that could
+not name a file inside the checkout.
+
+Patterns are validated where they are read rather than only where
+they are written: a pattern can be stored by one version of the
+server and read by another, and the agent is the one that touches the
+filesystem.
+
+```go
+func ArtefactPatterns(value string) []string
+```
+
+### JoinArtefactPatterns
+
+JoinArtefactPatterns renders patterns for the artefact_paths column,
+keeping only the ones that survive validation.
+
+```go
+func JoinArtefactPatterns(patterns []string) string
+```
+
 ### LookupSetting
 
 LookupSetting returns the definition for a name.
 
 ```go
 func LookupSetting(name string) (SettingDefinition, bool)
+```
+
+### MatchArtefactPath
+
+MatchArtefactPath reports whether a path relative to the job's
+directory matches a collection pattern. `*` matches within a path
+segment, `**` across segments, exactly as the repository allowlist
+patterns do.
+
+Unlike MatchRepository this is case-sensitive: repository slugs are
+lowercased on the way in, filenames are not, and `*.JSON` collecting
+`scan.json` on one agent and not another would be worse than strict.
+
+```go
+func MatchArtefactPath(pattern, value string) bool
 ```
 
 ### MatchRepository
@@ -929,6 +1144,16 @@ case-insensitive because slugs are lowercased.
 
 ```go
 func MatchRepository(pattern, slug string) bool
+```
+
+### ParseBytes
+
+ParseBytes reads a size written as a plain number of bytes or with a
+KB/MB/GB suffix. The units are powers of 1024: this bounds a file on
+a disk, and disks are measured the way `ls -lh` measures them.
+
+```go
+func ParseBytes(value string) (int64, error)
 ```
 
 ### RepositorySlug
@@ -1040,6 +1265,14 @@ GetAgentID will return the value of AgentID.
 
 ```go
 func (*Job) GetAgentID() string
+```
+
+### GetArtefactPaths
+
+GetArtefactPaths will return the value of ArtefactPaths.
+
+```go
+func (*Job) GetArtefactPaths() string
 ```
 
 ### GetCloneDepth
@@ -1242,6 +1475,14 @@ SetAgentID sets AgentID to the provided value.
 func (*Job) SetAgentID(val string)
 ```
 
+### SetArtefactPaths
+
+SetArtefactPaths sets ArtefactPaths to the provided value.
+
+```go
+func (*Job) SetArtefactPaths(val string)
+```
+
 ### SetCloneDepth
 
 SetCloneDepth sets CloneDepth to the provided value.
@@ -1416,6 +1657,198 @@ Update starts building a UPDATE query.
 
 ```go
 func (*Job) Update(opts ...QueryOption) string
+```
+
+### Delete
+
+Delete starts building a DELETE query.
+
+```go
+func (*JobArtefact) Delete(opts ...QueryOption) string
+```
+
+### GetAgentID
+
+GetAgentID will return the value of AgentID.
+
+```go
+func (*JobArtefact) GetAgentID() string
+```
+
+### GetChecksum
+
+GetChecksum will return the value of Checksum.
+
+```go
+func (*JobArtefact) GetChecksum() string
+```
+
+### GetContentType
+
+GetContentType will return the value of ContentType.
+
+```go
+func (*JobArtefact) GetContentType() string
+```
+
+### GetCreatedAt
+
+GetCreatedAt will return the value of CreatedAt.
+
+```go
+func (*JobArtefact) GetCreatedAt() *time.Time
+```
+
+### GetDeletedAt
+
+GetDeletedAt will return the value of DeletedAt.
+
+```go
+func (*JobArtefact) GetDeletedAt() *time.Time
+```
+
+### GetID
+
+GetID will return the value of ID.
+
+```go
+func (*JobArtefact) GetID() string
+```
+
+### GetJobID
+
+GetJobID will return the value of JobID.
+
+```go
+func (*JobArtefact) GetJobID() string
+```
+
+### GetPath
+
+GetPath will return the value of Path.
+
+```go
+func (*JobArtefact) GetPath() string
+```
+
+### GetSize
+
+GetSize will return the value of Size.
+
+```go
+func (*JobArtefact) GetSize() int64
+```
+
+### GetStorageKey
+
+GetStorageKey will return the value of StorageKey.
+
+```go
+func (*JobArtefact) GetStorageKey() string
+```
+
+### Insert
+
+Insert starts building an INSERT INTO query.
+
+```go
+func (*JobArtefact) Insert(opts ...QueryOption) string
+```
+
+### Select
+
+Select starts building a SELECT query.
+
+```go
+func (*JobArtefact) Select(opts ...QueryOption) string
+```
+
+### SetAgentID
+
+SetAgentID sets AgentID to the provided value.
+
+```go
+func (*JobArtefact) SetAgentID(val string)
+```
+
+### SetChecksum
+
+SetChecksum sets Checksum to the provided value.
+
+```go
+func (*JobArtefact) SetChecksum(val string)
+```
+
+### SetContentType
+
+SetContentType sets ContentType to the provided value.
+
+```go
+func (*JobArtefact) SetContentType(val string)
+```
+
+### SetCreatedAt
+
+SetCreatedAt sets CreatedAt to the provided value.
+
+```go
+func (*JobArtefact) SetCreatedAt(stamp time.Time)
+```
+
+### SetDeletedAt
+
+SetDeletedAt sets DeletedAt to the provided value.
+
+```go
+func (*JobArtefact) SetDeletedAt(stamp time.Time)
+```
+
+### SetID
+
+SetID sets ID to the provided value.
+
+```go
+func (*JobArtefact) SetID(val string)
+```
+
+### SetJobID
+
+SetJobID sets JobID to the provided value.
+
+```go
+func (*JobArtefact) SetJobID(val string)
+```
+
+### SetPath
+
+SetPath sets Path to the provided value.
+
+```go
+func (*JobArtefact) SetPath(val string)
+```
+
+### SetSize
+
+SetSize sets Size to the provided value.
+
+```go
+func (*JobArtefact) SetSize(val int64)
+```
+
+### SetStorageKey
+
+SetStorageKey sets StorageKey to the provided value.
+
+```go
+func (*JobArtefact) SetStorageKey(val string)
+```
+
+### Update
+
+Update starts building a UPDATE query.
+
+```go
+func (*JobArtefact) Update(opts ...QueryOption) string
 ```
 
 ### Delete

--- a/docs/api/atkins_server_storage.md
+++ b/docs/api/atkins_server_storage.md
@@ -19,6 +19,39 @@ instead so transactions and scoping stay in one place.
 ## Types
 
 ```go
+// ArtefactRequest is one uploaded file.
+type ArtefactRequest struct {
+	// JobID is the job that produced the file. The caller has already
+	// established that it exists.
+	JobID string
+
+	// AgentID records which worker uploaded it.
+	AgentID string
+
+	// Path is the name the pipeline gave the file, relative to the
+	// directory the job ran in.
+	Path string
+
+	// ContentType is what the agent thought it was uploading.
+	ContentType string
+
+	// Checksum, when set, is the SHA256 the agent computed. It is
+	// compared against what actually arrived.
+	Checksum string
+
+	// Content is the file. It is streamed to the blob store rather than
+	// read into memory: an artefact is as large as the limit allows.
+	Content io.Reader
+
+	// MaxSize bounds this upload; MaxCount bounds how many artefacts
+	// the job may keep. Both come from the setting registry, so an
+	// admin can change them without a restart.
+	MaxSize  int64
+	MaxCount int64
+}
+```
+
+```go
 // CheckoutRequest is what an agent reports having checked out.
 type CheckoutRequest struct {
 	// Ref is the effective ref: the one the job named, or the default
@@ -49,6 +82,18 @@ type Flags struct {
 	IsAdmin  *bool `json:"is_admin"`
 	IsActive *bool `json:"is_active"`
 	IsAgent  *bool `json:"is_agent"`
+}
+```
+
+```go
+// JobArtefactStorage persists the files a job produced.
+// It owns both halves of an artefact: the row that describes it and the
+// bytes it points at. Keeping them behind one type is what stops the
+// two from drifting — a caller cannot insert a row for bytes that were
+// never written, or delete a row and forget the file.
+type JobArtefactStorage struct {
+	db    *sqlx.DB
+	blobs blob.Store
 }
 ```
 
@@ -91,6 +136,10 @@ type JobRequest struct {
 
 	// Params is a JSON object handed to the job as ATKINS_JOB_PARAMS.
 	Params string
+
+	// Artefacts are glob patterns the agent collects after the command
+	// exits, relative to the directory it ran in.
+	Artefacts []string
 }
 ```
 
@@ -312,6 +361,7 @@ const (
 
 - `func DB (ctx context.Context, name string) (*sqlx.DB, error)`
 - `func Migrate (ctx context.Context, db *sqlx.DB, schema fs.FS) error`
+- `func NewJobArtefactStorage (db *sqlx.DB, blobs blob.Store) *JobArtefactStorage`
 - `func NewJobLogStorage (db *sqlx.DB) *JobLogStorage`
 - `func NewJobStorage (db *sqlx.DB, maxDepth int64, leaseTTL time.Duration) *JobStorage`
 - `func NewRepositoryRuleStorage (db *sqlx.DB) *RepositoryRuleStorage`
@@ -320,6 +370,12 @@ const (
 - `func NewSessionStorage (db *sqlx.DB, ttl time.Duration) *SessionStorage`
 - `func NewSettingStorage (db *sqlx.DB) *SettingStorage`
 - `func NewUserStorage (db *sqlx.DB) *UserStorage`
+- `func (*JobArtefactStorage) Count (ctx context.Context, jobID string) (int64, error)`
+- `func (*JobArtefactStorage) Create (ctx context.Context, req ArtefactRequest) (*model.JobArtefact, error)`
+- `func (*JobArtefactStorage) Get (ctx context.Context, jobID,artefactID string) (*model.JobArtefact, error)`
+- `func (*JobArtefactStorage) List (ctx context.Context, jobID string) ([]model.JobArtefact, error)`
+- `func (*JobArtefactStorage) Open (ctx context.Context, artefact *model.JobArtefact) (io.ReadCloser, error)`
+- `func (*JobArtefactStorage) PruneExpired (ctx context.Context, cutoff time.Time) (int64, error)`
 - `func (*JobLogStorage) Append (ctx context.Context, jobID,stream,content string) error`
 - `func (*JobLogStorage) List (ctx context.Context, jobID string) ([]model.JobLog, error)`
 - `func (*JobStorage) Claim (ctx context.Context, agentID string, labels []string) (*model.Job, error)`
@@ -356,6 +412,7 @@ const (
 - `func (*SessionStorage) Touch (ctx context.Context, sessionID string) error`
 - `func (*SettingStorage) All () []SettingValue`
 - `func (*SettingStorage) Bool (name string) bool`
+- `func (*SettingStorage) Bytes (name string) int64`
 - `func (*SettingStorage) Duration (name string) time.Duration`
 - `func (*SettingStorage) Get (name string) string`
 - `func (*SettingStorage) Int (name string) int64`
@@ -391,6 +448,15 @@ Migrate applies SQL migrations from the given filesystem to the database.
 
 ```go
 func Migrate(ctx context.Context, db *sqlx.DB, schema fs.FS) error
+```
+
+### NewJobArtefactStorage
+
+NewJobArtefactStorage returns a JobArtefactStorage backed by the
+given pool and blob store.
+
+```go
+func NewJobArtefactStorage(db *sqlx.DB, blobs blob.Store) *JobArtefactStorage
 ```
 
 ### NewJobLogStorage
@@ -457,6 +523,69 @@ NewUserStorage returns a UserStorage backed by the given pool.
 
 ```go
 func NewUserStorage(db *sqlx.DB) *UserStorage
+```
+
+### Count
+
+Count returns how many artefacts a job currently keeps.
+
+```go
+func (*JobArtefactStorage) Count(ctx context.Context, jobID string) (int64, error)
+```
+
+### Create
+
+Create stores an uploaded artefact.
+
+Uploading a path a job already has replaces it. A collection that
+runs twice — a retried upload, a pipeline that copies the same file
+from two steps — should leave one scan.json rather than two, and the
+count limit should not be spent on duplicates.
+
+```go
+func (*JobArtefactStorage) Create(ctx context.Context, req ArtefactRequest) (*model.JobArtefact, error)
+```
+
+### Get
+
+Get returns one artefact of one job.
+
+The job is part of the lookup rather than checked afterwards: an
+artefact ID from another job must not resolve here just because the
+caller could read some job.
+
+```go
+func (*JobArtefactStorage) Get(ctx context.Context, jobID, artefactID string) (*model.JobArtefact, error)
+```
+
+### List
+
+List returns the artefacts of a job whose bytes are still there.
+
+```go
+func (*JobArtefactStorage) List(ctx context.Context, jobID string) ([]model.JobArtefact, error)
+```
+
+### Open
+
+Open returns the bytes of an artefact.
+
+```go
+func (*JobArtefactStorage) Open(ctx context.Context, artefact *model.JobArtefact) (io.ReadCloser, error)
+```
+
+### PruneExpired
+
+PruneExpired drops the bytes of artefacts older than the cutoff and
+reports how many it swept.
+
+The row is soft deleted rather than removed. It costs a few dozen
+bytes, it keeps the record that a 40MB scan.json was produced, and it
+makes the removal auditable: "swept by retention" and "never uploaded"
+are different answers to why a file isn't there.
+
+```go
+func (*JobArtefactStorage) PruneExpired(ctx context.Context, cutoff time.Time) (int64, error)
 ```
 
 ### Append
@@ -792,6 +921,14 @@ Bool returns a setting parsed as a boolean.
 
 ```go
 func (*SettingStorage) Bool(name string) bool
+```
+
+### Bytes
+
+Bytes returns a setting parsed as a size, such as 32MB.
+
+```go
+func (*SettingStorage) Bytes(name string) int64
 ```
 
 ### Duration

--- a/docs/api/atkins_server_web.md
+++ b/docs/api/atkins_server_web.md
@@ -21,6 +21,7 @@ agent captured. Everything else lives behind the JSON API.
 type Handlers struct {
 	jobs         *storage.JobStorage
 	jobLogs      *storage.JobLogStorage
+	artefacts    *storage.JobArtefactStorage
 	repositories *storage.RepositoryStorage
 
 	templates *template.Template
@@ -34,6 +35,7 @@ type JobPage struct {
 	Repository *model.Repository
 	Children   []model.Job
 	Log        []model.JobLog
+	Artefacts  []model.JobArtefact
 
 	// Refresh is the auto-reload interval in seconds. Zero for a
 	// settled job, which never changes again.
@@ -44,15 +46,17 @@ type JobPage struct {
 ```go
 // Options is passed from the server module scope.
 type Options struct {
-	JobStorage        *storage.JobStorage
-	JobLogStorage     *storage.JobLogStorage
-	RepositoryStorage *storage.RepositoryStorage
+	JobStorage         *storage.JobStorage
+	JobLogStorage      *storage.JobLogStorage
+	JobArtefactStorage *storage.JobArtefactStorage
+	RepositoryStorage  *storage.RepositoryStorage
 }
 ```
 
 ## Function symbols
 
 - `func NewHandlers (opts Options) (*Handlers, error)`
+- `func (*Handlers) Artefact (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Index (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Job (w http.ResponseWriter, r *http.Request)`
 - `func (*Handlers) Mount (r platform.Router)`
@@ -63,6 +67,14 @@ NewHandlers returns Handlers with the page templates parsed.
 
 ```go
 func NewHandlers(opts Options) (*Handlers, error)
+```
+
+### Artefact
+
+Artefact serves the bytes of one artefact, as a download.
+
+```go
+func (*Handlers) Artefact(w http.ResponseWriter, r *http.Request)
 ```
 
 ### Index
@@ -89,6 +101,12 @@ The pages are readable without a session. A job URL carries a ULID
 that is not enumerable in practice, and the point of printing one in
 a terminal is that pasting it into a browser just works. Run the
 server behind your own auth if the output is sensitive.
+The artefact download shares that trust model rather than a weaker or
+a stronger one. A file a job produced is no more sensitive than the
+output that produced it, and a download link on a page that needs no
+session must not be a link that fails: a browser has no bearer token
+to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated door
+for scripts.
 
 ```go
 func (*Handlers) Mount(r platform.Router)

--- a/docs/api/atkins_worker.md
+++ b/docs/api/atkins_worker.md
@@ -118,6 +118,11 @@ type Workspace struct {
 
 	// Checkout is what the work tree ended up at.
 	Checkout Checkout
+
+	// Artefacts is the directory the job copies files into to have them
+	// kept. It sits beside the work tree rather than inside it, so
+	// staging a file does not dirty the checkout the job is testing.
+	Artefacts string
 }
 ```
 

--- a/docs/content/usage/ci-cd.md
+++ b/docs/content/usage/ci-cd.md
@@ -19,6 +19,7 @@ atkins          ─────────► /api/dispatch  ──┐
                                             ──► clone into
                                                 /app/data/repos/<slug>
                            /api/job/{id}/log ◄─ streamed output
+                           /api/job/{id}/artefact ◄ files it produced
                            /api/job/{id}/status ◄ terminal state
 browser ──► /job/{ULID}
 ```
@@ -84,6 +85,7 @@ Once logged in, `atkins` posts to `/api/dispatch` and prints the job URL:
 | `parent_id`         | `ATKINS_JOB_ID`, when a job dispatches further work |
 | `labels`            | Which agents may run it                             |
 | `clone_depth`       | History the agent's work tree needs; 0 is all of it |
+| `artefacts`         | Globs the agent collects when the command exits     |
 
 The server normalizes the remote URL into a `host/owner/name` slug, so `git@github.com:you/repo.git` and `https://github.com/you/repo` are one repository. Repositories are created on first sight; nothing has to be registered up front.
 
@@ -111,6 +113,7 @@ An agent publishes these to the command it runs:
 | `ATKINS_ROOT_JOB_ID`   | Top of the job tree, stable across nesting  |
 | `ATKINS_JOB_PARAMS`    | The JSON object the job was dispatched with |
 | `ATKINS_WORKSPACE`     | The checkout the job runs in                |
+| `ATKINS_ARTEFACTS`     | Directory whose contents are kept           |
 | `ATKINS_REPOSITORY`    | Repository slug                             |
 | `ATKINS_REF`           | The ref that was checked out                |
 | `ATKINS_COMMIT_SHA`    | The commit that ref resolved to             |
@@ -200,6 +203,54 @@ What a shallow work tree buys is a small `.git`: it matters when the job package
 
 A job with `clone_depth: 1` has no history and no tags: `git describe`, `git log` past the tip and `git merge-base` will not work, even for the tag the job itself named. `ATKINS_REF` carries that name into the job, which is what a build usually wanted `git describe` for. Fan-outs over tags are the case that wants a depth — each child builds one commit and never looks behind it.
 
+## Artefacts
+
+A job that produces a file — a scan, a coverage report, a built binary — can push it back to the server and have it attached to the job. This is the "collect the outputs and data mine them centrally" half of a CI system: the agent's disk is thrown away with the work tree, and the server keeps what mattered.
+
+There are two ways to say what to keep, and a job can use both.
+
+**Copy it into `$ATKINS_ARTEFACTS`.** The agent creates that directory before the command runs, and uploads whatever is in it afterwards, named by its path within the directory:
+
+```yaml
+jobs:
+  scan:
+    steps:
+      - ./.atkins/bin/scan-repository > scan.json
+      - cp scan.json "$ATKINS_ARTEFACTS/"
+```
+
+Nothing has to be declared anywhere, no schema changes with your pipeline, and it works for any command in any language: a job says what it wants kept by putting it somewhere.
+
+**Declare a glob when you dispatch or trigger.** For a pipeline you'd rather not edit — one that writes `coverage.json` where it writes it — the job can say what to pick up:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO/trigger" \
+  -d '{"job": "test", "artefacts": ["coverage.json", "reports/**/*.json"]}'
+```
+
+Patterns are relative to the directory the job ran in. `*` matches within a path segment and `**` across segments, the same as the repository allowlist patterns. `.git` is never collected.
+
+Collection runs **after the command exits, whatever it exited with** — including a timeout. The artefacts of a failure are usually the ones worth having.
+
+The agent walks the checkout and matches what it finds, rather than handing the pattern to the filesystem: a pattern can only ever select among files that are already inside the checkout, symlinks are not followed, and a path that tries to leave — `../../etc/passwd` — is dropped when the job is created and again by the agent.
+
+Reading them back:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" "$SERVER/api/job/$JOB/artefact" |
+  jq -r '.[] | "\(.path)\t\(.size)\t\(.checksum)"'
+
+curl -sSL -H "Authorization: Bearer $TOKEN" -O "$SERVER/api/job/$JOB/artefact/$ARTEFACT"
+```
+
+The job page lists them with download links, so the URL atkins printed is also where the files are.
+
+**Where the bytes live.** The database records what an artefact is — job, path, size, media type, SHA256 — and the file itself goes under `server.artefact_dir` as `<job-id>/<artefact-id>`. That is a directory an operator can back up, rsync or mount on a volume. The upload is streamed straight to it and hashed on the way past, so the checksum is what the server received rather than what the agent claimed; an upload that arrives short of its declared checksum is refused.
+
+**Limits.** `artefact.max_size` bounds one file and `artefact.max_count` bounds how many one job may keep, both settings rather than constants, so a full disk is a `curl` away from being stopped rather than a redeploy. Re-uploading a path replaces it instead of adding to it.
+
+**Retention.** `artefact.retention` is how long the bytes are kept; `0` follows `job.retention`. The sweep runs on the same ticker as the lease reclaim, removes the file and marks the row deleted — so the record that a 40MB `scan.json` was produced and swept survives, while the 40MB does not. Artefacts are the thing that fills a disk, and they have their own setting because keeping a year of job history while keeping a week of files is a normal thing to want; the reverse never is.
+
 ## Retrying and cancelling
 
 ```bash
@@ -211,9 +262,11 @@ A retry is a **new job** built from the finished one, not a reset: the previous 
 
 ## The job page
 
-`/job/{ULID}` is the URL atkins prints. It shows the status, the command, the repository, the ref the job asked for and the commit the agent resolved it to, timing, the exit code, and the output the agent captured, and it refreshes itself until the job settles. `/` lists recent jobs.
+`/job/{ULID}` is the URL atkins prints. It shows the status, the command, the repository, the ref the job asked for and the commit the agent resolved it to, timing, the exit code, the output the agent captured and the artefacts it uploaded, and it refreshes itself until the job settles. `/` lists recent jobs.
 
 The pages are readable without a session: a ULID is not enumerable in practice, and the point of printing a URL in a terminal is that pasting it into a browser works. Put the server behind your own auth if the output is sensitive.
+
+Artefact downloads from the page — `/job/{ULID}/artefact/{ULID}` — are on the same terms, because a browser has no bearer token to offer and a download link that fails is not a link. `GET /api/job/{id}/artefact/{id}` is the authenticated door, and it is the one a script should use. A file a job produced is served as an attachment with `X-Content-Type-Options: nosniff`, so an artefact named `report.html` is something to save rather than something that runs in the server's origin.
 
 ## Configuration
 
@@ -234,6 +287,7 @@ client:
 server:
   addr: ":3200"
   database: sqlite://file:atkins.db
+  artefact_dir: artefacts
   signing_key: ""
   agent_token: ""
 
@@ -255,6 +309,7 @@ atkins server --signing-key "$(openssl rand -hex 32)" \
 |------------------------|-----------------------------|-----------------------------|
 | `--addr`               | `server.addr`               | `PLATFORM_SERVER_ADDR`      |
 | `--database`           | `server.database`           | `PLATFORM_DB_DEFAULT`       |
+| `--artefact-dir`       | `server.artefact_dir`       | `ATKINS_ARTEFACT_DIR`       |
 | `--signing-key`        | `server.signing_key`        | `ATKINS_SIGNING_KEY`        |
 | `--agent-token`        | `server.agent_token`        | `ATKINS_AGENT_TOKEN`        |
 | `--allow-registration` | `server.allow_registration` | `ATKINS_ALLOW_REGISTRATION` |
@@ -282,7 +337,8 @@ For each claimed job the agent:
 3. builds a work tree in `<data_dir>/work/<job-id>` at that commit, shallow if the job asked for a depth, and reports the ref and commit back to the server;
 4. runs the command in the job's working directory;
 5. streams the output back as it goes;
-6. reports `passed`, `failed` or `timeout`, and removes the work tree.
+6. uploads the artefacts the job asked to keep, whatever the exit code;
+7. reports `passed`, `failed` or `timeout`, and removes the work tree.
 
 The work tree is checked out detached. A job builds one commit; leaving a branch checked out would suggest it has somewhere to push it back to.
 
@@ -344,13 +400,16 @@ which rewrites `git@host:owner/repo.git` to `https://host/owner/repo.git` before
 
 Runtime configuration an admin can change without a restart:
 
-| Setting             | Default | Purpose                                       |
-|---------------------|---------|-----------------------------------------------|
-| `repository.policy` | `open`  | `open`, or `allowlist` to gate on rules       |
-| `registration.open` | `false` | Let anyone register                           |
-| `job.max_depth`     | `3`     | How deep a job may dispatch children          |
-| `job.lease_ttl`     | `15m`   | How long an agent may hold a job              |
-| `job.retention`     | `0`     | How long finished jobs are kept; 0 is forever |
+| Setting              | Default | Purpose                                             |
+|----------------------|---------|-----------------------------------------------------|
+| `repository.policy`  | `open`  | `open`, or `allowlist` to gate on rules             |
+| `registration.open`  | `false` | Let anyone register                                 |
+| `job.max_depth`      | `3`     | How deep a job may dispatch children                |
+| `job.lease_ttl`      | `15m`   | How long an agent may hold a job                    |
+| `job.retention`      | `0`     | How long finished jobs are kept; 0 is forever       |
+| `artefact.max_size`  | `32MB`  | Largest single artefact an agent may upload         |
+| `artefact.max_count` | `50`    | How many artefacts one job may keep                 |
+| `artefact.retention` | `0`     | How long artefact bytes are kept; 0 follows the job |
 
 ```bash
 curl -sS -H "Authorization: Bearer $TOKEN" "$SERVER/api/admin/setting" |
@@ -388,6 +447,8 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/job`                     | GET             | user   | List jobs                              |
 | `/api/job/{id}`                | GET             | user   | Read one job                           |
 | `/api/job/{id}/log`            | GET             | user   | Read captured output                   |
+| `/api/job/{id}/artefact`       | GET             | user   | List the files a job produced          |
+| `/api/job/{id}/artefact/{id}`  | GET             | user   | Download one artefact                  |
 | `/api/job/{id}/retry`          | POST            | user   | Queue a copy of a finished job         |
 | `/api/job/{id}/cancel`         | POST            | user   | Settle an unfinished job               |
 | `/api/job/claim`               | POST            | agent  | Lease the oldest pending job           |
@@ -395,6 +456,7 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/job/{id}/checkout`       | POST            | agent  | Record the ref and commit it built     |
 | `/api/job/{id}/heartbeat`      | POST            | agent  | Extend the lease                       |
 | `/api/job/{id}/log`            | POST            | agent  | Append output                          |
+| `/api/job/{id}/artefact`       | POST            | agent  | Upload a file, `?path=` names it       |
 | `/api/agent/enrol`             | POST            | token  | Trade the shared token for credentials |
 | `/api/agent/policy`            | GET             | agent  | The repository policy to enforce       |
 | `/api/agent/ssh-key`           | GET             | agent  | Deploy keys, with private material     |

--- a/serve.go
+++ b/serve.go
@@ -26,6 +26,9 @@ type ServerOptions struct {
 	// mysql://user:pass@tcp(host)/atkins.
 	Database string
 
+	// ArtefactDir is where the bytes of job artefacts are stored.
+	ArtefactDir string
+
 	// SigningKey signs access tokens. Required.
 	SigningKey string
 
@@ -41,6 +44,7 @@ type ServerOptions struct {
 func (o *ServerOptions) Bind(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Addr, "addr", "", "Listen address")
 	fs.StringVar(&o.Database, "database", "", "Database DSN")
+	fs.StringVar(&o.ArtefactDir, "artefact-dir", "", "Directory for the bytes of job artefacts")
 	fs.StringVar(&o.SigningKey, "signing-key", "", "Signing key for access tokens")
 	fs.StringVar(&o.AgentToken, "agent-token", "", "Shared token agents enrol with")
 	fs.BoolVar(&o.AllowRegistration, "allow-registration", false, "Keep registration open after the first user")
@@ -71,6 +75,7 @@ func runServer(ctx context.Context, opts *ServerOptions) error {
 	config := settings.Server
 	override(&config.Addr, opts.Addr)
 	override(&config.Database, opts.Database)
+	override(&config.ArtefactDir, opts.ArtefactDir)
 	override(&config.SigningKey, opts.SigningKey)
 	override(&config.AgentToken, opts.AgentToken)
 	if opts.AllowRegistration {

--- a/server/README.md
+++ b/server/README.md
@@ -18,7 +18,9 @@ server/
 │   ├── dispatch.go  dispatch and the job queue
 │   ├── agent.go     enrolment, policy, deploy keys
 │   └── admin.go     users, allowlist, settings, keys
+│   └── artefact.go  upload, list and download job outputs
 ├── auth/            HS256 access tokens
+├── blob/            artefact bytes, behind a Put/Open/Remove interface
 ├── model/           generated records (types.mig.go) + domain helpers
 ├── schema/          append-only migrations, one file per table
 ├── storage/         SQL, via titpetric/pdo generic methods
@@ -54,6 +56,7 @@ Generated files say `DO NOT EDIT`: change SQL and regenerate.
 | `repository`      | A git repository, identified by its normalized slug  |
 | `job`             | One dispatched run, its lease and its outcome        |
 | `job_log`         | Output chunks, sequenced per job                     |
+| `job_artefact`    | Files a job produced, and where their bytes are      |
 | `repository_rule` | Allowlist patterns                                   |
 | `setting`         | Runtime configuration an admin can change            |
 | `ssh_key`         | Deploy keys for clone and fetch                      |
@@ -84,15 +87,43 @@ The pool comes from the platform's connection provider, named `atkins`
 give each case its own database: the platform caches pools by name for
 the life of the process.
 
+## Artefacts
+
+A job's output splits in two. `job_artefact` holds what the file is —
+job, path, size, media type, SHA256 — and `blob` holds the bytes,
+addressed by the `storage_key` on the row.
+
+The split is what keeps an object store backend to one interface: `Put`,
+`Open`, `Remove` over a key namespace, with no SQL and no handler near
+it. `blob.Dir` writes under a root directory, which is the right first
+backend and probably the right one for most installs — the database is
+already on a disk, artefacts are written once and read rarely, and a
+directory is something an operator can back up without asking anybody
+for a bucket.
+
+`JobArtefactStorage` owns both halves so they cannot drift: bytes are
+written before the row exists, and removed if the insert fails; a
+retention sweep removes bytes first and then soft deletes the row, so
+the failure mode is a row that reads as "swept" rather than a file
+nothing will ever clean up.
+
+The count and size limits are settings rather than constants, because
+the moment they matter is the moment a disk is filling, and that is the
+worst moment to need a redeploy.
+
 ## Lifecycle
 
-`Start` connects, migrates, wires storage and handlers, and starts the
-lease sweep. `Mount` registers routes. `Stop` cancels the sweep and
-waits for it.
+`Start` connects, migrates, wires storage and handlers, prepares the
+artefact root, and starts the sweep. `Mount` registers routes. `Stop`
+cancels the sweep and waits for it.
 
 The sweep is the reason an agent can die without stranding a job: a
 `running` job whose `lease_expires_at` has passed is moved to `timeout`
-and can be retried.
+and can be retried. It carries the artefact retention pass too, which
+reads its setting on every tick rather than at start-up.
+
+A root the server cannot create is fatal at start-up rather than a
+surprise on the first job that produces a file.
 
 ## Authentication and roles
 

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -36,6 +36,7 @@ type Handlers struct {
 	repositories *storage.RepositoryStorage
 	jobs         *storage.JobStorage
 	jobLogs      *storage.JobLogStorage
+	artefacts    *storage.JobArtefactStorage
 	rules        *storage.RepositoryRuleStorage
 	settings     *storage.SettingStorage
 	sshKeys      *storage.SSHKeyStorage
@@ -58,6 +59,7 @@ func NewHandlers(opts Options) *Handlers {
 		repositories:      opts.RepositoryStorage,
 		jobs:              opts.JobStorage,
 		jobLogs:           opts.JobLogStorage,
+		artefacts:         opts.JobArtefactStorage,
 		rules:             opts.RepositoryRuleStorage,
 		settings:          opts.SettingStorage,
 		sshKeys:           opts.SSHKeyStorage,
@@ -88,6 +90,10 @@ func (s *Handlers) Mount(r platform.Router) {
 		r.Post("/api/job/{jobID}/heartbeat", s.JobHeartbeat)
 		r.Get("/api/job/{jobID}/log", s.GetJobLog)
 		r.Post("/api/job/{jobID}/log", s.AppendJobLog)
+
+		r.Get("/api/job/{jobID}/artefact", s.ListArtefacts)
+		r.Post("/api/job/{jobID}/artefact", s.UploadArtefact)
+		r.Get("/api/job/{jobID}/artefact/{artefactID}", s.DownloadArtefact)
 	})
 
 	s.MountAgent(r)

--- a/server/api/artefact.go
+++ b/server/api/artefact.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/titpetric/platform"
+
+	"github.com/titpetric/atkins/server/model"
+	"github.com/titpetric/atkins/server/storage"
+)
+
+// HeaderArtefactChecksum carries the SHA256 the agent computed while
+// reading the file. It is optional; when present the server compares it
+// against what actually arrived, so a truncated upload is a 400 rather
+// than an artefact nobody can use.
+const HeaderArtefactChecksum = "X-Atkins-Checksum"
+
+// ArtefactView is how an artefact is described over the API.
+//
+// It is a projection rather than the row: `storage_key` says where the
+// bytes sit on the server, and that is the server's business. The rule
+// is the same one SSHKeyView follows — the projection is the guard, not
+// a `json:"-"` somebody has to remember to add to a new column.
+type ArtefactView struct {
+	ID          string `json:"id"`
+	JobID       string `json:"job_id"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	Checksum    string `json:"checksum"`
+	AgentID     string `json:"agent_id,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+
+	// URL is where the bytes are, so a caller that listed artefacts
+	// does not have to know how to build the path.
+	URL string `json:"url"`
+}
+
+// artefactView projects a stored artefact.
+func artefactView(artefact model.JobArtefact) ArtefactView {
+	view := ArtefactView{
+		ID:          artefact.ID,
+		JobID:       artefact.JobID,
+		Path:        artefact.Path,
+		Size:        artefact.Size,
+		ContentType: artefact.ContentType,
+		Checksum:    artefact.Checksum,
+		AgentID:     artefact.AgentID,
+		URL:         "/api/job/" + artefact.JobID + "/artefact/" + artefact.ID,
+	}
+	if artefact.CreatedAt != nil {
+		view.CreatedAt = artefact.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return view
+}
+
+// UploadArtefact stores a file a job produced.
+//
+// The body is the file itself rather than a multipart form: an artefact
+// is bytes, and a raw body streams from the agent's disk to the
+// server's without either side building an envelope around it. The
+// name, the media type and the checksum are small enough to be
+// metadata, and travel as the `path` query parameter, `Content-Type`
+// and `X-Atkins-Checksum`.
+func (s *Handlers) UploadArtefact(w http.ResponseWriter, r *http.Request) {
+	s.respond(w, r, s.uploadArtefact(w, r))
+}
+
+func (s *Handlers) uploadArtefact(w http.ResponseWriter, r *http.Request) error {
+	// Artefacts are pushed by the agent that ran the job, exactly like
+	// its output.
+	agent, err := s.requireAgent(r)
+	if err != nil {
+		return err
+	}
+
+	jobID := platform.URLParam(r, "jobID")
+	if _, err := s.jobs.Get(r.Context(), jobID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return requestError(http.StatusNotFound, errors.New("job not found"))
+		}
+		return err
+	}
+
+	maxSize := s.settings.Bytes(model.SettingArtefactMaxSize)
+
+	// The store stops reading at the limit on its own. This caps what
+	// the server will take off the socket at all, so the remainder of
+	// an oversized upload is not politely drained after the refusal.
+	// A limit of zero is "no limit", which an admin can choose.
+	var body io.Reader = r.Body
+	if maxSize > 0 {
+		body = http.MaxBytesReader(w, r.Body, maxSize+1)
+	}
+
+	artefact, err := s.artefacts.Create(r.Context(), storage.ArtefactRequest{
+		JobID:       jobID,
+		AgentID:     agent.Username,
+		Path:        platform.QueryParam(r, "path"),
+		ContentType: r.Header.Get("Content-Type"),
+		Checksum:    r.Header.Get(HeaderArtefactChecksum),
+		Content:     body,
+		MaxSize:     maxSize,
+		MaxCount:    s.settings.Int(model.SettingArtefactMaxCount),
+	})
+	if err != nil {
+		return mapArtefactError(err)
+	}
+
+	platform.JSON(w, r, http.StatusCreated, artefactView(*artefact))
+	return nil
+}
+
+// ListArtefacts returns the artefacts a job produced.
+func (s *Handlers) ListArtefacts(w http.ResponseWriter, r *http.Request) {
+	s.respond(w, r, s.listArtefacts(w, r))
+}
+
+func (s *Handlers) listArtefacts(w http.ResponseWriter, r *http.Request) error {
+	if _, _, err := s.authenticateUser(r); err != nil {
+		return err
+	}
+
+	artefacts, err := s.artefacts.List(r.Context(), platform.URLParam(r, "jobID"))
+	if err != nil {
+		return err
+	}
+
+	views := make([]ArtefactView, 0, len(artefacts))
+	for _, artefact := range artefacts {
+		views = append(views, artefactView(artefact))
+	}
+
+	platform.JSON(w, r, http.StatusOK, views)
+	return nil
+}
+
+// DownloadArtefact writes the bytes of one artefact.
+//
+// This is the authenticated way to read an artefact, and the one a
+// script should use. The job page has an unauthenticated route of its
+// own, on the same terms as the output it shows.
+func (s *Handlers) DownloadArtefact(w http.ResponseWriter, r *http.Request) {
+	s.respond(w, r, s.downloadArtefact(w, r))
+}
+
+func (s *Handlers) downloadArtefact(w http.ResponseWriter, r *http.Request) error {
+	if _, _, err := s.authenticateUser(r); err != nil {
+		return err
+	}
+
+	artefact, err := s.artefacts.Get(r.Context(),
+		platform.URLParam(r, "jobID"), platform.URLParam(r, "artefactID"))
+	if err != nil {
+		return mapArtefactError(err)
+	}
+
+	contents, err := s.artefacts.Open(r.Context(), artefact)
+	if err != nil {
+		return mapArtefactError(err)
+	}
+	defer contents.Close()
+
+	WriteArtefact(w, artefact, contents)
+	return nil
+}
+
+// WriteArtefact streams an artefact as a download.
+//
+// The web package serves the same bytes from the job page, and a
+// difference between the two responses would only ever be a bug.
+func WriteArtefact(w http.ResponseWriter, artefact *model.JobArtefact, contents io.Reader) {
+	w.Header().Set("Content-Type", artefact.ContentType)
+	w.Header().Set("Content-Length", strconv.FormatInt(artefact.Size, 10))
+	// A job's output is not to be trusted as a page: an artefact named
+	// report.html is a file to save, never something to run in the
+	// server's origin.
+	w.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(downloadName(artefact.Path)))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	_, _ = io.Copy(w, contents)
+}
+
+// downloadName reduces a stored path to the file name a browser should
+// save it as.
+func downloadName(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[i+1:]
+		}
+	}
+	return path
+}
+
+// mapArtefactError turns an artefact failure into a status.
+//
+// Oversize is 413 because the request was too big to accept; too many
+// is 422 because the request was fine and the job was not, which is how
+// the runaway-nesting limit already reports itself.
+func mapArtefactError(err error) error {
+	switch {
+	case errors.Is(err, model.ErrInvalidArtefactPath):
+		return requestError(http.StatusBadRequest, err)
+	case errors.Is(err, model.ErrChecksumMismatch):
+		return requestError(http.StatusBadRequest, err)
+	case errors.Is(err, model.ErrArtefactTooLarge):
+		return requestError(http.StatusRequestEntityTooLarge, err)
+	case errors.Is(err, model.ErrTooManyArtefacts):
+		return requestError(http.StatusUnprocessableEntity, err)
+	case errors.Is(err, model.ErrArtefactNotFound):
+		return requestError(http.StatusNotFound, err)
+	}
+	return err
+}

--- a/server/api/dispatch.go
+++ b/server/api/dispatch.go
@@ -45,6 +45,10 @@ type DispatchRequest struct {
 	// CloneDepth limits the history of the work tree the agent builds.
 	// 0, the default, is the whole history.
 	CloneDepth int64 `json:"clone_depth"`
+
+	// Artefacts are glob patterns the agent collects after the command
+	// exits, relative to the directory it ran in.
+	Artefacts []string `json:"artefacts"`
 }
 
 // RepositoryPayload is the git detail a client reports about its checkout.
@@ -192,6 +196,7 @@ func (s *Handlers) dispatch(w http.ResponseWriter, r *http.Request) error {
 		CloneDepth:       req.CloneDepth,
 		Labels:           req.Labels,
 		Params:           params,
+		Artefacts:        req.Artefacts,
 	})
 	if err != nil {
 		switch {

--- a/server/api/options.go
+++ b/server/api/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	RepositoryStorage     *storage.RepositoryStorage
 	JobStorage            *storage.JobStorage
 	JobLogStorage         *storage.JobLogStorage
+	JobArtefactStorage    *storage.JobArtefactStorage
 	RepositoryRuleStorage *storage.RepositoryRuleStorage
 	SettingStorage        *storage.SettingStorage
 	SSHKeyStorage         *storage.SSHKeyStorage

--- a/server/api/trigger.go
+++ b/server/api/trigger.go
@@ -52,6 +52,11 @@ type TriggerRequest struct {
 
 	Labels []string `json:"labels"`
 
+	// Artefacts are glob patterns the agent collects after the command
+	// exits. This is what lets a cron collect `coverage/*.json` from a
+	// pipeline that knows nothing about artefacts.
+	Artefacts []string `json:"artefacts"`
+
 	// ParentID records the job that triggered this one.
 	ParentID string `json:"parent_id"`
 }
@@ -122,6 +127,7 @@ func (s *Handlers) trigger(w http.ResponseWriter, r *http.Request) error {
 		CloneDepth:       req.CloneDepth,
 		Labels:           req.Labels,
 		Params:           params,
+		Artefacts:        req.Artefacts,
 	})
 	if err != nil {
 		return mapJobCreateError(err)
@@ -202,6 +208,10 @@ func (s *Handlers) retryJob(w http.ResponseWriter, r *http.Request) error {
 		CloneDepth:       previous.CloneDepth,
 		Labels:           splitLabels(previous.Labels),
 		Params:           previous.Params,
+		// A retry collects what the original was asked to collect;
+		// otherwise the re-run of a failed job would come back without
+		// the files that explain it.
+		Artefacts: model.ArtefactPatterns(previous.ArtefactPaths),
 	})
 	if err != nil {
 		return mapJobCreateError(err)

--- a/server/artefact_test.go
+++ b/server/artefact_test.go
@@ -1,0 +1,498 @@
+package server_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server"
+	"github.com/titpetric/atkins/server/api"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// artefactView mirrors api.ArtefactView.
+type artefactView struct {
+	ID          string `json:"id"`
+	JobID       string `json:"job_id"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	Checksum    string `json:"checksum"`
+	URL         string `json:"url"`
+}
+
+// artefactUpload is one file being pushed to a job.
+type artefactUpload struct {
+	Path        string
+	ContentType string
+	Checksum    string
+	Content     []byte
+}
+
+// uploadArtefact posts a file to a job, the way the agent does: the
+// body is the file, and everything else is a query parameter or a
+// header.
+func uploadArtefact(t *testing.T, server, token, jobID string, upload artefactUpload, target any) int {
+	t.Helper()
+
+	endpoint := server + "/api/job/" + jobID + "/artefact?path=" + url.QueryEscape(upload.Path)
+
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(upload.Content))
+	require.NoError(t, err)
+
+	if upload.ContentType != "" {
+		request.Header.Set("Content-Type", upload.ContentType)
+	}
+	if upload.Checksum != "" {
+		request.Header.Set(api.HeaderArtefactChecksum, upload.Checksum)
+	}
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	if target != nil && response.StatusCode < http.StatusBadRequest {
+		require.NoError(t, json.NewDecoder(response.Body).Decode(target))
+	} else {
+		_, _ = io.Copy(io.Discard, response.Body)
+	}
+
+	return response.StatusCode
+}
+
+// fetch performs a GET and returns the status, the body and the
+// response headers.
+func fetch(t *testing.T, target, token string) (int, []byte, http.Header) {
+	t.Helper()
+
+	request, err := http.NewRequest(http.MethodGet, target, nil)
+	require.NoError(t, err)
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	return response.StatusCode, body, response.Header
+}
+
+// checksum is the SHA256 an agent sends with an upload.
+func checksum(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// artefacts lists what a job produced.
+func artefacts(t *testing.T, server, token, jobID string) []artefactView {
+	t.Helper()
+
+	var listed []artefactView
+	status := call(t, http.MethodGet, server+"/api/job/"+jobID+"/artefact", token, nil, &listed)
+	require.Equal(t, http.StatusOK, status)
+
+	return listed
+}
+
+func TestArtefactRoundTrip(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+	content := []byte(`{"findings": 3}`)
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:        "reports/scan.json",
+		ContentType: "application/json",
+		Checksum:    checksum(content),
+		Content:     content,
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	assert.Equal(t, "reports/scan.json", stored.Path)
+	assert.Equal(t, int64(len(content)), stored.Size)
+	assert.Equal(t, "application/json", stored.ContentType)
+	// The server hashes what it received rather than trusting the
+	// header, so this is evidence the bytes arrived intact.
+	assert.Equal(t, checksum(content), stored.Checksum)
+
+	listed := artefacts(t, url, admin.Token, job.JobID)
+	require.Len(t, listed, 1)
+	assert.Equal(t, stored.ID, listed[0].ID)
+	// The location of the bytes on the server is not part of the view.
+	assert.NotContains(t, listed[0].URL, "storage_key")
+
+	status, body, header := fetch(t, url+listed[0].URL, admin.Token)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, content, body)
+	assert.Equal(t, "application/json", header.Get("Content-Type"))
+	// A job's own output must never render as a page in the server's
+	// origin.
+	assert.Contains(t, header.Get("Content-Disposition"), "attachment")
+	assert.Equal(t, "nosniff", header.Get("X-Content-Type-Options"))
+}
+
+func TestArtefactAppearsOnTheJobPage(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+	content := []byte("coverage: 81%\n")
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "coverage.txt",
+		Content: content,
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	status, page, _ := fetch(t, url+"/job/"+job.JobID, "")
+	require.Equal(t, http.StatusOK, status)
+	assert.Contains(t, string(page), "coverage.txt")
+
+	// The link on the page has to work in a browser, which carries no
+	// bearer token: it is governed by the same unguessable job URL the
+	// page itself is.
+	download := "/job/" + job.JobID + "/artefact/" + stored.ID
+	assert.Contains(t, string(page), download)
+
+	status, body, _ := fetch(t, url+download, "")
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, content, body)
+}
+
+func TestArtefactUploadIsAgentOnly(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	// An ordinary human, not an agent and not an admin.
+	setSetting(t, url, admin.Token, model.SettingRegistrationOpen, "true")
+
+	var human tokenResponse
+	status := call(t, http.MethodPost, url+"/api/user/register", "", map[string]string{
+		"email":    "dev@example.com",
+		"username": "dev",
+		"password": "correct-horse",
+	}, &human)
+	require.Equal(t, http.StatusCreated, status)
+
+	status = uploadArtefact(t, url, human.Token, job.JobID, artefactUpload{
+		Path:    "planted.json",
+		Content: []byte("{}"),
+	}, nil)
+	assert.Equal(t, http.StatusForbidden, status)
+
+	status = uploadArtefact(t, url, "", job.JobID, artefactUpload{
+		Path:    "planted.json",
+		Content: []byte("{}"),
+	}, nil)
+	assert.Equal(t, http.StatusUnauthorized, status)
+
+	// Neither attempt left anything behind.
+	assert.Empty(t, artefacts(t, url, admin.Token, job.JobID))
+}
+
+func TestArtefactUploadForAnUnknownJob(t *testing.T) {
+	url := testServer(t)
+	register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	status := uploadArtefact(t, url, agent.Token, "01ARZ3NDEKTSV4RRFFQ69G5FAV", artefactUpload{
+		Path:    "scan.json",
+		Content: []byte("{}"),
+	}, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestArtefactRejectsPathsOutsideTheJob(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	// A path is a name within the job, not a location on the server.
+	for _, path := range []string{"../../etc/passwd", "/etc/passwd", "reports/../../escape", "", "..", `..\..\windows`} {
+		status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+			Path:    path,
+			Content: []byte("planted"),
+		}, nil)
+		assert.Equal(t, http.StatusBadRequest, status, "path %q", path)
+	}
+
+	assert.Empty(t, artefacts(t, url, admin.Token, job.JobID))
+}
+
+func TestArtefactRejectsOversize(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	setSetting(t, url, admin.Token, model.SettingArtefactMaxSize, "64B")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "core.dump",
+		Content: bytes.Repeat([]byte("x"), 65),
+	}, nil)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, status)
+
+	// Refused, and not half stored: the row only exists once the bytes
+	// are complete.
+	assert.Empty(t, artefacts(t, url, admin.Token, job.JobID))
+
+	// Exactly at the limit is still allowed.
+	status = uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "small.txt",
+		Content: bytes.Repeat([]byte("x"), 64),
+	}, nil)
+	assert.Equal(t, http.StatusCreated, status)
+}
+
+func TestArtefactRejectsTooMany(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	setSetting(t, url, admin.Token, model.SettingArtefactMaxCount, "2")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	for _, path := range []string{"one.json", "two.json"} {
+		status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+			Path:    path,
+			Content: []byte("{}"),
+		}, nil)
+		require.Equal(t, http.StatusCreated, status, path)
+	}
+
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "three.json",
+		Content: []byte("{}"),
+	}, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, status)
+
+	// Replacing one of the two it already has is not "one more".
+	status = uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "two.json",
+		Content: []byte(`{"replaced": true}`),
+	}, nil)
+	assert.Equal(t, http.StatusCreated, status)
+
+	assert.Len(t, artefacts(t, url, admin.Token, job.JobID), 2)
+}
+
+func TestArtefactRejectsAChecksumMismatch(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	// What the agent hashed is not what the server received: the upload
+	// was truncated or altered in flight.
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:     "scan.json",
+		Checksum: checksum([]byte("the whole file")),
+		Content:  []byte("half the f"),
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	assert.Empty(t, artefacts(t, url, admin.Token, job.JobID))
+}
+
+func TestArtefactReplacesTheSamePath(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	var first artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte(`{"run": 1}`),
+	}, &first)
+	require.Equal(t, http.StatusCreated, status)
+
+	var second artefactView
+	status = uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte(`{"run": 2}`),
+	}, &second)
+	require.Equal(t, http.StatusCreated, status)
+
+	// One scan.json, holding the newer bytes.
+	listed := artefacts(t, url, admin.Token, job.JobID)
+	require.Len(t, listed, 1)
+	assert.Equal(t, second.ID, listed[0].ID)
+
+	status, body, _ := fetch(t, url+second.URL, admin.Token)
+	require.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"run": 2}`, string(body))
+
+	// The superseded artefact is gone rather than merely hidden.
+	status, _, _ = fetch(t, url+first.URL, admin.Token)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestArtefactDownloadNeedsAuthentication(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte("{}"),
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	status, _, _ = fetch(t, url+stored.URL, "")
+	assert.Equal(t, http.StatusUnauthorized, status)
+
+	status, _, _ = fetch(t, url+"/api/job/"+job.JobID+"/artefact", "")
+	assert.Equal(t, http.StatusUnauthorized, status)
+}
+
+func TestArtefactBelongsToOneJob(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	first := dispatch(t, url, admin.Token, "atkins scan", "")
+	second := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, first.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte("{}"),
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	// An artefact ID from one job does not resolve under another.
+	status, _, _ = fetch(t, url+"/api/job/"+second.JobID+"/artefact/"+stored.ID, admin.Token)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestDispatchNormalizesArtefactPatterns(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	var dispatched dispatchResponse
+	status := call(t, http.MethodPost, url+"/api/dispatch", admin.Token, map[string]any{
+		"repository": map[string]string{"remote_url": "git@github.com:titpetric/atkins.git"},
+		"command":    "atkins scan",
+		// The traversal is dropped rather than stored for an agent to
+		// deal with later.
+		"artefacts": []string{"reports/*.json", "../../etc/passwd", " ./coverage.out "},
+	}, &dispatched)
+	require.Equal(t, http.StatusCreated, status)
+
+	var job map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+dispatched.JobID, admin.Token, nil, &job)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "reports/*.json,coverage.out", job["artefact_paths"])
+}
+
+func TestArtefactSizeSettingIsValidated(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	status := call(t, http.MethodPost, url+"/api/admin/setting/"+model.SettingArtefactMaxSize, admin.Token,
+		map[string]string{"value": "a handful"}, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	setSetting(t, url, admin.Token, model.SettingArtefactMaxSize, "8MB")
+
+	var settings []map[string]any
+	status = call(t, http.MethodGet, url+"/api/admin/setting", admin.Token, nil, &settings)
+	require.Equal(t, http.StatusOK, status)
+
+	var found bool
+	for _, setting := range settings {
+		if setting["name"] == model.SettingArtefactMaxSize {
+			found = true
+			assert.Equal(t, "8MB", setting["value"])
+			assert.Equal(t, string(model.KindBytes), setting["kind"])
+		}
+	}
+	assert.True(t, found, "artefact.max_size is missing from the registry listing")
+}
+
+func TestArtefactRetentionSweepsTheBytes(t *testing.T) {
+	var root string
+
+	url := testServerWith(t, func(opts *server.Options) {
+		root = filepath.Join(t.TempDir(), "artefacts")
+		opts.ArtefactDir = root
+		// The sweep shares the lease reclaim ticker.
+		opts.ReclaimInterval = 50 * time.Millisecond
+	})
+
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	setSetting(t, url, admin.Token, model.SettingArtefactRetention, "1ms")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte(`{"findings": 3}`),
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	require.FileExists(t, filepath.Join(root, job.JobID, stored.ID))
+
+	// The sweep is on a ticker, so wait for it rather than for a
+	// fixed sleep to be long enough.
+	require.Eventually(t, func() bool {
+		return len(artefacts(t, url, admin.Token, job.JobID)) == 0
+	}, 5*time.Second, 25*time.Millisecond)
+
+	// Retention is about the disk: the bytes are what has to go.
+	assert.NoFileExists(t, filepath.Join(root, job.JobID, stored.ID))
+
+	status, _, _ = fetch(t, url+stored.URL, admin.Token)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestArtefactEmptyListForAJobWithNone(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	// An empty list rather than null: a caller should be able to range
+	// over it without a nil check.
+	status, body, _ := fetch(t, url+"/api/job/"+job.JobID+"/artefact", admin.Token)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "[]", strings.TrimSpace(string(body)))
+}

--- a/server/blob/blob.go
+++ b/server/blob/blob.go
@@ -1,0 +1,206 @@
+// Package blob stores the bytes of job artefacts.
+//
+// The database records what an artefact is — which job produced it,
+// what the pipeline called it, how big it is and what it hashes to.
+// This package holds the bytes themselves, addressed by an opaque key
+// that the row carries.
+//
+// Splitting the two is the whole point. A row is small and worth
+// keeping; bytes are large and are the thing that fills a disk. It also
+// means the only thing an object store backend has to implement is this
+// interface: Put, Open, Remove against a key namespace, with no SQL and
+// no HTTP handler anywhere near it.
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/titpetric/platform/pkg/ulid"
+)
+
+// Store holds artefact bytes under opaque keys.
+//
+// A key is a slash separated path in the store's own namespace, not a
+// filesystem path and not the name the pipeline used. Callers build it;
+// the store only refuses one it cannot address safely.
+type Store interface {
+	// Put writes r under key, stopping at limit bytes, and reports what
+	// was written. A limit of zero or less is unbounded.
+	//
+	// Nothing is readable under key until the write completes, so a
+	// failed or oversized upload never leaves half an artefact behind.
+	Put(ctx context.Context, key string, r io.Reader, limit int64) (Result, error)
+
+	// Open returns the bytes stored under key.
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
+
+	// Remove deletes the bytes stored under key. Removing a key that
+	// isn't there is not an error: retention has to be idempotent.
+	Remove(ctx context.Context, key string) error
+}
+
+// Result describes what a Put wrote.
+type Result struct {
+	// Size is the number of bytes stored.
+	Size int64
+
+	// Checksum is the SHA256 of those bytes, in lower case hex. It is
+	// computed while writing rather than by reading the file back,
+	// which would double the I/O for no extra confidence.
+	Checksum string
+}
+
+// Errors returned by a Store.
+var (
+	// ErrTooLarge is returned when the reader had more to give than the
+	// limit allowed.
+	ErrTooLarge = errors.New("blob exceeds the maximum size")
+
+	// ErrInvalidKey is returned for a key that cannot address a blob.
+	ErrInvalidKey = errors.New("invalid blob key")
+)
+
+// Key builds the key an artefact's bytes live under.
+//
+// Grouping by job means retention can drop a job's bytes as a
+// directory, and it keeps a single flat directory from growing to a
+// million entries on a busy instance.
+func Key(jobID, artefactID string) string {
+	return path.Join(jobID, artefactID)
+}
+
+// Dir stores blobs as files under a root directory.
+//
+// It is the right first backend and probably the right one for most
+// installs: the server already keeps its database on a disk, artefacts
+// are written once and read rarely, and a directory is something an
+// operator can back up, rsync or point a webserver at without asking
+// anybody for a bucket.
+type Dir struct {
+	root string
+}
+
+// Verify contract.
+var _ Store = (*Dir)(nil)
+
+// NewDir returns a Store writing under root.
+func NewDir(root string) *Dir {
+	return &Dir{root: root}
+}
+
+// Root returns the directory blobs are written under.
+func (d *Dir) Root() string {
+	return d.root
+}
+
+// Prepare creates the root directory.
+//
+// The server calls this at start-up: a root it cannot write to should
+// stop the process with a clear error, not surface as a failed upload
+// on the first job that produces a file.
+func (d *Dir) Prepare() error {
+	return os.MkdirAll(d.root, 0o750)
+}
+
+// Put streams r into the store, hashing as it goes.
+func (d *Dir) Put(_ context.Context, key string, r io.Reader, limit int64) (Result, error) {
+	name, err := d.resolve(key)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(name), 0o750); err != nil {
+		return Result{}, err
+	}
+
+	// Write beside the target and rename: a reader can then only ever
+	// see a complete blob, and an interrupted upload leaves a .part
+	// file rather than a truncated artefact.
+	temporary := name + "." + ulid.String() + ".part"
+	file, err := os.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o640)
+	if err != nil {
+		return Result{}, err
+	}
+
+	defer func() {
+		file.Close()
+		os.Remove(temporary)
+	}()
+
+	source := r
+	if limit > 0 {
+		// One byte past the limit: enough to tell "exactly at the
+		// limit" from "more than we agreed to store".
+		source = io.LimitReader(r, limit+1)
+	}
+
+	hash := sha256.New()
+	size, err := io.Copy(io.MultiWriter(file, hash), source)
+	if err != nil {
+		return Result{}, err
+	}
+	if limit > 0 && size > limit {
+		return Result{}, ErrTooLarge
+	}
+
+	if err := file.Close(); err != nil {
+		return Result{}, err
+	}
+	if err := os.Rename(temporary, name); err != nil {
+		return Result{}, err
+	}
+
+	return Result{Size: size, Checksum: hex.EncodeToString(hash.Sum(nil))}, nil
+}
+
+// Open returns the stored bytes.
+func (d *Dir) Open(_ context.Context, key string) (io.ReadCloser, error) {
+	name, err := d.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(name)
+}
+
+// Remove deletes the stored bytes, and the job directory with them once
+// it is empty.
+func (d *Dir) Remove(_ context.Context, key string) error {
+	name, err := d.resolve(key)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(name); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// Best effort: this fails while the job has other artefacts, which
+	// is the normal case and not worth reporting.
+	_ = os.Remove(filepath.Dir(name))
+
+	return nil
+}
+
+// resolve turns a key into a path under the root, refusing anything
+// that would address a file outside it.
+func (d *Dir) resolve(key string) (string, error) {
+	key = strings.TrimSpace(strings.ReplaceAll(key, `\`, "/"))
+	if key == "" || strings.HasPrefix(key, "/") {
+		return "", ErrInvalidKey
+	}
+
+	clean := path.Clean(key)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", ErrInvalidKey
+	}
+
+	return filepath.Join(d.root, filepath.FromSlash(clean)), nil
+}

--- a/server/blob/blob_test.go
+++ b/server/blob/blob_test.go
@@ -1,0 +1,181 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testDir returns a store over a temporary root.
+func testDir(t *testing.T) *Dir {
+	t.Helper()
+
+	store := NewDir(filepath.Join(t.TempDir(), "artefacts"))
+	require.NoError(t, store.Prepare())
+
+	return store
+}
+
+// read drains a reader and closes it.
+func read(t *testing.T, contents io.ReadCloser) []byte {
+	t.Helper()
+
+	defer contents.Close()
+
+	body, err := io.ReadAll(contents)
+	require.NoError(t, err)
+
+	return body
+}
+
+func TestPutAndOpen(t *testing.T) {
+	store := testDir(t)
+	content := []byte(`{"findings": 3}`)
+
+	written, err := store.Put(t.Context(), Key("job-1", "artefact-1"), bytes.NewReader(content), 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(len(content)), written.Size)
+
+	// The checksum is computed while writing rather than by reading the
+	// file back.
+	sum := sha256.Sum256(content)
+	assert.Equal(t, hex.EncodeToString(sum[:]), written.Checksum)
+
+	contents, err := store.Open(t.Context(), Key("job-1", "artefact-1"))
+	require.NoError(t, err)
+	assert.Equal(t, content, read(t, contents))
+}
+
+func TestPutStopsAtTheLimit(t *testing.T) {
+	store := testDir(t)
+
+	_, err := store.Put(t.Context(), Key("job-1", "artefact-1"),
+		bytes.NewReader(bytes.Repeat([]byte("x"), 65)), 64)
+	assert.ErrorIs(t, err, ErrTooLarge)
+
+	// Nothing readable, and no partial file left in its place: a
+	// refused upload must not become a truncated artefact.
+	_, err = store.Open(t.Context(), Key("job-1", "artefact-1"))
+	assert.Error(t, err)
+
+	assert.Empty(t, leftovers(t, store.Root()))
+
+	// Exactly at the limit is stored.
+	written, err := store.Put(t.Context(), Key("job-1", "artefact-2"),
+		bytes.NewReader(bytes.Repeat([]byte("x"), 64)), 64)
+	require.NoError(t, err)
+	assert.Equal(t, int64(64), written.Size)
+}
+
+func TestOpenMissingKey(t *testing.T) {
+	store := testDir(t)
+
+	_, err := store.Open(t.Context(), Key("job-1", "nothing"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRemoveIsIdempotent(t *testing.T) {
+	store := testDir(t)
+
+	key := Key("job-1", "artefact-1")
+	_, err := store.Put(t.Context(), key, strings.NewReader("contents"), 0)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Remove(t.Context(), key))
+
+	// Retention runs on a ticker and may see the same row twice;
+	// removing what is already gone is not a failure.
+	require.NoError(t, store.Remove(t.Context(), key))
+
+	// The job's directory goes with its last artefact.
+	assert.NoDirExists(t, filepath.Join(store.Root(), "job-1"))
+}
+
+func TestKeysStayUnderTheRoot(t *testing.T) {
+	store := testDir(t)
+
+	for _, key := range []string{"", "   ", "/etc/passwd", "../escape", "job-1/../../escape", ".."} {
+		_, err := store.Put(t.Context(), key, strings.NewReader("planted"), 0)
+		assert.ErrorIs(t, err, ErrInvalidKey, "key %q", key)
+
+		_, err = store.Open(t.Context(), key)
+		assert.ErrorIs(t, err, ErrInvalidKey, "key %q", key)
+
+		assert.ErrorIs(t, store.Remove(t.Context(), key), ErrInvalidKey, "key %q", key)
+	}
+}
+
+func TestPutOverwritesTheSameKey(t *testing.T) {
+	store := testDir(t)
+	key := Key("job-1", "artefact-1")
+
+	_, err := store.Put(t.Context(), key, strings.NewReader("first"), 0)
+	require.NoError(t, err)
+
+	_, err = store.Put(t.Context(), key, strings.NewReader("second"), 0)
+	require.NoError(t, err)
+
+	contents, err := store.Open(t.Context(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("second"), read(t, contents))
+
+	assert.Empty(t, leftovers(t, store.Root()))
+}
+
+func TestPutReportsAFailedRead(t *testing.T) {
+	store := testDir(t)
+
+	_, err := store.Put(t.Context(), Key("job-1", "artefact-1"), failingReader{}, 0)
+	assert.Error(t, err)
+
+	// A connection that died mid-upload leaves no debris either.
+	assert.Empty(t, leftovers(t, store.Root()))
+}
+
+// failingReader stands in for an upload whose connection dropped.
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("connection reset")
+}
+
+// Verify contract: a context is accepted but unused by the filesystem
+// backend, so a cancelled one must not be mistaken for a failure.
+func TestContextIsNotRequired(t *testing.T) {
+	store := testDir(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := store.Put(ctx, Key("job-1", "artefact-1"), strings.NewReader("contents"), 0)
+	assert.NoError(t, err)
+}
+
+// leftovers lists the temporary files a store has left behind.
+func leftovers(t *testing.T, root string) []string {
+	t.Helper()
+
+	var found []string
+	require.NoError(t, filepath.WalkDir(root, func(name string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && strings.HasSuffix(name, ".part") {
+			found = append(found, name)
+		}
+		return nil
+	}))
+
+	return found
+}

--- a/server/model/artefact.go
+++ b/server/model/artefact.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"strings"
+	"unicode"
+)
+
+// DefaultContentType is what an artefact is served as when the agent
+// could not tell what it uploaded.
+const DefaultContentType = "application/octet-stream"
+
+// MaxArtefactPathLength bounds the name an artefact is stored under.
+// The value is a path, not prose; anything longer is a mistake or an
+// attempt to fill a column.
+const MaxArtefactPathLength = 512
+
+// ArtefactPath normalizes the name a pipeline gave a file into a clean
+// path relative to the directory the job ran in, or "" when the name
+// cannot mean that.
+//
+// This is the same decision cleanWorkingDirectory makes, and it is made
+// here for the same reason: the value arrives over the network and ends
+// up addressing bytes on the server's disk. An absolute path or a `..`
+// escape is rejected outright rather than repaired, because a caller
+// asking for `../../etc/passwd` should be told no, not quietly handed
+// `etc/passwd`.
+func ArtefactPath(value string) string {
+	return relativePath(value)
+}
+
+// ArtefactPattern normalizes one collection glob, or returns "".
+//
+// A pattern is a path with `*` and `**` in it, so it is held to exactly
+// the same rules as a path: relative, no `..`, no leading separator.
+func ArtefactPattern(value string) string {
+	return relativePath(value)
+}
+
+// relativePath cleans a slash-separated path that must stay inside the
+// directory it is relative to.
+func relativePath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, `\`, "/"))
+	if value == "" || len(value) > MaxArtefactPathLength || strings.HasPrefix(value, "/") {
+		return ""
+	}
+
+	segments := strings.Split(value, "/")
+	clean := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		switch segment {
+		case "", ".":
+			// A doubled or trailing separator is sloppiness, not intent.
+			continue
+		case "..":
+			return ""
+		}
+		if strings.ContainsFunc(segment, unicode.IsControl) {
+			return ""
+		}
+		clean = append(clean, segment)
+	}
+
+	if len(clean) == 0 {
+		return ""
+	}
+	return strings.Join(clean, "/")
+}
+
+// ArtefactContentType sanitizes a client-declared media type.
+//
+// It is echoed back on download, so a header the agent invented must
+// not be able to carry a newline into the response.
+func ArtefactContentType(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 || strings.ContainsFunc(value, unicode.IsControl) {
+		return DefaultContentType
+	}
+	return value
+}
+
+// ArtefactPatterns parses the comma separated artefact_paths column
+// into the globs an agent should collect, dropping anything that could
+// not name a file inside the checkout.
+//
+// Patterns are validated where they are read rather than only where
+// they are written: a pattern can be stored by one version of the
+// server and read by another, and the agent is the one that touches the
+// filesystem.
+func ArtefactPatterns(value string) []string {
+	parts := strings.Split(value, ",")
+
+	patterns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if pattern := ArtefactPattern(part); pattern != "" {
+			patterns = append(patterns, pattern)
+		}
+	}
+
+	if len(patterns) == 0 {
+		return nil
+	}
+	return patterns
+}
+
+// JoinArtefactPatterns renders patterns for the artefact_paths column,
+// keeping only the ones that survive validation.
+func JoinArtefactPatterns(patterns []string) string {
+	return strings.Join(ArtefactPatterns(strings.Join(patterns, ",")), ",")
+}
+
+// MatchArtefactPath reports whether a path relative to the job's
+// directory matches a collection pattern. `*` matches within a path
+// segment, `**` across segments, exactly as the repository allowlist
+// patterns do.
+//
+// Unlike MatchRepository this is case-sensitive: repository slugs are
+// lowercased on the way in, filenames are not, and `*.JSON` collecting
+// `scan.json` on one agent and not another would be worse than strict.
+func MatchArtefactPath(pattern, value string) bool {
+	pattern = strings.TrimSpace(pattern)
+	value = strings.TrimSpace(value)
+
+	if pattern == "" || value == "" {
+		return false
+	}
+
+	return matchSegments(strings.Split(pattern, "/"), strings.Split(value, "/"))
+}

--- a/server/model/artefact_test.go
+++ b/server/model/artefact_test.go
@@ -1,0 +1,97 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArtefactPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"plain file", "scan.json", "scan.json"},
+		{"nested", "reports/scan.json", "reports/scan.json"},
+		{"leading dot slash", "./scan.json", "scan.json"},
+		{"doubled separators", "reports//scan.json", "reports/scan.json"},
+		{"windows separators", `reports\scan.json`, "reports/scan.json"},
+		{"whitespace", "  scan.json  ", "scan.json"},
+
+		// Everything below would address a file the job never
+		// produced, and is refused rather than repaired.
+		{"traversal", "../../etc/passwd", ""},
+		{"traversal inside", "reports/../../escape", ""},
+		{"absolute", "/etc/passwd", ""},
+		{"windows absolute", `\etc\passwd`, ""},
+		{"bare traversal", "..", ""},
+		{"empty", "", ""},
+		{"only separators", "///", ""},
+		{"newline in the name", "scan\n.json", ""},
+		{"too long", strings.Repeat("a", MaxArtefactPathLength+1), ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, ArtefactPath(test.value))
+		})
+	}
+}
+
+func TestMatchArtefactPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		value    string
+		expected bool
+	}{
+		{"exact", "scan.json", "scan.json", true},
+		{"extension in a directory", "reports/*.json", "reports/scan.json", true},
+		{"star does not cross a separator", "*.json", "reports/scan.json", false},
+		{"double star crosses", "**/*.json", "a/b/scan.json", true},
+		{"double star matches nothing", "**/scan.json", "scan.json", true},
+		{"everything", "**", "a/b/c.txt", true},
+		{"prefix", "coverage*", "coverage.out", true},
+		{"no match", "*.json", "scan.xml", false},
+
+		// Filenames are case-sensitive on the systems agents run on,
+		// so matching is too.
+		{"case matters", "*.json", "SCAN.JSON", false},
+
+		{"empty pattern", "", "scan.json", false},
+		{"empty value", "*.json", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, MatchArtefactPath(test.pattern, test.value))
+		})
+	}
+}
+
+func TestArtefactPatterns(t *testing.T) {
+	assert.Nil(t, ArtefactPatterns(""))
+	assert.Nil(t, ArtefactPatterns("  ,  "))
+	assert.Equal(t, []string{"*.json", "coverage/*"}, ArtefactPatterns(" *.json , coverage/* "))
+
+	// A pattern that could leave the checkout is dropped, and the rest
+	// of the list still stands.
+	assert.Equal(t, []string{"*.json"}, ArtefactPatterns("*.json,../../etc/*,/etc/*"))
+}
+
+func TestJoinArtefactPatterns(t *testing.T) {
+	assert.Equal(t, "", JoinArtefactPatterns(nil))
+	assert.Equal(t, "*.json,dist/*", JoinArtefactPatterns([]string{"*.json", "../escape", "./dist/*"}))
+}
+
+func TestArtefactContentType(t *testing.T) {
+	assert.Equal(t, "application/json", ArtefactContentType("application/json"))
+	assert.Equal(t, DefaultContentType, ArtefactContentType(""))
+	assert.Equal(t, DefaultContentType, ArtefactContentType(strings.Repeat("x", 200)))
+
+	// The value is echoed back as a response header, so a smuggled
+	// newline must not survive.
+	assert.Equal(t, DefaultContentType, ArtefactContentType("text/html\r\nSet-Cookie: a=b"))
+}

--- a/server/model/errors.go
+++ b/server/model/errors.go
@@ -60,6 +60,28 @@ var (
 	// usable private key.
 	ErrInvalidSSHKey = errors.New("not a usable ssh private key")
 
+	// ErrInvalidArtefactPath is returned when an upload names a file
+	// that could not be inside the job's directory.
+	ErrInvalidArtefactPath = errors.New("artefact path must be relative to the job directory")
+
+	// ErrArtefactTooLarge is returned when an upload runs past
+	// artefact.max_size. The bytes written so far are discarded.
+	ErrArtefactTooLarge = errors.New("artefact is larger than artefact.max_size")
+
+	// ErrTooManyArtefacts is returned when a job has already stored
+	// artefact.max_count files. It is the per-job backstop against a
+	// pipeline that uploads in a loop.
+	ErrTooManyArtefacts = errors.New("job has reached artefact.max_count")
+
+	// ErrChecksumMismatch is returned when the bytes received do not
+	// hash to the checksum the agent declared, which means the upload
+	// was truncated or altered in flight.
+	ErrChecksumMismatch = errors.New("artefact checksum does not match the uploaded bytes")
+
+	// ErrArtefactNotFound is returned when an artefact does not exist,
+	// belongs to another job, or has been swept by retention.
+	ErrArtefactNotFound = errors.New("artefact not found")
+
 	// ErrForbidden is returned when a user is authenticated but not
 	// permitted to perform the action.
 	ErrForbidden = errors.New("insufficient permissions")

--- a/server/model/setting.go
+++ b/server/model/setting.go
@@ -2,7 +2,9 @@ package model
 
 import (
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -26,6 +28,17 @@ const (
 	// SettingJobRetention is how long finished jobs and their output
 	// are kept. Zero keeps them forever.
 	SettingJobRetention = "job.retention"
+
+	// SettingArtefactMaxSize bounds one uploaded artefact.
+	SettingArtefactMaxSize = "artefact.max_size"
+
+	// SettingArtefactMaxCount bounds how many artefacts one job may
+	// keep.
+	SettingArtefactMaxCount = "artefact.max_count"
+
+	// SettingArtefactRetention is how long artefact bytes are kept.
+	// Zero follows job.retention.
+	SettingArtefactRetention = "artefact.retention"
 )
 
 // SettingKind is how a setting's value is validated and parsed.
@@ -38,6 +51,10 @@ const (
 	KindInt      SettingKind = "int"
 	KindDuration SettingKind = "duration"
 	KindEnum     SettingKind = "enum"
+
+	// KindBytes is a size, written the way an operator thinks about
+	// one: 32MB rather than 33554432.
+	KindBytes SettingKind = "bytes"
 )
 
 // SettingDefinition describes one configurable value.
@@ -84,6 +101,24 @@ var settingDefinitions = []SettingDefinition{
 		Default:     "0",
 		Description: "How long finished jobs are kept. 0 keeps them forever.",
 	},
+	{
+		Name:        SettingArtefactMaxSize,
+		Kind:        KindBytes,
+		Default:     "32MB",
+		Description: "Largest single artefact an agent may upload, e.g. 32MB. 0 removes the limit.",
+	},
+	{
+		Name:        SettingArtefactMaxCount,
+		Kind:        KindInt,
+		Default:     "50",
+		Description: "How many artefacts one job may keep. Further uploads are refused. 0 removes the limit.",
+	},
+	{
+		Name:        SettingArtefactRetention,
+		Kind:        KindDuration,
+		Default:     "0",
+		Description: "How long artefact bytes are kept. 0 follows job.retention.",
+	},
 }
 
 // SettingDefinitions returns the registry.
@@ -118,6 +153,10 @@ func (d SettingDefinition) ValidateSetting(value string) error {
 		if _, err := time.ParseDuration(value); err != nil {
 			return fmt.Errorf("%s must be a duration such as 15m or 24h", d.Name)
 		}
+	case KindBytes:
+		if _, err := ParseBytes(value); err != nil {
+			return fmt.Errorf("%s must be a size such as 512KB or 32MB", d.Name)
+		}
 	case KindEnum:
 		for _, allowed := range d.Values {
 			if value == allowed {
@@ -128,4 +167,48 @@ func (d SettingDefinition) ValidateSetting(value string) error {
 	}
 
 	return nil
+}
+
+// byteUnits are the suffixes ParseBytes understands, longest first so
+// "KB" is not read as "B" with a stray K in front.
+var byteUnits = []struct {
+	suffix string
+	scale  int64
+}{
+	{"GB", 1 << 30},
+	{"MB", 1 << 20},
+	{"KB", 1 << 10},
+	{"B", 1},
+}
+
+// ParseBytes reads a size written as a plain number of bytes or with a
+// KB/MB/GB suffix. The units are powers of 1024: this bounds a file on
+// a disk, and disks are measured the way `ls -lh` measures them.
+func ParseBytes(value string) (int64, error) {
+	trimmed := strings.ToUpper(strings.TrimSpace(value))
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+
+	scale := int64(1)
+	for _, unit := range byteUnits {
+		if rest, ok := strings.CutSuffix(trimmed, unit.suffix); ok {
+			trimmed = strings.TrimSpace(rest)
+			scale = unit.scale
+			break
+		}
+	}
+
+	amount, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a size", value)
+	}
+	if amount < 0 {
+		return 0, fmt.Errorf("%q is negative", value)
+	}
+	if amount > math.MaxInt64/scale {
+		return 0, fmt.Errorf("%q is too large", value)
+	}
+
+	return amount * scale, nil
 }

--- a/server/model/setting_test.go
+++ b/server/model/setting_test.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBytes(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected int64
+		invalid  bool
+	}{
+		{value: "0", expected: 0},
+		{value: "1024", expected: 1024},
+		{value: "64B", expected: 64},
+		{value: "512KB", expected: 512 * 1024},
+		{value: "32MB", expected: 32 * 1024 * 1024},
+		{value: "1GB", expected: 1024 * 1024 * 1024},
+		{value: " 8 mb ", expected: 8 * 1024 * 1024},
+
+		{value: "", invalid: true},
+		{value: "a handful", invalid: true},
+		{value: "-1", invalid: true},
+		{value: "12TB", invalid: true},
+		// The multiplication must not be allowed to wrap into a
+		// negative limit, which would refuse every upload.
+		{value: "9223372036854775807GB", invalid: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			parsed, err := ParseBytes(test.value)
+			if test.invalid {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, parsed)
+		})
+	}
+}
+
+func TestArtefactSettingsAreRegistered(t *testing.T) {
+	for _, name := range []string{
+		SettingArtefactMaxSize,
+		SettingArtefactMaxCount,
+		SettingArtefactRetention,
+	} {
+		definition, ok := LookupSetting(name)
+		require.True(t, ok, "%s is not in the registry", name)
+
+		// A default that fails its own validation would leave a fresh
+		// instance with a setting nobody can read.
+		assert.NoError(t, definition.ValidateSetting(definition.Default))
+	}
+}

--- a/server/model/types.mig.go
+++ b/server/model/types.mig.go
@@ -183,6 +183,9 @@ type Job struct {
 	// Updated At
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at"`
 
+	// Artefact Paths
+	ArtefactPaths string `db:"artefact_paths" json:"artefact_paths"`
+
 	// Ref
 	Ref string `db:"ref" json:"ref"`
 
@@ -307,6 +310,12 @@ func (j *Job) GetUpdatedAt() *time.Time { return j.UpdatedAt }
 // SetUpdatedAt sets UpdatedAt to the provided value.
 func (j *Job) SetUpdatedAt(stamp time.Time) { j.UpdatedAt = &stamp }
 
+// GetArtefactPaths will return the value of ArtefactPaths.
+func (j *Job) GetArtefactPaths() string { return j.ArtefactPaths }
+
+// SetArtefactPaths sets ArtefactPaths to the provided value.
+func (j *Job) SetArtefactPaths(val string) { j.ArtefactPaths = val }
+
 // GetRef will return the value of Ref.
 func (j *Job) GetRef() string { return j.Ref }
 
@@ -329,10 +338,114 @@ func (j *Job) SetCloneDepth(val int64) { j.CloneDepth = val }
 const JobTable = "`job`"
 
 // JobFields is a list of all columns in the DB table.
-var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "ref", "commit_sha", "clone_depth"}
+var JobFields = []string{"id", "parent_id", "root_id", "depth", "repository_id", "user_id", "working_directory", "command", "labels", "params", "status", "exit_code", "error", "agent_id", "lease_expires_at", "started_at", "finished_at", "created_at", "updated_at", "artefact_paths", "ref", "commit_sha", "clone_depth"}
 
 // JobPrimaryFields are the primary key fields in the DB table.
 var JobPrimaryFields = []string{"id"}
+
+// JobArtefact generated for db table `job_artefact`.
+//
+// Job Artefact.
+type JobArtefact struct {
+	// ID
+	ID string `db:"id" json:"id"`
+
+	// Job ID
+	JobID string `db:"job_id" json:"job_id"`
+
+	// Path
+	Path string `db:"path" json:"path"`
+
+	// Storage Key
+	StorageKey string `db:"storage_key" json:"storage_key"`
+
+	// Size
+	Size int64 `db:"size" json:"size"`
+
+	// Content Type
+	ContentType string `db:"content_type" json:"content_type"`
+
+	// Checksum
+	Checksum string `db:"checksum" json:"checksum"`
+
+	// Agent ID
+	AgentID string `db:"agent_id" json:"agent_id"`
+
+	// Created At
+	CreatedAt *time.Time `db:"created_at" json:"created_at"`
+
+	// Deleted At
+	DeletedAt *time.Time `db:"deleted_at" json:"deleted_at"`
+}
+
+// GetID will return the value of ID.
+func (j *JobArtefact) GetID() string { return j.ID }
+
+// SetID sets ID to the provided value.
+func (j *JobArtefact) SetID(val string) { j.ID = val }
+
+// GetJobID will return the value of JobID.
+func (j *JobArtefact) GetJobID() string { return j.JobID }
+
+// SetJobID sets JobID to the provided value.
+func (j *JobArtefact) SetJobID(val string) { j.JobID = val }
+
+// GetPath will return the value of Path.
+func (j *JobArtefact) GetPath() string { return j.Path }
+
+// SetPath sets Path to the provided value.
+func (j *JobArtefact) SetPath(val string) { j.Path = val }
+
+// GetStorageKey will return the value of StorageKey.
+func (j *JobArtefact) GetStorageKey() string { return j.StorageKey }
+
+// SetStorageKey sets StorageKey to the provided value.
+func (j *JobArtefact) SetStorageKey(val string) { j.StorageKey = val }
+
+// GetSize will return the value of Size.
+func (j *JobArtefact) GetSize() int64 { return j.Size }
+
+// SetSize sets Size to the provided value.
+func (j *JobArtefact) SetSize(val int64) { j.Size = val }
+
+// GetContentType will return the value of ContentType.
+func (j *JobArtefact) GetContentType() string { return j.ContentType }
+
+// SetContentType sets ContentType to the provided value.
+func (j *JobArtefact) SetContentType(val string) { j.ContentType = val }
+
+// GetChecksum will return the value of Checksum.
+func (j *JobArtefact) GetChecksum() string { return j.Checksum }
+
+// SetChecksum sets Checksum to the provided value.
+func (j *JobArtefact) SetChecksum(val string) { j.Checksum = val }
+
+// GetAgentID will return the value of AgentID.
+func (j *JobArtefact) GetAgentID() string { return j.AgentID }
+
+// SetAgentID sets AgentID to the provided value.
+func (j *JobArtefact) SetAgentID(val string) { j.AgentID = val }
+
+// GetCreatedAt will return the value of CreatedAt.
+func (j *JobArtefact) GetCreatedAt() *time.Time { return j.CreatedAt }
+
+// SetCreatedAt sets CreatedAt to the provided value.
+func (j *JobArtefact) SetCreatedAt(stamp time.Time) { j.CreatedAt = &stamp }
+
+// GetDeletedAt will return the value of DeletedAt.
+func (j *JobArtefact) GetDeletedAt() *time.Time { return j.DeletedAt }
+
+// SetDeletedAt sets DeletedAt to the provided value.
+func (j *JobArtefact) SetDeletedAt(stamp time.Time) { j.DeletedAt = &stamp }
+
+// JobArtefactTable is the name of the table in the DB.
+const JobArtefactTable = "`job_artefact`"
+
+// JobArtefactFields is a list of all columns in the DB table.
+var JobArtefactFields = []string{"id", "job_id", "path", "storage_key", "size", "content_type", "checksum", "agent_id", "created_at", "deleted_at"}
+
+// JobArtefactPrimaryFields are the primary key fields in the DB table.
+var JobArtefactPrimaryFields = []string{"id"}
 
 // JobLog generated for db table `job_log`.
 //
@@ -1093,6 +1206,67 @@ func (j *Job) Update(opts ...QueryOption) string {
 // Delete starts building a DELETE query.
 func (j *Job) Delete(opts ...QueryOption) string {
 	cfg := (&QueryConfig{Table: JobTable}).Apply(opts...)
+	query := fmt.Sprintf("DELETE FROM %s", cfg.Table)
+	if cfg.Where != "" {
+		query += " WHERE " + cfg.Where
+	}
+	return query
+}
+
+// Insert starts building an INSERT INTO query.
+func (j *JobArtefact) Insert(opts ...QueryOption) string {
+	cfg := (&QueryConfig{Table: JobArtefactTable, Statement: "INSERT INTO"}).Apply(opts...)
+	cols := JobArtefactFields
+	if len(cfg.Columns) > 0 {
+		cols = cfg.Columns
+	}
+	return fmt.Sprintf("%s %s (%s) VALUES (:%s)", cfg.Statement, cfg.Table, strings.Join(cols, ", "), strings.Join(cols, ", :"))
+}
+
+// Select starts building a SELECT query.
+func (j *JobArtefact) Select(opts ...QueryOption) string {
+	cfg := (&QueryConfig{Table: JobArtefactTable}).Apply(opts...)
+	cols := "*"
+	if len(cfg.Columns) > 0 {
+		cols = strings.Join(cfg.Columns, ", ")
+	}
+	query := fmt.Sprintf("SELECT %s FROM %s", cols, cfg.Table)
+	if cfg.Where != "" {
+		query += " WHERE " + cfg.Where
+	}
+	if cfg.OrderBy != "" {
+		query += " ORDER BY " + cfg.OrderBy
+	}
+	if cfg.LimitOffset > 0 {
+		query += fmt.Sprintf(" LIMIT %d, %d", cfg.LimitStart, cfg.LimitOffset)
+	}
+	return query
+}
+
+// Update starts building a UPDATE query.
+func (j *JobArtefact) Update(opts ...QueryOption) string {
+	cfg := (&QueryConfig{Table: JobArtefactTable}).Apply(opts...)
+	cols := JobArtefactFields
+	if len(cfg.Columns) > 0 {
+		cols = cfg.Columns
+	}
+	setClause := ""
+	for i, col := range cols {
+		if i > 0 {
+			setClause += ", "
+		}
+		setClause += col + "=:" + col
+	}
+	query := fmt.Sprintf("UPDATE %s SET %s", cfg.Table, setClause)
+	if cfg.Where != "" {
+		query += " WHERE " + cfg.Where
+	}
+	return query
+}
+
+// Delete starts building a DELETE query.
+func (j *JobArtefact) Delete(opts ...QueryOption) string {
+	cfg := (&QueryConfig{Table: JobArtefactTable}).Apply(opts...)
 	query := fmt.Sprintf("DELETE FROM %s", cfg.Table)
 	if cfg.Where != "" {
 		query += " WHERE " + cfg.Where

--- a/server/options.go
+++ b/server/options.go
@@ -26,6 +26,10 @@ type Options struct {
 	// PLATFORM_DB_ATKINS, falling back to PLATFORM_DB_DEFAULT).
 	Connection string
 
+	// ArtefactDir is the root the bytes of job artefacts are written
+	// under. Empty selects DefaultArtefactDir.
+	ArtefactDir string
+
 	// TokenTTL is the access token lifetime.
 	TokenTTL time.Duration
 
@@ -57,12 +61,18 @@ const (
 	EnvAgentToken = "ATKINS_AGENT_TOKEN"
 )
 
+// DefaultArtefactDir is where artefact bytes go when nothing says
+// otherwise: beside the database, which is where the rest of a small
+// instance's state already lives.
+const DefaultArtefactDir = "artefacts"
+
 // FromConfig builds module options from a resolved server config.
 func FromConfig(cfg config.ServerConfig) *Options {
 	return &Options{
 		SigningKey:        cfg.SigningKey,
 		AgentToken:        cfg.AgentToken,
 		Connection:        cfg.Connection,
+		ArtefactDir:       cfg.ArtefactDir,
 		TokenTTL:          cfg.TokenTTL,
 		SessionTTL:        cfg.SessionTTL,
 		AllowRegistration: cfg.AllowRegistration,

--- a/server/schema/docs/job.md
+++ b/server/schema/docs/job.md
@@ -23,6 +23,7 @@ Job.
 | finished_at       | datetime |     | Finished At       |
 | created_at        | datetime | MUL | Created At        |
 | updated_at        | datetime |     | Updated At        |
+| artefact_paths    | varchar  |     | Artefact Paths    |
 | ref               | varchar  |     | Ref               |
 | commit_sha        | varchar  | MUL | Commit Sha        |
 | clone_depth       | bigint   |     | Clone Depth       |

--- a/server/schema/docs/job_artefact.md
+++ b/server/schema/docs/job_artefact.md
@@ -1,0 +1,16 @@
+# Job Artefact
+
+Job Artefact.
+
+| Name         | Type     | Key | Comment      |
+|--------------|----------|-----|--------------|
+| id           | char(26) | PRI | ID           |
+| job_id       | char(26) | MUL | Job ID       |
+| path         | varchar  | MUL | Path         |
+| storage_key  | varchar  |     | Storage Key  |
+| size         | bigint   |     | Size         |
+| content_type | varchar  |     | Content Type |
+| checksum     | char(64) |     | Checksum     |
+| agent_id     | varchar  | MUL | Agent ID     |
+| created_at   | datetime | MUL | Created At   |
+| deleted_at   | datetime | MUL | Deleted At   |

--- a/server/schema/job_artefact.up.sql
+++ b/server/schema/job_artefact.up.sql
@@ -1,0 +1,30 @@
+-- job_artefact: A file a job produced, uploaded by the agent that ran it
+CREATE TABLE IF NOT EXISTS job_artefact (
+    id CHAR(26) PRIMARY KEY NOT NULL,
+    job_id CHAR(26) NOT NULL,
+    -- path is the name the pipeline gave the file, relative to the
+    -- directory the job ran in. It is what a person recognizes the
+    -- artefact by, and never where the bytes actually are.
+    path TEXT NOT NULL,
+    -- storage_key addresses the bytes in the blob store. Holding it
+    -- apart from path is what lets a filesystem root be swapped for an
+    -- object store later without reshaping this table or the API.
+    storage_key TEXT NOT NULL DEFAULT '',
+    size INTEGER NOT NULL DEFAULT 0,
+    content_type TEXT NOT NULL DEFAULT 'application/octet-stream',
+    -- checksum is the SHA256 of the bytes, computed while they were
+    -- written. A truncated upload is detectable rather than silently
+    -- half a file.
+    checksum CHAR(64) NOT NULL DEFAULT '',
+    agent_id TEXT NOT NULL DEFAULT '',
+    created_at DATETIME,
+    -- deleted_at marks an artefact whose bytes retention has swept.
+    -- The row stays behind on purpose: it is a few dozen bytes, it
+    -- records that the file existed and how big it was, and it is what
+    -- makes the removal auditable rather than silent.
+    deleted_at DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_artefact_job_id_path ON job_artefact(job_id, path);
+CREATE INDEX IF NOT EXISTS idx_job_artefact_created_at ON job_artefact(created_at);
+CREATE INDEX IF NOT EXISTS idx_job_artefact_deleted_at ON job_artefact(deleted_at);

--- a/server/schema/job_artefact_paths.up.sql
+++ b/server/schema/job_artefact_paths.up.sql
@@ -1,0 +1,12 @@
+-- Add declared artefact paths to job.
+--
+-- A job says what it wants kept before it runs, so the agent can
+-- collect it after the command exits — including when the command
+-- failed, which is when the files matter most. The column holds comma
+-- separated glob patterns matched against the checkout the job ran in.
+--
+-- It travels on the job rather than in params because it governs what
+-- the agent does after the command, not what the command does: a
+-- trigger can ask for `coverage.json` from a pipeline that knows
+-- nothing about artefacts.
+ALTER TABLE job ADD COLUMN artefact_paths TEXT NOT NULL DEFAULT '';

--- a/server/schema/schema.yml
+++ b/server/schema/schema.yml
@@ -95,6 +95,10 @@
       type: timestamp
       comment: Updated At
       datatype: datetime
+    - name: artefact_paths
+      type: text
+      comment: Artefact Paths
+      datatype: varchar
     - name: ref
       type: text
       comment: Ref
@@ -137,6 +141,72 @@
     - name: idx_job_user_id
       columns:
         - user_id
+- name: job_artefact
+  comment: Job Artefact
+  columns:
+    - name: id
+      type: text
+      key: PRI
+      comment: ID
+      datatype: char(26)
+    - name: job_id
+      type: text
+      key: MUL
+      comment: Job ID
+      datatype: char(26)
+    - name: path
+      type: text
+      key: MUL
+      comment: Path
+      datatype: varchar
+    - name: storage_key
+      type: text
+      comment: Storage Key
+      datatype: varchar
+    - name: size
+      type: integer
+      comment: Size
+      datatype: bigint
+      size: 8
+    - name: content_type
+      type: text
+      comment: Content Type
+      datatype: varchar
+    - name: checksum
+      type: text
+      comment: Checksum
+      datatype: char(64)
+    - name: agent_id
+      type: text
+      key: MUL
+      comment: Agent ID
+      datatype: varchar
+    - name: created_at
+      type: timestamp
+      key: MUL
+      comment: Created At
+      datatype: datetime
+    - name: deleted_at
+      type: timestamp
+      key: MUL
+      comment: Deleted At
+      datatype: datetime
+  indexes:
+    - name: sqlite_autoindex_job_artefact_1
+      columns:
+        - id
+      primary: true
+      unique: true
+    - name: idx_job_artefact_created_at
+      columns:
+        - created_at
+    - name: idx_job_artefact_deleted_at
+      columns:
+        - deleted_at
+    - name: idx_job_artefact_job_id_path
+      columns:
+        - job_id
+        - path
 - name: job_log
   comment: Job Log
   columns:

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/titpetric/platform/pkg/telemetry"
 
 	"github.com/titpetric/atkins/server/api"
+	"github.com/titpetric/atkins/server/blob"
 	"github.com/titpetric/atkins/server/model"
 	"github.com/titpetric/atkins/server/schema"
 	"github.com/titpetric/atkins/server/storage"
@@ -44,7 +46,9 @@ type Module struct {
 	api  *api.Handlers
 	web  *web.Handlers
 
-	jobs *storage.JobStorage
+	jobs      *storage.JobStorage
+	artefacts *storage.JobArtefactStorage
+	settings  *storage.SettingStorage
 
 	// reclaim is the background sweep of expired agent leases.
 	cancel context.CancelFunc
@@ -91,6 +95,19 @@ func (m *Module) Start(ctx context.Context) error {
 	if err := settings.Load(ctx); err != nil {
 		return err
 	}
+	m.settings = settings
+
+	// Artefact bytes live on a disk rather than in the database. A root
+	// the server cannot create is fatal here, instead of a surprise on
+	// the first job that produces a file.
+	artefactDir := m.opts.ArtefactDir
+	if artefactDir == "" {
+		artefactDir = DefaultArtefactDir
+	}
+	blobs := blob.NewDir(artefactDir)
+	if err := blobs.Prepare(); err != nil {
+		return fmt.Errorf("atkins server: artefact directory %q: %w", artefactDir, err)
+	}
 
 	// A setting overrides the corresponding start-up flag, so an admin
 	// can change these without a restart.
@@ -104,6 +121,7 @@ func (m *Module) Start(ctx context.Context) error {
 	}
 
 	m.jobs = storage.NewJobStorage(db, maxDepth, leaseTTL)
+	m.artefacts = storage.NewJobArtefactStorage(db, blobs)
 	jobLogs := storage.NewJobLogStorage(db)
 	repositories := storage.NewRepositoryStorage(db)
 
@@ -117,15 +135,17 @@ func (m *Module) Start(ctx context.Context) error {
 		RepositoryStorage:     repositories,
 		JobStorage:            m.jobs,
 		JobLogStorage:         jobLogs,
+		JobArtefactStorage:    m.artefacts,
 		RepositoryRuleStorage: storage.NewRepositoryRuleStorage(db),
 		SettingStorage:        settings,
 		SSHKeyStorage:         storage.NewSSHKeyStorage(db),
 	})
 
 	m.web, err = web.NewHandlers(web.Options{
-		JobStorage:        m.jobs,
-		JobLogStorage:     jobLogs,
-		RepositoryStorage: repositories,
+		JobStorage:         m.jobs,
+		JobLogStorage:      jobLogs,
+		JobArtefactStorage: m.artefacts,
+		RepositoryStorage:  repositories,
 	})
 	if err != nil {
 		return err
@@ -152,9 +172,12 @@ func (m *Module) Stop(context.Context) error {
 	return nil
 }
 
-// startReclaim sweeps jobs whose agent lease has lapsed back out of the
-// running state. Without it, an agent that dies mid-job strands that
-// job as running forever.
+// startReclaim runs the two periodic sweeps: expired agent leases, and
+// artefacts past their retention.
+//
+// They share a ticker because they are the same kind of work — a small
+// amount of tidying on a timer — and because a server with one
+// background goroutine is easier to reason about than one with two.
 func (m *Module) startReclaim(ctx context.Context) {
 	if m.opts.ReclaimInterval <= 0 {
 		return
@@ -185,7 +208,40 @@ func (m *Module) startReclaim(ctx context.Context) {
 				if reclaimed > 0 {
 					log.Printf("[atkins] reclaimed %d job(s) from expired agent leases", reclaimed)
 				}
+
+				m.pruneArtefacts(ctx)
 			}
 		}
 	}()
+}
+
+// pruneArtefacts drops artefact bytes that have outlived their
+// retention.
+//
+// Retention is read on every pass rather than captured at start-up,
+// because it is a setting an admin changes when a disk fills up, and
+// that is exactly the moment a restart is least welcome.
+//
+// `artefact.retention` falls back to `job.retention`: an artefact
+// belongs to a job and should not outlive it. It exists separately
+// because bytes are the expensive half — keeping the ledger of what ran
+// for a year while dropping the files after a week is a normal thing to
+// want, and the reverse never is.
+func (m *Module) pruneArtefacts(ctx context.Context) {
+	retention := m.settings.Duration(model.SettingArtefactRetention)
+	if retention <= 0 {
+		retention = m.settings.Duration(model.SettingJobRetention)
+	}
+	if retention <= 0 {
+		return
+	}
+
+	swept, err := m.artefacts.PruneExpired(ctx, time.Now().Add(-retention))
+	if err != nil {
+		telemetry.CaptureError(ctx, err)
+		return
+	}
+	if swept > 0 {
+		log.Printf("[atkins] swept %d artefact(s) older than %s", swept, retention)
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -38,6 +38,14 @@ const testAgentToken = "test-agent-token"
 func testServer(t *testing.T) string {
 	t.Helper()
 
+	return testServerWith(t, nil)
+}
+
+// testServerWith starts an instance whose options a test can adjust,
+// for the cases that need a background sweep or a different root.
+func testServerWith(t *testing.T, configure func(*server.Options)) string {
+	t.Helper()
+
 	// The platform caches connection pools by name for the life of the
 	// process, so each test claims a name of its own and gets a fresh
 	// database instead of the previous test's fixtures.
@@ -50,10 +58,17 @@ func testServer(t *testing.T) string {
 	opts.Connection = connection
 	opts.SigningKey = "test-signing-key"
 	opts.AgentToken = testAgentToken
+	// Artefact bytes go somewhere the test owns, rather than into an
+	// `artefacts` directory beside the package source.
+	opts.ArtefactDir = filepath.Join(t.TempDir(), "artefacts")
 	// Off by default: the bootstrap path (no users yet) is what the
 	// first register call in each test exercises.
 	opts.AllowRegistration = false
 	opts.ReclaimInterval = 0
+
+	if configure != nil {
+		configure(opts)
+	}
 
 	svc := platform.New(platform.NewTestOptions())
 	svc.Register(server.NewModule(opts))

--- a/server/storage/job.go
+++ b/server/storage/job.go
@@ -85,6 +85,10 @@ type JobRequest struct {
 
 	// Params is a JSON object handed to the job as ATKINS_JOB_PARAMS.
 	Params string
+
+	// Artefacts are glob patterns the agent collects after the command
+	// exits, relative to the directory it ran in.
+	Artefacts []string
 }
 
 // Create records a dispatched job.
@@ -134,7 +138,10 @@ func (s *JobStorage) Create(ctx context.Context, req JobRequest) (*model.Job, er
 		CloneDepth:       req.CloneDepth,
 		Labels:           strings.Join(req.Labels, ","),
 		Params:           params,
-		Status:           model.JobStatusPending,
+		// Patterns are normalized on the way in, so an agent reading
+		// the column never has to decide what `../../etc` means.
+		ArtefactPaths: model.JoinArtefactPatterns(req.Artefacts),
+		Status:        model.JobStatusPending,
 	}
 	job.SetCreatedAt(now)
 	job.SetUpdatedAt(now)

--- a/server/storage/job_artefact.go
+++ b/server/storage/job_artefact.go
@@ -1,0 +1,261 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/titpetric/platform/pkg/telemetry"
+	"github.com/titpetric/platform/pkg/ulid"
+
+	"github.com/titpetric/atkins/server/blob"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// JobArtefactStorage persists the files a job produced.
+//
+// It owns both halves of an artefact: the row that describes it and the
+// bytes it points at. Keeping them behind one type is what stops the
+// two from drifting — a caller cannot insert a row for bytes that were
+// never written, or delete a row and forget the file.
+type JobArtefactStorage struct {
+	db    *sqlx.DB
+	blobs blob.Store
+}
+
+// NewJobArtefactStorage returns a JobArtefactStorage backed by the
+// given pool and blob store.
+func NewJobArtefactStorage(db *sqlx.DB, blobs blob.Store) *JobArtefactStorage {
+	return &JobArtefactStorage{db: db, blobs: blobs}
+}
+
+// ArtefactRequest is one uploaded file.
+type ArtefactRequest struct {
+	// JobID is the job that produced the file. The caller has already
+	// established that it exists.
+	JobID string
+
+	// AgentID records which worker uploaded it.
+	AgentID string
+
+	// Path is the name the pipeline gave the file, relative to the
+	// directory the job ran in.
+	Path string
+
+	// ContentType is what the agent thought it was uploading.
+	ContentType string
+
+	// Checksum, when set, is the SHA256 the agent computed. It is
+	// compared against what actually arrived.
+	Checksum string
+
+	// Content is the file. It is streamed to the blob store rather than
+	// read into memory: an artefact is as large as the limit allows.
+	Content io.Reader
+
+	// MaxSize bounds this upload; MaxCount bounds how many artefacts
+	// the job may keep. Both come from the setting registry, so an
+	// admin can change them without a restart.
+	MaxSize  int64
+	MaxCount int64
+}
+
+// Create stores an uploaded artefact.
+//
+// Uploading a path a job already has replaces it. A collection that
+// runs twice — a retried upload, a pipeline that copies the same file
+// from two steps — should leave one scan.json rather than two, and the
+// count limit should not be spent on duplicates.
+func (s *JobArtefactStorage) Create(ctx context.Context, req ArtefactRequest) (*model.JobArtefact, error) {
+	ctx, span := telemetry.StartAuto(ctx, s.Create)
+	defer span.End()
+
+	path := model.ArtefactPath(req.Path)
+	if path == "" {
+		return nil, model.ErrInvalidArtefactPath
+	}
+
+	superseded, err := s.byPath(ctx, req.JobID, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// A replacement takes the slot of the file it replaces, so a job
+	// re-uploading its one artefact never runs into the count limit.
+	if superseded == nil && req.MaxCount > 0 {
+		count, err := s.Count(ctx, req.JobID)
+		if err != nil {
+			return nil, err
+		}
+		if count >= req.MaxCount {
+			return nil, model.ErrTooManyArtefacts
+		}
+	}
+
+	id := ulid.String()
+	key := blob.Key(req.JobID, id)
+
+	written, err := s.blobs.Put(ctx, key, req.Content, req.MaxSize)
+	if err != nil {
+		if errors.Is(err, blob.ErrTooLarge) {
+			return nil, model.ErrArtefactTooLarge
+		}
+		return nil, fmt.Errorf("store artefact: %w", err)
+	}
+
+	// Hex, so case is presentation rather than meaning.
+	if req.Checksum != "" && !strings.EqualFold(req.Checksum, written.Checksum) {
+		_ = s.blobs.Remove(ctx, key)
+		return nil, model.ErrChecksumMismatch
+	}
+
+	artefact := &model.JobArtefact{
+		ID:          id,
+		JobID:       req.JobID,
+		Path:        path,
+		StorageKey:  key,
+		Size:        written.Size,
+		ContentType: model.ArtefactContentType(req.ContentType),
+		Checksum:    written.Checksum,
+		AgentID:     req.AgentID,
+	}
+	artefact.SetCreatedAt(time.Now())
+
+	if err := client(s.db).Insert(ctx, model.JobArtefactTable, artefact); err != nil {
+		// Leave no bytes nobody can reach.
+		_ = s.blobs.Remove(ctx, key)
+		return nil, fmt.Errorf("create artefact: %w", err)
+	}
+
+	if superseded != nil {
+		// Only now that the replacement is durable.
+		if err := s.remove(ctx, superseded); err != nil {
+			return nil, err
+		}
+	}
+
+	return artefact, nil
+}
+
+// List returns the artefacts of a job whose bytes are still there.
+func (s *JobArtefactStorage) List(ctx context.Context, jobID string) ([]model.JobArtefact, error) {
+	ctx, span := telemetry.StartAuto(ctx, s.List)
+	defer span.End()
+
+	query := `SELECT * FROM ` + model.JobArtefactTable + ` WHERE job_id = ? AND deleted_at IS NULL ORDER BY path ASC`
+	return client(s.db).Select[model.JobArtefact](ctx, query, jobID)
+}
+
+// Get returns one artefact of one job.
+//
+// The job is part of the lookup rather than checked afterwards: an
+// artefact ID from another job must not resolve here just because the
+// caller could read some job.
+func (s *JobArtefactStorage) Get(ctx context.Context, jobID, artefactID string) (*model.JobArtefact, error) {
+	query := `SELECT * FROM ` + model.JobArtefactTable + ` WHERE id = ? AND job_id = ? AND deleted_at IS NULL`
+
+	artefact, err := client(s.db).Get[model.JobArtefact](ctx, query, artefactID, jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, model.ErrArtefactNotFound
+		}
+		return nil, err
+	}
+	return artefact, nil
+}
+
+// Open returns the bytes of an artefact.
+func (s *JobArtefactStorage) Open(ctx context.Context, artefact *model.JobArtefact) (io.ReadCloser, error) {
+	contents, err := s.blobs.Open(ctx, artefact.StorageKey)
+	if err != nil {
+		// The row survives its bytes: retention sweeps them, and so
+		// does an operator with a full disk. Either way this is a 404
+		// rather than a 500.
+		return nil, fmt.Errorf("%w: %s", model.ErrArtefactNotFound, artefact.Path)
+	}
+	return contents, nil
+}
+
+// Count returns how many artefacts a job currently keeps.
+func (s *JobArtefactStorage) Count(ctx context.Context, jobID string) (int64, error) {
+	query := `SELECT COUNT(*) AS count FROM ` + model.JobArtefactTable + ` WHERE job_id = ? AND deleted_at IS NULL`
+
+	result, err := client(s.db).Get[struct {
+		Count int64 `db:"count"`
+	}](ctx, query, jobID)
+	if err != nil {
+		return 0, fmt.Errorf("count artefacts: %w", err)
+	}
+	return result.Count, nil
+}
+
+// PruneExpired drops the bytes of artefacts older than the cutoff and
+// reports how many it swept.
+//
+// The row is soft deleted rather than removed. It costs a few dozen
+// bytes, it keeps the record that a 40MB scan.json was produced, and it
+// makes the removal auditable: "swept by retention" and "never uploaded"
+// are different answers to why a file isn't there.
+func (s *JobArtefactStorage) PruneExpired(ctx context.Context, cutoff time.Time) (int64, error) {
+	ctx, span := telemetry.StartAuto(ctx, s.PruneExpired)
+	defer span.End()
+
+	query := `SELECT * FROM ` + model.JobArtefactTable + `
+		WHERE deleted_at IS NULL AND created_at IS NOT NULL AND created_at < ?
+		ORDER BY created_at ASC LIMIT ?`
+	expired, err := client(s.db).Select[model.JobArtefact](ctx, query, cutoff, pruneBatch)
+	if err != nil {
+		return 0, fmt.Errorf("select expired artefacts: %w", err)
+	}
+
+	var swept int64
+	for _, artefact := range expired {
+		if err := s.remove(ctx, &artefact); err != nil {
+			return swept, err
+		}
+		swept++
+	}
+
+	return swept, nil
+}
+
+// pruneBatch bounds one retention sweep. The sweep runs on a ticker, so
+// a backlog drains over several passes rather than holding the database
+// and the disk for one very long delete.
+const pruneBatch = 500
+
+// byPath returns the live artefact a job already has under a path.
+func (s *JobArtefactStorage) byPath(ctx context.Context, jobID, path string) (*model.JobArtefact, error) {
+	query := `SELECT * FROM ` + model.JobArtefactTable + ` WHERE job_id = ? AND path = ? AND deleted_at IS NULL`
+
+	artefact, err := client(s.db).Get[model.JobArtefact](ctx, query, jobID, path)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("look up artefact: %w", err)
+	}
+	return artefact, nil
+}
+
+// remove drops an artefact's bytes and marks the row deleted.
+//
+// Bytes first: a row that outlives its file reads as "swept", while a
+// file that outlives its row is unreachable garbage nothing will ever
+// clean up.
+func (s *JobArtefactStorage) remove(ctx context.Context, artefact *model.JobArtefact) error {
+	if err := s.blobs.Remove(ctx, artefact.StorageKey); err != nil {
+		return fmt.Errorf("remove artefact bytes: %w", err)
+	}
+
+	query := `UPDATE ` + model.JobArtefactTable + ` SET deleted_at = ? WHERE id = ?`
+	if err := client(s.db).Exec(ctx, query, time.Now(), artefact.ID); err != nil {
+		return fmt.Errorf("delete artefact: %w", err)
+	}
+	return nil
+}

--- a/server/storage/job_artefact_test.go
+++ b/server/storage/job_artefact_test.go
@@ -1,0 +1,303 @@
+package storage_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/titpetric/platform/pkg/drivers"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/titpetric/platform"
+
+	"github.com/titpetric/atkins/server/blob"
+	"github.com/titpetric/atkins/server/model"
+	"github.com/titpetric/atkins/server/schema"
+	"github.com/titpetric/atkins/server/storage"
+)
+
+// connectionSeq hands each test a unique database connection name.
+var connectionSeq atomic.Int64
+
+// testStorage returns artefact storage over a throwaway database and a
+// blob root the test owns.
+func testStorage(t *testing.T) (*storage.JobArtefactStorage, *blob.Dir, *sqlx.DB) {
+	t.Helper()
+
+	// The platform caches pools by connection name for the life of the
+	// process, so each test claims a name of its own.
+	connection := "atkins_storage_test_" + strconv.Itoa(int(connectionSeq.Add(1)))
+	dsn := "sqlite://file:" + filepath.Join(t.TempDir(), "atkins.db")
+	t.Setenv("PLATFORM_DB_"+strings.ToUpper(connection), dsn)
+	platform.SetupConnections(os.Environ())
+
+	ctx := t.Context()
+
+	db, err := storage.DB(ctx, connection)
+	require.NoError(t, err)
+	require.NoError(t, storage.Migrate(ctx, db, schema.Migrations()))
+
+	blobs := blob.NewDir(filepath.Join(t.TempDir(), "artefacts"))
+	require.NoError(t, blobs.Prepare())
+
+	return storage.NewJobArtefactStorage(db, blobs), blobs, db
+}
+
+// store writes one artefact for a job.
+func store(t *testing.T, artefacts *storage.JobArtefactStorage, jobID, path, content string) *model.JobArtefact {
+	t.Helper()
+
+	artefact, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+		JobID:    jobID,
+		AgentID:  "agent-1",
+		Path:     path,
+		Content:  strings.NewReader(content),
+		MaxSize:  1024,
+		MaxCount: 10,
+	})
+	require.NoError(t, err)
+
+	return artefact
+}
+
+// contents reads an artefact back.
+func contents(t *testing.T, artefacts *storage.JobArtefactStorage, artefact *model.JobArtefact) string {
+	t.Helper()
+
+	reader, err := artefacts.Open(t.Context(), artefact)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func TestCreateStoresRowAndBytes(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	artefact := store(t, artefacts, "job-1", "reports/scan.json", `{"findings":3}`)
+
+	assert.Equal(t, int64(14), artefact.Size)
+	assert.Len(t, artefact.Checksum, 64)
+	// The row points at the bytes rather than holding them, which is
+	// what keeps a swap to an object store to one interface.
+	assert.Equal(t, blob.Key("job-1", artefact.ID), artefact.StorageKey)
+	assert.FileExists(t, filepath.Join(blobs.Root(), "job-1", artefact.ID))
+
+	assert.Equal(t, `{"findings":3}`, contents(t, artefacts, artefact))
+
+	listed, err := artefacts.List(t.Context(), "job-1")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, artefact.ID, listed[0].ID)
+}
+
+func TestCreateRejectsAPathOutsideTheJob(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	for _, path := range []string{"../../etc/passwd", "/etc/passwd", "", "   "} {
+		_, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+			JobID:   "job-1",
+			Path:    path,
+			Content: strings.NewReader("planted"),
+			MaxSize: 1024,
+		})
+		assert.ErrorIs(t, err, model.ErrInvalidArtefactPath, "path %q", path)
+	}
+
+	// The path is checked before anything is written, so a refused
+	// upload costs no disk at all.
+	assert.NoDirExists(t, filepath.Join(blobs.Root(), "job-1"))
+}
+
+func TestCreateEnforcesTheSizeLimit(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	_, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+		JobID:   "job-1",
+		Path:    "core.dump",
+		Content: strings.NewReader(strings.Repeat("x", 65)),
+		MaxSize: 64,
+	})
+	assert.ErrorIs(t, err, model.ErrArtefactTooLarge)
+
+	// No row, and no half-written file: the two never disagree.
+	listed, err := artefacts.List(t.Context(), "job-1")
+	require.NoError(t, err)
+	assert.Empty(t, listed)
+
+	entries, err := os.ReadDir(filepath.Join(blobs.Root(), "job-1"))
+	if err == nil {
+		assert.Empty(t, entries)
+	}
+}
+
+func TestCreateEnforcesTheCountLimit(t *testing.T) {
+	artefacts, _, _ := testStorage(t)
+
+	for _, path := range []string{"one.json", "two.json"} {
+		_, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+			JobID:    "job-1",
+			Path:     path,
+			Content:  strings.NewReader("{}"),
+			MaxSize:  1024,
+			MaxCount: 2,
+		})
+		require.NoError(t, err, path)
+	}
+
+	_, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+		JobID:    "job-1",
+		Path:     "three.json",
+		Content:  strings.NewReader("{}"),
+		MaxSize:  1024,
+		MaxCount: 2,
+	})
+	assert.ErrorIs(t, err, model.ErrTooManyArtefacts)
+
+	// A different job has its own allowance.
+	_, err = artefacts.Create(t.Context(), storage.ArtefactRequest{
+		JobID:    "job-2",
+		Path:     "one.json",
+		Content:  strings.NewReader("{}"),
+		MaxSize:  1024,
+		MaxCount: 2,
+	})
+	assert.NoError(t, err)
+}
+
+func TestCreateVerifiesTheChecksum(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	_, err := artefacts.Create(t.Context(), storage.ArtefactRequest{
+		JobID:    "job-1",
+		Path:     "scan.json",
+		Checksum: strings.Repeat("0", 64),
+		Content:  strings.NewReader("{}"),
+		MaxSize:  1024,
+	})
+	assert.ErrorIs(t, err, model.ErrChecksumMismatch)
+
+	// The bytes that failed the comparison are dropped rather than left
+	// for a later upload to trip over.
+	entries, err := os.ReadDir(filepath.Join(blobs.Root(), "job-1"))
+	if err == nil {
+		assert.Empty(t, entries)
+	}
+}
+
+func TestCreateReplacesTheSamePath(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	first := store(t, artefacts, "job-1", "scan.json", `{"run":1}`)
+	second := store(t, artefacts, "job-1", "scan.json", `{"run":2}`)
+
+	listed, err := artefacts.List(t.Context(), "job-1")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, second.ID, listed[0].ID)
+
+	// The superseded bytes are gone, not orphaned on the disk.
+	assert.NoFileExists(t, filepath.Join(blobs.Root(), "job-1", first.ID))
+
+	_, err = artefacts.Get(t.Context(), "job-1", first.ID)
+	assert.ErrorIs(t, err, model.ErrArtefactNotFound)
+}
+
+func TestGetIsScopedToTheJob(t *testing.T) {
+	artefacts, _, _ := testStorage(t)
+
+	artefact := store(t, artefacts, "job-1", "scan.json", "{}")
+
+	found, err := artefacts.Get(t.Context(), "job-1", artefact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, artefact.ID, found.ID)
+
+	// An ID from another job does not resolve here.
+	_, err = artefacts.Get(t.Context(), "job-2", artefact.ID)
+	assert.ErrorIs(t, err, model.ErrArtefactNotFound)
+}
+
+func TestOpenReportsSweptBytes(t *testing.T) {
+	artefacts, blobs, _ := testStorage(t)
+
+	artefact := store(t, artefacts, "job-1", "scan.json", "{}")
+	require.NoError(t, blobs.Remove(context.Background(), artefact.StorageKey))
+
+	// A row whose file an operator removed reads as a missing artefact,
+	// not as a server error.
+	_, err := artefacts.Open(t.Context(), artefact)
+	assert.ErrorIs(t, err, model.ErrArtefactNotFound)
+}
+
+func TestPruneExpired(t *testing.T) {
+	artefacts, blobs, db := testStorage(t)
+
+	old := store(t, artefacts, "job-1", "old.json", "{}")
+	fresh := store(t, artefacts, "job-1", "fresh.json", "{}")
+
+	// Age one of them past the cutoff.
+	backdated := time.Now().Add(-2 * time.Hour)
+	_, err := db.ExecContext(t.Context(),
+		"UPDATE job_artefact SET created_at = ? WHERE id = ?", backdated, old.ID)
+	require.NoError(t, err)
+
+	swept, err := artefacts.PruneExpired(t.Context(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), swept)
+
+	listed, err := artefacts.List(t.Context(), "job-1")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, fresh.ID, listed[0].ID)
+
+	// Retention is about the disk.
+	assert.NoFileExists(t, filepath.Join(blobs.Root(), "job-1", old.ID))
+	assert.FileExists(t, filepath.Join(blobs.Root(), "job-1", fresh.ID))
+
+	// The row survives its bytes, so the page can still say the file
+	// existed and how big it was.
+	var count int
+	require.NoError(t, db.GetContext(t.Context(), &count,
+		"SELECT COUNT(*) FROM job_artefact WHERE id = ? AND deleted_at IS NOT NULL", old.ID))
+	assert.Equal(t, 1, count)
+
+	// A second pass has nothing left to do.
+	swept, err = artefacts.PruneExpired(t.Context(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), swept)
+}
+
+func TestCountIgnoresSweptArtefacts(t *testing.T) {
+	artefacts, _, db := testStorage(t)
+
+	store(t, artefacts, "job-1", "one.json", "{}")
+	store(t, artefacts, "job-1", "two.json", "{}")
+
+	count, err := artefacts.Count(t.Context(), "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	_, err = db.ExecContext(t.Context(),
+		"UPDATE job_artefact SET created_at = ? WHERE path = ?", time.Now().Add(-2*time.Hour), "one.json")
+	require.NoError(t, err)
+
+	_, err = artefacts.PruneExpired(t.Context(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+
+	// A job whose artefacts were swept can produce new ones: the limit
+	// counts what is on the disk, not what ever was.
+	count, err = artefacts.Count(t.Context(), "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}

--- a/server/storage/setting.go
+++ b/server/storage/setting.go
@@ -83,6 +83,12 @@ func (s *SettingStorage) Int(name string) int64 {
 	return parsed
 }
 
+// Bytes returns a setting parsed as a size, such as 32MB.
+func (s *SettingStorage) Bytes(name string) int64 {
+	parsed, _ := model.ParseBytes(s.Get(name))
+	return parsed
+}
+
 // Duration returns a setting parsed as a duration.
 func (s *SettingStorage) Duration(name string) time.Duration {
 	parsed, _ := time.ParseDuration(s.Get(name))

--- a/server/web/templates/job.html
+++ b/server/web/templates/job.html
@@ -89,6 +89,20 @@
   <p class="muted">No output recorded{{if not .Job.StartedAt}} — the job has not been claimed by an agent yet{{end}}.</p>
   {{end}}
 
+  {{if .Artefacts}}
+  <h2>Artefacts</h2>
+  <table>
+    <tr><th>File</th><td>Size</td><td>Type</td></tr>
+    {{range .Artefacts}}
+    <tr>
+      <th class="mono"><a href="/job/{{.JobID}}/artefact/{{.ID}}">{{.Path}}</a></th>
+      <td>{{filesize .Size}}</td>
+      <td class="mono">{{.ContentType}}</td>
+    </tr>
+    {{end}}
+  </table>
+  {{end}}
+
   {{if .Children}}
   <h2>Dispatched by this job</h2>
   <table>

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -10,12 +10,14 @@ package web
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"html/template"
 	"net/http"
 	"time"
 
 	"github.com/titpetric/platform"
 
+	"github.com/titpetric/atkins/server/api"
 	"github.com/titpetric/atkins/server/model"
 	"github.com/titpetric/atkins/server/storage"
 )
@@ -24,6 +26,7 @@ import (
 type Handlers struct {
 	jobs         *storage.JobStorage
 	jobLogs      *storage.JobLogStorage
+	artefacts    *storage.JobArtefactStorage
 	repositories *storage.RepositoryStorage
 
 	templates *template.Template
@@ -31,9 +34,10 @@ type Handlers struct {
 
 // Options is passed from the server module scope.
 type Options struct {
-	JobStorage        *storage.JobStorage
-	JobLogStorage     *storage.JobLogStorage
-	RepositoryStorage *storage.RepositoryStorage
+	JobStorage         *storage.JobStorage
+	JobLogStorage      *storage.JobLogStorage
+	JobArtefactStorage *storage.JobArtefactStorage
+	RepositoryStorage  *storage.RepositoryStorage
 }
 
 // NewHandlers returns Handlers with the page templates parsed.
@@ -46,6 +50,7 @@ func NewHandlers(opts Options) (*Handlers, error) {
 	return &Handlers{
 		jobs:         opts.JobStorage,
 		jobLogs:      opts.JobLogStorage,
+		artefacts:    opts.JobArtefactStorage,
 		repositories: opts.RepositoryStorage,
 		templates:    templates,
 	}, nil
@@ -57,9 +62,16 @@ func NewHandlers(opts Options) (*Handlers, error) {
 // that is not enumerable in practice, and the point of printing one in
 // a terminal is that pasting it into a browser just works. Run the
 // server behind your own auth if the output is sensitive.
+// The artefact download shares that trust model rather than a weaker or
+// a stronger one. A file a job produced is no more sensitive than the
+// output that produced it, and a download link on a page that needs no
+// session must not be a link that fails: a browser has no bearer token
+// to offer. `GET /api/job/{id}/artefact/{id}` is the authenticated door
+// for scripts.
 func (h *Handlers) Mount(r platform.Router) {
 	r.Get("/", h.Index)
 	r.Get("/job/{jobID}", h.Job)
+	r.Get("/job/{jobID}/artefact/{artefactID}", h.Artefact)
 }
 
 // JobPage is the view model for the job page.
@@ -68,6 +80,7 @@ type JobPage struct {
 	Repository *model.Repository
 	Children   []model.Job
 	Log        []model.JobLog
+	Artefacts  []model.JobArtefact
 
 	// Refresh is the auto-reload interval in seconds. Zero for a
 	// settled job, which never changes again.
@@ -114,11 +127,35 @@ func (h *Handlers) Job(w http.ResponseWriter, r *http.Request) {
 	if entries, err := h.jobLogs.List(ctx, job.ID); err == nil {
 		page.Log = entries
 	}
+	if artefacts, err := h.artefacts.List(ctx, job.ID); err == nil {
+		page.Artefacts = artefacts
+	}
 	if children, err := h.jobs.List(ctx, storage.ListFilter{RootID: job.RootID}); err == nil {
 		page.Children = childrenOf(children, job.ID)
 	}
 
 	h.render(w, r, "job.html", page)
+}
+
+// Artefact serves the bytes of one artefact, as a download.
+func (h *Handlers) Artefact(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	artefact, err := h.artefacts.Get(ctx, platform.URLParam(r, "jobID"), platform.URLParam(r, "artefactID"))
+	if err != nil {
+		h.fail(w, r, http.StatusNotFound, errors.New("no such artefact"))
+		return
+	}
+
+	contents, err := h.artefacts.Open(ctx, artefact)
+	if err != nil {
+		// The row outlives its bytes once retention has swept them.
+		h.fail(w, r, http.StatusNotFound, errors.New("this artefact has been removed by retention"))
+		return
+	}
+	defer contents.Close()
+
+	api.WriteArtefact(w, artefact, contents)
 }
 
 // childrenOf filters the job tree down to direct children.
@@ -158,7 +195,27 @@ func functions() template.FuncMap {
 	return template.FuncMap{
 		"stamp":    stamp,
 		"duration": duration,
+		"filesize": filesize,
 	}
+}
+
+// filesize renders a byte count the way a person reads one.
+func filesize(size int64) string {
+	const unit = 1024
+
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+
+	value := float64(size)
+	for _, suffix := range []string{"KB", "MB", "GB", "TB"} {
+		value /= unit
+		if value < unit {
+			return fmt.Sprintf("%.1f %s", value, suffix)
+		}
+	}
+
+	return fmt.Sprintf("%.1f PB", value/unit)
 }
 
 // stamp formats a nullable timestamp.

--- a/server/web/web_test.go
+++ b/server/web/web_test.go
@@ -83,6 +83,41 @@ func TestJobPageEscapesOutput(t *testing.T) {
 	assert.Contains(t, out.String(), "&lt;script&gt;")
 }
 
+func TestJobPageListsArtefacts(t *testing.T) {
+	handlers, err := NewHandlers(Options{})
+	require.NoError(t, err)
+
+	job := &model.Job{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Status: model.JobStatusPassed, Command: "atkins scan"}
+
+	var out strings.Builder
+	err = handlers.templates.ExecuteTemplate(&out, "job.html", &JobPage{
+		Job: job,
+		Artefacts: []model.JobArtefact{{
+			ID:          "01J000000000000000000ART1",
+			JobID:       job.ID,
+			Path:        "reports/scan.json",
+			Size:        2048,
+			ContentType: "application/json",
+		}},
+	})
+	require.NoError(t, err)
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "reports/scan.json")
+	assert.Contains(t, rendered, "2.0 KB")
+	// The link a browser can follow: no bearer token to offer, so it
+	// is the page's own route rather than the API's.
+	assert.Contains(t, rendered, "/job/"+job.ID+"/artefact/01J000000000000000000ART1")
+}
+
+func TestFilesize(t *testing.T) {
+	assert.Equal(t, "0 B", filesize(0))
+	assert.Equal(t, "512 B", filesize(512))
+	assert.Equal(t, "1.0 KB", filesize(1024))
+	assert.Equal(t, "1.5 MB", filesize(1536*1024))
+	assert.Equal(t, "2.0 GB", filesize(2*1024*1024*1024))
+}
+
 func TestStamp(t *testing.T) {
 	assert.Equal(t, "—", stamp(nil))
 

--- a/worker/artefact.go
+++ b/worker/artefact.go
@@ -1,0 +1,237 @@
+package worker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"mime"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/titpetric/atkins/client"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// Limits on one job's collection. The server enforces its own, from the
+// setting registry; these keep a runaway pipeline from turning into
+// thousands of pointless requests before the server says no.
+const (
+	// maxCollected bounds how many files one job may offer.
+	maxCollected = 200
+
+	// uploadTimeout bounds a single artefact transfer.
+	uploadTimeout = 5 * time.Minute
+)
+
+// candidate is one file to upload.
+type candidate struct {
+	// path is the name the artefact is stored under, relative to the
+	// directory the job ran in.
+	path string
+
+	// source is where the file actually is on this agent.
+	source string
+}
+
+// collect uploads what the job produced and reports how many artefacts
+// the server accepted.
+//
+// It runs whether the command passed or failed, on purpose: the files
+// produced by a failure — a coverage report, a scan that found
+// something, a core dump — are usually the ones worth having.
+func (w *Worker) collect(ctx context.Context, job *jobContext, workspace *Workspace) int {
+	candidates := w.candidates(job, workspace)
+	if len(candidates) == 0 {
+		return 0
+	}
+
+	// The job's own deadline has usually just expired when it timed
+	// out, and the artefacts of a timeout are worth as much as any
+	// others.
+	ctx = context.WithoutCancel(ctx)
+
+	uploaded := 0
+	for _, item := range candidates {
+		if err := w.upload(ctx, job.Job.ID, item); err != nil {
+			w.appendLog(ctx, job.Job.ID, client.StreamError,
+				fmt.Sprintf("artefact %s was not stored: %v\n", item.path, err))
+			log.Printf("[agent] job %s: artefact %s failed: %v", job.Job.ID, item.path, err)
+			continue
+		}
+		uploaded++
+	}
+
+	if uploaded > 0 {
+		log.Printf("[agent] job %s: stored %d artefact(s)", job.Job.ID, uploaded)
+	}
+
+	return uploaded
+}
+
+// upload streams one file to the server.
+func (w *Worker) upload(ctx context.Context, jobID string, item candidate) error {
+	checksum, err := checksumFile(item.source)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Open(item.source)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, uploadTimeout)
+	defer cancel()
+
+	_, err = w.client.UploadArtefact(ctx, jobID, client.ArtefactUpload{
+		Path:        item.path,
+		ContentType: contentType(item.path),
+		Checksum:    checksum,
+		Content:     file,
+	})
+	return err
+}
+
+// candidates gathers the files a job asked to keep, from the two places
+// a job can put them.
+func (w *Worker) candidates(job *jobContext, workspace *Workspace) []candidate {
+	found := map[string]string{}
+
+	// The output directory: everything a job copied into
+	// $ATKINS_ARTEFACTS, named by its path within that directory.
+	walkTree(workspace.Artefacts, nil, found)
+
+	// The declared globs, matched against the checkout the command ran
+	// in. A job that already writes coverage.json where it writes it
+	// can be collected without editing the pipeline.
+	if patterns := model.ArtefactPatterns(job.Job.ArtefactPaths); len(patterns) > 0 {
+		walkTree(workspace.Dir, patterns, found)
+	}
+
+	paths := make([]string, 0, len(found))
+	for name := range found {
+		paths = append(paths, name)
+	}
+	sort.Strings(paths)
+
+	if len(paths) > maxCollected {
+		log.Printf("[agent] job %s: %d files matched, uploading the first %d",
+			job.Job.ID, len(paths), maxCollected)
+		paths = paths[:maxCollected]
+	}
+
+	candidates := make([]candidate, 0, len(paths))
+	for _, name := range paths {
+		candidates = append(candidates, candidate{path: name, source: found[name]})
+	}
+	return candidates
+}
+
+// walkTree collects files under root into found, keyed by their path
+// relative to root. A nil patterns list takes everything.
+//
+// Collection walks the tree rather than expanding the patterns into
+// paths. That is the difference between a pattern that can only select
+// among files that are already inside the checkout, and one that gets
+// handed to the filesystem and can name `../../etc/passwd`. WalkDir
+// does not follow symlinks either, so a link planted in a repository
+// cannot widen the walk to somewhere else on the agent.
+func walkTree(root string, patterns []string, found map[string]string) {
+	if strings.TrimSpace(root) == "" {
+		return
+	}
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return
+	}
+
+	_ = filepath.WalkDir(root, func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			// An unreadable directory is not worth failing the job for;
+			// the rest of the tree is still collectable.
+			return nil
+		}
+
+		if entry.IsDir() {
+			// Never the repository's own object store: it is large, it
+			// is not an output, and nobody asked for it.
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only regular files: a symlink, a socket or a device is not an
+		// artefact, and following one is how a walk leaves its tree.
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+
+		relative, err := filepath.Rel(root, name)
+		if err != nil {
+			return nil
+		}
+
+		stored := model.ArtefactPath(filepath.ToSlash(relative))
+		if stored == "" {
+			return nil
+		}
+		if !matchesAny(patterns, stored) {
+			return nil
+		}
+
+		// First writer wins, so an explicitly staged file is not
+		// replaced by a glob match with the same name.
+		if _, taken := found[stored]; !taken {
+			found[stored] = name
+		}
+		return nil
+	})
+}
+
+// matchesAny reports whether a path is wanted. No patterns means the
+// whole tree was asked for.
+func matchesAny(patterns []string, value string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+
+	for _, pattern := range patterns {
+		if model.MatchArtefactPath(pattern, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// checksumFile hashes a file so the server can tell a complete upload
+// from a truncated one.
+func checksumFile(name string) (string, error) {
+	file, err := os.Open(name)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// contentType guesses a media type from the file extension. The server
+// falls back to application/octet-stream for anything unrecognized, so
+// a guess that fails costs nothing.
+func contentType(name string) string {
+	return mime.TypeByExtension(path.Ext(name))
+}

--- a/worker/artefact_test.go
+++ b/worker/artefact_test.go
@@ -1,0 +1,180 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/client"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// collecting returns a jobContext that also declares artefact patterns.
+func collecting(remote, workingDirectory, command, patterns string) *jobContext {
+	job := job(remote, workingDirectory, command)
+	job.Job.ArtefactPaths = patterns
+	return job
+}
+
+func TestCollectUploadsTheOutputDirectory(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	// The zero-configuration declaration: whatever the job copies into
+	// $ATKINS_ARTEFACTS is kept.
+	worker.run(t.Context(), job(remote, "",
+		`mkdir -p "$ATKINS_ARTEFACTS/reports" && echo '{"findings":3}' > "$ATKINS_ARTEFACTS/reports/scan.json"`))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status)
+
+	uploaded := fake.stored()
+	require.Contains(t, uploaded, "reports/scan.json")
+	assert.JSONEq(t, `{"findings":3}`, string(uploaded["reports/scan.json"]))
+}
+
+func TestCollectMatchesDeclaredPatterns(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	// A pipeline that knows nothing about artefacts: the files are
+	// written where the command already writes them, and the job says
+	// what to pick up.
+	worker.run(t.Context(), collecting(remote, "",
+		`echo '{"ok":true}' > coverage.json; mkdir -p out; echo report > out/summary.txt; echo noise > noise.log`,
+		"*.json,out/*.txt"))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status)
+
+	uploaded := fake.stored()
+	assert.Contains(t, uploaded, "coverage.json")
+	assert.Contains(t, uploaded, "out/summary.txt")
+	assert.NotContains(t, uploaded, "noise.log")
+
+	// The checkout's own object store is never an output.
+	for path := range uploaded {
+		assert.NotContains(t, path, ".git/")
+	}
+}
+
+func TestCollectRunsAfterAFailure(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	// The artefacts of a failing run are the ones worth having, so
+	// collection is not conditional on the exit code.
+	worker.run(t.Context(), collecting(remote, "",
+		`echo 'stack trace' > crash.log; exit 3`, "*.log"))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusFailed, status.Status)
+	assert.Equal(t, int64(3), status.ExitCode)
+
+	uploaded := fake.stored()
+	require.Contains(t, uploaded, "crash.log")
+	assert.Contains(t, string(uploaded["crash.log"]), "stack trace")
+}
+
+func TestCollectRunsAfterATimeout(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+	worker.opts.JobTimeout = 500 * time.Millisecond
+
+	worker.run(t.Context(), collecting(remote, "",
+		`echo 'partial' > progress.log; sleep 30`, "*.log"))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusTimeout, status.Status)
+
+	// The job's context has expired by now: collection must not be
+	// cancelled with it, or a timeout would lose exactly the output
+	// that explains it.
+	assert.Contains(t, fake.stored(), "progress.log")
+}
+
+func TestCollectStaysInsideTheWorkspace(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("not yours"), 0o600))
+
+	// A traversal pattern, and a symlink pointing out of the checkout.
+	// Collection walks the tree rather than expanding patterns against
+	// the filesystem, so neither can name a file outside it.
+	worker.run(t.Context(), collecting(remote, "",
+		"ln -s "+secret+" link.txt; echo mine > kept.txt",
+		"../../*,/etc/*,**/*.txt"))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status)
+
+	uploaded := fake.stored()
+	assert.Contains(t, uploaded, "kept.txt")
+	assert.NotContains(t, uploaded, "link.txt")
+	for _, content := range uploaded {
+		assert.NotContains(t, string(content), "not yours")
+	}
+}
+
+func TestCollectUploadsNothingWhenNothingWasProduced(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	worker.run(t.Context(), collecting(remote, "", "echo hello", "*.json"))
+
+	_, status := fake.result()
+	require.Equal(t, client.StatusPassed, status.Status)
+	assert.Empty(t, fake.stored())
+}
+
+func TestCollectCleansUpTheOutputDirectory(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	worker.run(t.Context(), job(remote, "", `echo kept > "$ATKINS_ARTEFACTS/kept.txt"`))
+
+	require.Contains(t, fake.stored(), "kept.txt")
+
+	// The staged copy would fill the agent's disk if it outlived the
+	// job, exactly as the work tree would.
+	entries, err := os.ReadDir(filepath.Join(worker.opts.DataDir, "work"))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestCollectReportsAFailedUpload(t *testing.T) {
+	remote := gitRepository(t).Path
+	fake := newAgentServer(t, client.PolicyResponse{Policy: model.PolicyOpen})
+	worker := testWorker(t, fake)
+
+	// The server refuses everything: a rejected artefact is reported in
+	// the job's output rather than swallowed, and it does not change
+	// the outcome of the command.
+	fake.refuseArtefacts = true
+
+	worker.run(t.Context(), collecting(remote, "", "echo mine > kept.txt", "*.txt"))
+
+	output, status := fake.result()
+	assert.Equal(t, client.StatusPassed, status.Status)
+	assert.Contains(t, output, "kept.txt was not stored")
+}
+
+func TestContentTypeFromExtension(t *testing.T) {
+	assert.Contains(t, contentType("reports/scan.json"), "application/json")
+	// Unrecognized is left empty; the server applies its own default
+	// rather than the agent guessing wrong.
+	assert.Empty(t, contentType("core.dump-42"))
+}

--- a/worker/execute.go
+++ b/worker/execute.go
@@ -81,6 +81,7 @@ func (w *Worker) environment(job *jobContext, workspace *Workspace) []string {
 		client.EnvRootJobID+"="+job.Job.RootID,
 		"ATKINS_AGENT_ID="+w.opts.AgentID,
 		"ATKINS_WORKSPACE="+workspace.Root,
+		client.EnvArtefacts+"="+workspace.Artefacts,
 	)
 
 	if job.Job.ParentID != "" {

--- a/worker/repository.go
+++ b/worker/repository.go
@@ -22,6 +22,11 @@ type Workspace struct {
 
 	// Checkout is what the work tree ended up at.
 	Checkout Checkout
+
+	// Artefacts is the directory the job copies files into to have them
+	// kept. It sits beside the work tree rather than inside it, so
+	// staging a file does not dirty the checkout the job is testing.
+	Artefacts string
 }
 
 // Checkout records what the agent actually put in the work tree.
@@ -73,8 +78,20 @@ func (w *Worker) prepare(ctx context.Context, job *jobContext) (*Workspace, erro
 		}
 	}
 
-	return &Workspace{Root: root, Dir: dir, Checkout: *checkout}, nil
+	// The output directory exists before the command starts, so a
+	// pipeline can copy into it without first testing whether it is
+	// there.
+	artefacts := root + artefactSuffix
+	if err := os.MkdirAll(artefacts, 0o755); err != nil {
+		return nil, fmt.Errorf("create artefact directory: %w", err)
+	}
+
+	return &Workspace{Root: root, Dir: dir, Checkout: *checkout, Artefacts: artefacts}, nil
 }
+
+// artefactSuffix names the output directory beside a job's work tree,
+// so one cleanup pass over <data>/work removes both.
+const artefactSuffix = ".artefacts"
 
 // CleanWorkingDirectory normalizes a job's working directory into a
 // clean path relative to the repository root, or "" for the root.

--- a/worker/run_test.go
+++ b/worker/run_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -102,12 +103,20 @@ type agentServer struct {
 	statusSeen bool
 	checkout   client.JobCheckoutRequest
 	heartbeats int
+
+	// artefacts records what was uploaded, keyed by the path the agent
+	// declared.
+	artefacts map[string][]byte
+
+	// refuseArtefacts turns every upload into a 422, standing in for a
+	// server that has hit its per-job limit.
+	refuseArtefacts bool
 }
 
 func newAgentServer(t *testing.T, policy client.PolicyResponse) *agentServer {
 	t.Helper()
 
-	fake := &agentServer{}
+	fake := &agentServer{artefacts: map[string][]byte{}}
 
 	fake.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fake.mu.Lock()
@@ -131,6 +140,23 @@ func newAgentServer(t *testing.T, policy client.PolicyResponse) *agentServer {
 		case r.URL.Path == "/api/agent/ssh-key":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]client.AgentSSHKey{})
+
+		case strings.HasSuffix(r.URL.Path, "/artefact"):
+			body, _ := io.ReadAll(r.Body)
+			if fake.refuseArtefacts {
+				http.Error(w, "job has reached artefact.max_count", http.StatusUnprocessableEntity)
+				return
+			}
+			fake.artefacts[r.URL.Query().Get("path")] = body
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(client.Artefact{
+				ID:          "artefact-1",
+				Path:        r.URL.Query().Get("path"),
+				Size:        int64(len(body)),
+				ContentType: r.Header.Get("Content-Type"),
+				Checksum:    r.Header.Get(client.HeaderArtefactChecksum),
+			})
 
 		case strings.HasSuffix(r.URL.Path, "/log"):
 			var req client.JobLogRequest
@@ -175,6 +201,18 @@ func (f *agentServer) checkedOut() client.JobCheckoutRequest {
 	defer f.mu.Unlock()
 
 	return f.checkout
+}
+
+// stored reports the artefacts the server accepted.
+func (f *agentServer) stored() map[string][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	uploaded := make(map[string][]byte, len(f.artefacts))
+	for path, content := range f.artefacts {
+		uploaded[path] = content
+	}
+	return uploaded
 }
 
 // testWorker enrols an agent against the fake server.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -210,8 +210,10 @@ func (w *Worker) run(ctx context.Context, job *jobContext) {
 	w.recordCheckout(ctx, job.Job.ID, workspace.Checkout)
 
 	defer func() {
-		if err := os.RemoveAll(workspace.Root); err != nil {
-			log.Printf("[agent] job %s: cleanup failed: %v", job.Job.ID, err)
+		for _, dir := range []string{workspace.Root, workspace.Artefacts} {
+			if err := os.RemoveAll(dir); err != nil {
+				log.Printf("[agent] job %s: cleanup failed: %v", job.Job.ID, err)
+			}
 		}
 	}()
 
@@ -224,6 +226,10 @@ func (w *Worker) run(ctx context.Context, job *jobContext) {
 	case result.ExitCode != 0:
 		status = client.StatusFailed
 	}
+
+	// Collect before settling the job: the lease is still held, and a
+	// page that says `passed` should not then grow files for a while.
+	w.collect(ctx, job, workspace)
 
 	w.report(ctx, job.Job.ID, client.JobStatusRequest{
 		Status:   status,


### PR DESCRIPTION
Closes #28

A job can now push files back. `job_artefact` records what a file is, `server/blob` holds the bytes, the agent collects after the command exits, and the job page lists what came back.

```bash
curl -sS -X POST -H "Authorization: Bearer $TOKEN" "$SERVER/api/repository/$REPO/trigger" \
  -d '{"job": "scan", "artefacts": ["reports/*.json"]}'

curl -sS -H "Authorization: Bearer $TOKEN" "$SERVER/api/job/$JOB/artefact" |
  jq -r '.[] | "\(.path)\t\(.size)\t\(.checksum)"'
```

## Where the bytes live

Split in two, on purpose. The database records what an artefact is — job, path, size, media type, SHA256, agent — and `server/blob` holds the file under `<root>/<job-id>/<artefact-id>`. The row carries a `storage_key`, never a filesystem path, so the only thing an S3 backend has to implement is `Put`, `Open`, `Remove` over a key namespace: no SQL, no handler, no change to the API.

A directory is the right first backend and probably the right one for most installs. The database is already on a disk, artefacts are written once and read rarely, and a directory is something an operator can back up, rsync or put on a volume without asking anybody for a bucket. Grouping by job means retention drops a job's files as a directory and no single directory grows to a million entries.

Uploads are a raw body with `?path=` and `Content-Type` rather than multipart: there is one part, and the two fields around it fit in a query parameter and a header. It streams from the agent's disk to the server's, hashed on the way past, written to a `.part` file and renamed — so a refused or interrupted upload can never be read as a truncated artefact. `X-Atkins-Checksum` is compared against what actually arrived, which is how a short upload becomes a 400 instead of a file nobody can use.

`JobArtefactStorage` owns both halves so they can't drift: bytes before the row, bytes removed if the insert fails, and on retention bytes first then the soft delete — the surviving failure mode is a row that reads as "swept", not a file nothing will ever clean up.

## How a pipeline declares what to collect

Both of the options the issue floated, because they answer different questions.

**`$ATKINS_ARTEFACTS`** — the agent creates a directory beside the work tree, exports it, and uploads whatever is in it. `cp scan.json "$ATKINS_ARTEFACTS/"` is the whole interface: no schema, no parser, no atkins-specific file, works for any command in any language. It is beside the checkout rather than inside it so staging a file doesn't dirty the tree the job is testing.

**A glob on dispatch/trigger** — stored on `job.artefact_paths`. This is the one that matters for #26's actual use case: a cron triggers `analyzeTag` a hundred times and wants the JSON back, without editing a pipeline it may not own. `{"job": "test", "artefacts": ["coverage.json"]}` collects from a pipeline that has never heard of artefacts. A retry inherits the patterns, or the re-run of a failed job would come back without the files that explain it.

I did not put this in a `.atkins/` convention file. The pipeline already has a place to say "keep this" — the step that writes it — and a second declaration file would need the agent to parse the pipeline it is only supposed to run.

Collection happens **after the command exits, whatever it exited with**, including a timeout: it uses a context detached from the job's deadline, so a job killed at its timeout still ships the log that explains why. It runs before the terminal status report, so a page that says `passed` doesn't then grow files for a few seconds.

The agent **walks the tree and matches what it finds**, rather than expanding patterns against the filesystem. That is the difference between a pattern that can only select among files already in the checkout and one that can name `../../etc/passwd`. `WalkDir` doesn't follow symlinks, so a link planted in a repository can't widen the walk either; `.git` is skipped; only regular files are considered. Patterns are also normalized when the job is created, so a traversal never reaches the agent in the first place.

## Retention

`artefact.retention`, falling back to `job.retention` when it is `0`. Wiring artefacts to `job.retention` alone would have been wrong in practice: bytes are the expensive half, and keeping a year of job history while keeping a week of files is a normal thing to want — the reverse never is. The sweep rides the existing lease-reclaim ticker (same kind of work, one background goroutine), reads its setting on every pass because the moment retention matters is the moment a disk is filling, and that is the worst moment to need a restart. `job.retention` still sweeps nothing else; jobs and logs are unchanged.

## Where this differs from the issue

- **A second declaration mechanism.** The issue asked for one and named the glob as the obvious candidate. The glob alone would mean every artefact-producing pipeline has to be dispatched with the right patterns; the directory alone would mean editing any pipeline you want output from. They cost one collector between them.
- **`artefact.retention` as well as `job.retention`.** The issue said "wire them into `job.retention` or explain why they need their own" — argued above. `0` follows the job, so an instance that only sets `job.retention` behaves exactly as the issue asked.
- **Two download routes, and I'd like a second opinion on it.** `GET /api/job/{id}/artefact/{id}` requires an authenticated user, as the issue asked. But the job page needs no session — a printed ULID is the capability, which is the trade #27 already made for job output — and a browser has no bearer token to offer, so an authenticated-only download would have put a link on the page that 401s. `GET /job/{id}/artefact/{id}` serves the same bytes on the same terms as the page that lists them. The honest framing: artefacts are exactly as protected as the output that produced them. If that is wrong, the fix is to protect the page, not to leave a link that doesn't work.
- **A new setting kind.** `artefact.max_size` is `32MB`, not `33554432`. `KindBytes` parses `B/KB/MB/GB` in powers of 1024 and refuses overflow, so a bad value is a 400 rather than a limit that silently wraps negative.
- **Status codes.** Oversize is 413, too many is 422 — matching how the runaway-nesting limit already reports itself. Re-uploading a path replaces it rather than adding to it, so a collection that runs twice leaves one `scan.json` and doesn't spend the count limit on duplicates.
- **Uploads are not gated on the job still running.** Tempting, and wrong: a job the server has already reclaimed as `timeout` is exactly the one whose files you want. The count and size limits bound the damage instead.

## Tests

1264 tests, `atkins test:simple` green, `atkins fmt` run, schema regenerated with the `mig` skill.

New coverage: `server/blob` 96.7%, `server/api` 85.2% (artefact handlers 85–100%), `server/storage`, `worker` 82.7%, `server` 89.1%. Storage is tested directly against sqlite and a real blob root, the endpoints over HTTP, and the agent's collect-and-upload path against a real git repository and a fake server.

The failure cases the issue named all have a test: oversize (413, and nothing half-stored), too many (422), traversal in the declared path (400 at the API, dropped at dispatch, and structurally impossible in the agent), upload for an unknown job (404), upload by a non-agent (403) and by nobody (401). Plus checksum mismatch, cross-job artefact IDs, replacement, retention sweeping bytes while the row survives, and collection after a failure and after a timeout.

## Verified end to end

`atkins up`, `atkins --register`, `atkins test:docs` dispatched; then a triggered job producing `reports/scan.json` (glob) and `staged.json` (directory) — both stored, `noise.log` correctly not; downloads over both routes with `attachment` and `nosniff`; the job page listing both with working links; bytes on disk at `/app/data/artefacts/<job>/<artefact>` and the agent's work directory empty afterwards; a job exiting 3 still uploading its `crash.log`; and with `artefact.retention: 1s`, `swept 3 artefact(s) older than 1s` with the files gone from the disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
