### PR TITLE
Stop admitting admins through requireAgent

### DIFF
--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -132,6 +132,42 @@ func TestOnlyAgentsClaimJobs(t *testing.T) {
 	assert.NotNil(t, claimed.Job)
 }
 
+func TestAgentRoutesRefuseAdmins(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	job := dispatch(t, url, admin.Token, "atkins build", "")
+
+	// An admin is not an agent: the flag is a role rather than a rank.
+	// Admitting one here would hand an admin token the private half of
+	// every deploy key, which the admin listing withholds on purpose,
+	// and let it settle jobs under an agent_id that never ran them.
+	for _, route := range []string{"/api/agent/ssh-key", "/api/agent/policy"} {
+		status := call(t, http.MethodGet, url+route, admin.Token, nil, nil)
+		assert.Equal(t, http.StatusForbidden, status, route)
+	}
+
+	status := call(t, http.MethodPost, url+"/api/job/claim", admin.Token, map[string]any{
+		"agent_id": "impostor",
+	}, nil)
+	assert.Equal(t, http.StatusForbidden, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", admin.Token, map[string]any{
+		"status": model.JobStatusPassed,
+	}, nil)
+	assert.Equal(t, http.StatusForbidden, status)
+
+	// The queue is untouched: the job is still there for a real agent.
+	agent := enrol(t, url, "agent-1")
+	var claimed claimResponse
+	status = call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
+		"agent_id": "agent-1",
+	}, &claimed)
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, claimed.Job)
+	assert.Equal(t, job.JobID, claimed.Job.ID)
+}
+
 func TestAdminRoutesRefuseNonAdmins(t *testing.T) {
 	url := testServer(t)
 	register(t, url)

--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -60,14 +60,22 @@ func (s *Handlers) MountAgent(r platform.Router) {
 	})
 }
 
-// requireAgent authenticates the caller and refuses anyone who is
-// neither an agent nor an admin.
+// requireAgent authenticates the caller and refuses anyone who is not
+// an agent.
+//
+// An admin is not admitted, deliberately. `is_agent` means what the
+// roles section says it means, and widening it for convenience would
+// undo two things built on purpose: SSHKeyView withholds private key
+// material from the admin surface, and this route hands it over; and a
+// job settled here records an `agent_id` that would then name an agent
+// that never ran it. An admin who needs to act as an agent enrols one,
+// which is a decision written down rather than a side effect.
 func (s *Handlers) requireAgent(r *http.Request) (*model.User, error) {
 	user, _, err := s.authenticateUser(r)
 	if err != nil {
 		return nil, err
 	}
-	if !user.IsAgent && !user.IsAdmin {
+	if !user.IsAgent {
 		return nil, requestError(http.StatusForbidden, model.ErrForbidden)
 	}
 	return user, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -338,11 +338,12 @@ func TestDispatchRequiresAuthentication(t *testing.T) {
 func TestJobStatusSettlesOnce(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	job := dispatch(t, url, token.Token, "atkins", "")
 
 	var settled map[string]any
-	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", token.Token, map[string]any{
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", agent.Token, map[string]any{
 		"status":    model.JobStatusFailed,
 		"exit_code": 2,
 		"error":     "step failed",
@@ -352,7 +353,7 @@ func TestJobStatusSettlesOnce(t *testing.T) {
 	assert.Equal(t, float64(2), settled["exit_code"])
 
 	// A second report cannot overwrite the recorded outcome.
-	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", agent.Token, map[string]any{
 		"status": model.JobStatusPassed,
 	}, nil)
 	assert.Equal(t, http.StatusConflict, status)
@@ -361,10 +362,11 @@ func TestJobStatusSettlesOnce(t *testing.T) {
 func TestJobStatusRejectsNonTerminalStatus(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	job := dispatch(t, url, token.Token, "atkins", "")
 
-	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", token.Token, map[string]any{
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", agent.Token, map[string]any{
 		"status": model.JobStatusRunning,
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, status)
@@ -373,11 +375,12 @@ func TestJobStatusRejectsNonTerminalStatus(t *testing.T) {
 func TestClaimLeasesOnePendingJob(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	job := dispatch(t, url, token.Token, "atkins build", "")
 
 	var claimed claimResponse
-	status := call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+	status := call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 		"agent_id": "agent-1",
 	}, &claimed)
 	require.Equal(t, http.StatusOK, status)
@@ -391,7 +394,7 @@ func TestClaimLeasesOnePendingJob(t *testing.T) {
 	assert.Equal(t, "github.com/titpetric/atkins", claimed.Repository.Slug)
 
 	// The queue is now empty for the next agent.
-	status = call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 		"agent_id": "agent-2",
 	}, nil)
 	assert.Equal(t, http.StatusNoContent, status)
@@ -400,6 +403,7 @@ func TestClaimLeasesOnePendingJob(t *testing.T) {
 func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	var triggered dispatchResponse
 	seed := dispatch(t, url, token.Token, "atkins", "")
@@ -410,7 +414,7 @@ func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
 	require.Equal(t, http.StatusCreated, status)
 
 	// A checkout can only be reported for a job an agent is running.
-	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", agent.Token, map[string]any{
 		"ref":        "v1.2.3",
 		"commit_sha": "0123456789abcdef0123456789abcdef01234567",
 	}, nil)
@@ -420,7 +424,7 @@ func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
 	// two jobs to reach the triggered one.
 	var claimed claimResponse
 	for range 2 {
-		status = call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+		status = call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 			"agent_id": "agent-1",
 		}, &claimed)
 		require.Equal(t, http.StatusOK, status)
@@ -428,7 +432,7 @@ func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
 	require.NotNil(t, claimed.Job)
 	require.Equal(t, triggered.JobID, claimed.Job.ID)
 
-	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/"+triggered.JobID+"/checkout", agent.Token, map[string]any{
 		"ref":        "v1.2.3",
 		"commit_sha": "0123456789abcdef0123456789abcdef01234567",
 	}, nil)
