### PR TITLE
Make the artefact retention sweep test deterministic

### DIFF
--- a/server/artefact_test.go
+++ b/server/artefact_test.go
@@ -502,7 +502,11 @@ func TestArtefactRetentionSweepsTheBytes(t *testing.T) {
 	admin := register(t, url)
 	agent := enrol(t, url, "agent-1")
 
-	setSetting(t, url, admin.Token, model.SettingArtefactRetention, "1ms")
+	// Kept long enough that no tick can take the file before the
+	// assertion below has seen it. Uploading with a 1ms window instead
+	// made "the bytes are there" a race against the ticker, one the
+	// full suite under load loses.
+	setSetting(t, url, admin.Token, model.SettingArtefactRetention, "1h")
 
 	job := dispatch(t, url, admin.Token, "atkins scan", "")
 
@@ -514,6 +518,11 @@ func TestArtefactRetentionSweepsTheBytes(t *testing.T) {
 	require.Equal(t, http.StatusCreated, status)
 
 	require.FileExists(t, filepath.Join(root, job.JobID, stored.ID))
+
+	// Retention is read on every pass, so shortening it here is what
+	// the setting is for — and it starts the window at a point the test
+	// controls rather than at the upload.
+	setSetting(t, url, admin.Token, model.SettingArtefactRetention, "1ms")
 
 	// The sweep is on a ticker, so wait for it rather than for a
 	// fixed sleep to be long enough.

--- a/server/server.go
+++ b/server/server.go
@@ -201,6 +201,10 @@ func (m *Module) Stop(context.Context) error {
 // background goroutine is easier to reason about than one with two.
 func (m *Module) startReclaim(ctx context.Context) {
 	m.sweep(ctx, m.opts.ReclaimInterval, func(ctx context.Context) error {
+		// Deferred rather than sequential: a reclaim that fails is no
+		// reason to leave expired bytes on the disk for another tick.
+		defer m.pruneArtefacts(ctx)
+
 		reclaimed, err := m.jobs.ReclaimExpired(ctx)
 		if err != nil {
 			return err
@@ -276,8 +280,6 @@ func (m *Module) sweep(ctx context.Context, interval time.Duration, work func(co
 				if err := work(ctx); err != nil {
 					telemetry.CaptureError(ctx, err)
 				}
-
-				m.pruneArtefacts(ctx)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #42.

`TestArtefactRetentionSweepsTheBytes` set `artefact.retention` to `1ms` *before* uploading, so the artefact was expired the moment it landed. The `require.FileExists` on the next line then held only while fewer than 50ms passed between the upload response and the assertion — a race against the test's own 50ms ticker, which the full suite under load loses.

## Change

`server/artefact_test.go`: upload under a `1h` window nothing can sweep, assert the bytes are on disk, *then* shorten `artefact.retention` to `1ms` and wait for the tick. `pruneArtefacts` reads the setting on every pass, so changing it mid-test is what the setting supports, and the window now starts where the test says it does. The assertion itself is kept — "the bytes were there and then they weren't" is the point of the test.

`server/server.go`: `pruneArtefacts` was called from `sweep()`, the helper both `startReclaim` and `startRetention` use, so on a default server artefact pruning ran on the 1m lease ticker *and* the 1h retention ticker. It is idempotent, so this was redundancy rather than a bug — but `docs/content/usage/ci-cd.md` says "the sweep runs on the same ticker as the lease reclaim", and now it does. It is deferred inside the reclaim pass rather than sequential, so a failing reclaim does not leave expired bytes on disk for another tick.

## Test

`atkins test:simple` run twice, 1369 tests, no failures. The flake was load-dependent and did not reproduce alone at `-count 30` per the issue, so this is a structural fix rather than one demonstrated by a red-to-green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)