### PR TITLE
Scope artefact list and download to the job's visibility

### DIFF
--- a/server/api/artefact.go
+++ b/server/api/artefact.go
@@ -121,11 +121,21 @@ func (s *Handlers) ListArtefacts(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) listArtefacts(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
 		return err
 	}
 
-	artefacts, err := s.artefacts.List(r.Context(), platform.URLParam(r, "jobID"))
+	// The files a job produced are read on the same terms as the job
+	// itself, so the job is loaded and scoped first. Listing is the
+	// cheapest way to learn an artefact ID, and a scoped ledger with an
+	// open index is not scoped at all.
+	job, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
+	if err != nil {
+		return err
+	}
+
+	artefacts, err := s.artefacts.List(r.Context(), job.ID)
 	if err != nil {
 		return err
 	}
@@ -149,12 +159,21 @@ func (s *Handlers) DownloadArtefact(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) downloadArtefact(w http.ResponseWriter, r *http.Request) error {
-	if _, _, err := s.authenticateUser(r); err != nil {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
+		return err
+	}
+
+	// A job the caller may not read is a 404 here too — an artefact
+	// holds the built binary, the scan output and the coverage report,
+	// which is the half of a run worth guessing an ID for.
+	job, err := s.readableJob(r, user, platform.URLParam(r, "jobID"))
+	if err != nil {
 		return err
 	}
 
 	artefact, err := s.artefacts.Get(r.Context(),
-		platform.URLParam(r, "jobID"), platform.URLParam(r, "artefactID"))
+		job.ID, platform.URLParam(r, "artefactID"))
 	if err != nil {
 		return mapArtefactError(err)
 	}

--- a/server/artefact_test.go
+++ b/server/artefact_test.go
@@ -385,6 +385,45 @@ func TestArtefactDownloadNeedsAuthentication(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, status)
 }
 
+func TestArtefactsAreScopedLikeTheJob(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	job := dispatch(t, url, admin.Token, "atkins scan", "")
+
+	var stored artefactView
+	status := uploadArtefact(t, url, agent.Token, job.JobID, artefactUpload{
+		Path:    "scan.json",
+		Content: []byte(`{"findings": 3}`),
+	}, &stored)
+	require.Equal(t, http.StatusCreated, status)
+
+	// An account that has never seen the job is told the same thing the
+	// job endpoint tells it: nothing here. Authentication alone is not
+	// the bar, or the artefact is the way around a scoped ledger.
+	status, _, _ = fetch(t, url+"/api/job/"+job.JobID+"/artefact", dev.Token)
+	assert.Equal(t, http.StatusNotFound, status)
+
+	status, body, _ := fetch(t, url+stored.URL, dev.Token)
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.NotContains(t, string(body), "findings")
+
+	// The person who dispatched it reads it as before.
+	status, body, _ = fetch(t, url+stored.URL, admin.Token)
+	require.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"findings": 3}`, string(body))
+
+	// And a public instance is shared again, artefacts included.
+	setSetting(t, url, admin.Token, model.SettingJobVisibility, model.VisibilityPublic)
+
+	require.Len(t, artefacts(t, url, dev.Token, job.JobID), 1)
+
+	status, _, _ = fetch(t, url+stored.URL, dev.Token)
+	assert.Equal(t, http.StatusOK, status)
+}
+
 func TestArtefactBelongsToOneJob(t *testing.T) {
 	url := testServer(t)
 	admin := register(t, url)


### PR DESCRIPTION
Fixes #36.

`job.visibility` was enforced on the job, its log, retry and cancel, but not on the two artefact endpoints — they authenticated the caller and went straight to storage. On a private instance that left the ledger scoped and the files open: an account that gets a 404 for `/api/job/{id}` could still list and download that job's built binaries, scan output and coverage reports. Job IDs are ULIDs, and the 404-not-403 rule everywhere else exists precisely so IDs cannot be probed.

## Change

`listArtefacts` and `downloadArtefact` now load the job through `readableJob`, the same helper `log.go`, `dispatch.go` and `trigger.go` use, so a job the caller may not read is a 404 and the artefact under it is unreachable. Both then key off `job.ID` rather than the raw URL parameter.

Uploads are untouched — that is the agent's door, guarded by `requireAgent`.

## Test

`TestArtefactsAreScopedLikeTheJob`: an unrelated registered account gets 404 on both the listing and the download (and the body does not carry the artefact's contents), the dispatcher still reads both, and flipping `job.visibility` to `public` shares them again. The existing `TestArtefactDownloadNeedsAuthentication` only proved an anonymous caller is refused.

`atkins test:simple` passes: 1369 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)