@@ -447,10 +451,11 @@ func TestJobCheckoutRecordsTheResolvedCommit(t *testing.T) {
 func TestJobCheckoutRequiresACommit(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	job := dispatch(t, url, token.Token, "atkins build", "")
 
-	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/checkout", token.Token, map[string]any{
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/checkout", agent.Token, map[string]any{
 		"ref": "main",
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, status)
@@ -459,6 +464,7 @@ func TestJobCheckoutRequiresACommit(t *testing.T) {
 func TestClaimRespectsLabels(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	var labelled dispatchResponse
 	status := call(t, http.MethodPost, url+"/api/dispatch", token.Token, map[string]any{
@@ -469,14 +475,14 @@ func TestClaimRespectsLabels(t *testing.T) {
 	require.Equal(t, http.StatusCreated, status)
 
 	// An agent missing one of the labels does not get the job.
-	status = call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 		"agent_id": "amd64-agent",
 		"labels":   []string{"linux", "amd64"},
 	}, nil)
 	assert.Equal(t, http.StatusNoContent, status)
 
 	var claimed claimResponse
-	status = call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 		"agent_id": "arm64-agent",
 		"labels":   []string{"linux", "arm64", "docker"},
 	}, &claimed)
@@ -488,20 +494,21 @@ func TestClaimRespectsLabels(t *testing.T) {
 func TestHeartbeatRequiresTheLeaseHolder(t *testing.T) {
 	url := testServer(t)
 	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
 
 	job := dispatch(t, url, token.Token, "atkins build", "")
 
-	status := call(t, http.MethodPost, url+"/api/job/claim", token.Token, map[string]any{
+	status := call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
 		"agent_id": "agent-1",
 	}, nil)
 	require.Equal(t, http.StatusOK, status)
 
-	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/heartbeat", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/heartbeat", agent.Token, map[string]any{
 		"agent_id": "agent-1",
 	}, nil)
 	assert.Equal(t, http.StatusNoContent, status)
 
-	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/heartbeat", token.Token, map[string]any{
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/heartbeat", agent.Token, map[string]any{
 		"agent_id": "impostor",
 	}, nil)
 	assert.Equal(t, http.StatusConflict, status)


### PR DESCRIPTION
Fixes #40.

`requireAgent` accepted `is_admin` as well as `is_agent`, so `GET /api/agent/ssh-key` returned the private half of every deploy key to an admin token. `SSHKeyView` has no field for private material precisely so the admin surface cannot leak it, and `docs/content/usage/ci-cd.md:478` promises it is returned "only to an enrolled agent" — the projection was doing its job and this route was walking around it.

The same door opened `POST /api/job/claim`, `/status`, `/checkout`, `/heartbeat`, `/log` and artefact upload, so an admin token could settle jobs it never ran and attach output and files to them. Smaller in impact — an admin can change the allowlist and dispatch anything — but the recorded `agent_id` would be naming an agent that did not do the work.

## Change

`server/api/agent.go`: drop `|| user.IsAdmin`. `is_agent` now means what the roles section documents: claim work, report status, append output, read deploy keys — reachable only by enrolment. An admin who needs to act as an agent enrols one, which is a decision written down rather than a side effect.

## Tests

`TestAgentRoutesRefuseAdmins` (new): an admin is refused 403 by `/api/agent/ssh-key`, `/api/agent/policy`, `/api/job/claim` and `/api/job/{id}/status`, and the job it failed to claim is still on the queue for a real agent afterwards.

The existing server tests used the bootstrap admin as a stand-in agent for claim, status, checkout and heartbeat — they now enrol an agent, which is what those endpoints are for and what an agent does in practice. That is the bulk of the diff; no assertion changed.

`atkins test:simple` passes: 1370 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)