### PR TITLE
Record dispatched jobs as `atkins`, not as argv[0]

### DIFF
--- a/client/dispatch.go
+++ b/client/dispatch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -155,20 +154,31 @@ func DispatchDisabled() bool {
 
 // Command renders an argv as the command to record.
 //
-// argv[0] is reduced to its base name: the recorded command is re-run
-// on another machine, and `/home/tit/go/bin/atkins` says more about
-// this laptop than about the job.
+// argv[0] is replaced with `atkins` rather than reduced to its base
+// name: the recorded command is re-run on another machine, where the
+// binary is called `atkins`, and what this one happens to be named is a
+// fact about this laptop. A build under test as `./bin/atkins-linux-amd64`,
+// the `atkins.old` the install job leaves behind, or a distro package
+// named `atkins-cli` would otherwise queue a command no agent can run,
+// and the job comes back as exit 127 with an empty log.
+//
+// A run of something other than atkins is what the explicit `command`
+// override on the trigger endpoint is for.
 func Command(argv []string) string {
 	if len(argv) == 0 {
-		return "atkins"
+		return commandName
 	}
 
 	command := make([]string, len(argv))
 	copy(command, argv)
-	command[0] = filepath.Base(command[0])
+	command[0] = commandName
 
 	return strings.Join(command, " ")
 }
+
+// commandName is what an agent invokes, whatever the local binary is
+// called.
+const commandName = "atkins"
 
 // Labels returns the labels constraining which agents may run this
 // machine's jobs.

--- a/client/repository_test.go
+++ b/client/repository_test.go
@@ -92,6 +92,15 @@ func TestLabels(t *testing.T) {
 func TestCommand(t *testing.T) {
 	assert.Equal(t, "atkins", client.Command(nil))
 	assert.Equal(t, "atkins test:build", client.Command([]string{"/usr/local/bin/atkins", "test:build"}))
+
+	// The agent runs `atkins`, so that is what the job records however
+	// the local binary is named. A build under test, the `atkins.old`
+	// the install job leaves behind or a distro's `atkins-cli` would
+	// otherwise queue a command the agent cannot find, and the job comes
+	// back as exit 127 with nothing in the log.
+	assert.Equal(t, "atkins test:build", client.Command([]string{"./bin/atkins-linux-amd64", "test:build"}))
+	assert.Equal(t, "atkins test:docs", client.Command([]string{"/tmp/atkins-main", "test:docs"}))
+	assert.Equal(t, "atkins", client.Command([]string{"/usr/local/bin/atkins.old"}))
 }
 
 func TestDispatchSkipsWithoutCredentials(t *testing.T) {


### PR DESCRIPTION
Fixes #39.

`client.Command` reduced `argv[0]` to its base name, so the job recorded whatever the local binary happened to be called. Run a build that is not literally named `atkins` and the queued command is one no agent can run — the job comes back `exit_code: 127` with an empty log, because `sh` writes "not found" to its own stderr before the command starts, and the client prints a URL and exits 0 either way.

Not contrived: `./bin/atkins-linux-amd64 test` while checking a build, the `atkins.old` / `atkins.new` pair this repo's own `install` job leaves in `/usr/local/bin`, a wrapper or vendored copy under another name, or a distro packaging it as `atkins-cli`.

## Change

`command[0]` is now the constant `atkins`. The field means "the atkins invocation", as the docs describe it, rather than "argv[0]". A caller that genuinely needs a different program has the explicit `command` override on the trigger endpoint.

## Test

`TestCommand` covers a build under test (`./bin/atkins-linux-amd64`), a renamed copy (`/tmp/atkins-main`) and the bare `atkins.old` the install job leaves behind — all record `atkins`.

`atkins test:simple` passes: 1369 tests.

## Not in this PR

The issue also suggests, as an explicitly unrelated improvement, that exit 127 with no captured output could carry a hint on the job page — "the agent could not find the command" is otherwise indistinguishable from "the build printed nothing and failed". That touches the web layer and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)