### PR TITLE
Read job.lease_ttl and job.max_depth where they are used

### DIFF
--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -554,9 +554,16 @@ var UserAgent = "atkins"
 
 Command renders an argv as the command to record.
 
-argv[0] is reduced to its base name: the recorded command is re-run
-on another machine, and `/home/tit/go/bin/atkins` says more about
-this laptop than about the job.
+argv[0] is replaced with `atkins` rather than reduced to its base
+name: the recorded command is re-run on another machine, where the
+binary is called `atkins`, and what this one happens to be named is a
+fact about this laptop. A build under test as `./bin/atkins-linux-amd64`,
+the `atkins.old` the install job leaves behind, or a distro package
+named `atkins-cli` would otherwise queue a command no agent can run,
+and the job comes back as exit 127 with an empty log.
+
+A run of something other than atkins is what the explicit `command`
+override on the trigger endpoint is for.
 
 ```go
 func Command(argv []string) string

--- a/docs/api/atkins_server_storage.md
+++ b/docs/api/atkins_server_storage.md
@@ -148,6 +148,14 @@ type JobRequest struct {
 type JobStorage struct {
 	db *sqlx.DB
 
+	// settings is consulted per use rather than read once here.
+	// `job.max_depth` and `job.lease_ttl` are documented as runtime
+	// configuration an admin changes without a restart, and a value
+	// captured at start-up would make that documentation false. A nil
+	// settings store leaves the configured values in charge, which is
+	// what a test constructing storage directly wants.
+	settings *SettingStorage
+
 	// maxDepth bounds how deep a job tree may nest. A pipeline that
 	// dispatches a child that dispatches a child is useful; one that
 	// does so without a floor is a fork bomb with a queue in front.
@@ -378,7 +386,8 @@ const Project = "atkins"
 ```
 
 ```go
-// Defaults applied when the corresponding JobStorage fields are zero.
+// Defaults applied when neither a stored setting nor a configured value
+// says otherwise.
 const (
 	// DefaultMaxDepth allows a dispatcher job to fan out to children
 	// and those children to fan out once more.
@@ -425,7 +434,7 @@ const (
 - `func Migrate (ctx context.Context, db *sqlx.DB, schema fs.FS) error`
 - `func NewJobArtefactStorage (db *sqlx.DB, blobs blob.Store) *JobArtefactStorage`
 - `func NewJobLogStorage (db *sqlx.DB) *JobLogStorage`
-- `func NewJobStorage (db *sqlx.DB, maxDepth int64, leaseTTL time.Duration) *JobStorage`
+- `func NewJobStorage (db *sqlx.DB, settings *SettingStorage, maxDepth int64, leaseTTL time.Duration) *JobStorage`
 - `func NewRepositoryRuleStorage (db *sqlx.DB) *RepositoryRuleStorage`
 - `func NewRepositoryStorage (db *sqlx.DB) *RepositoryStorage`
 - `func NewSSHKeyStorage (db *sqlx.DB) *SSHKeyStorage`
@@ -445,7 +454,9 @@ const (
 - `func (*JobStorage) Finish (ctx context.Context, jobID string, req StatusRequest) (*model.Job, error)`
 - `func (*JobStorage) Get (ctx context.Context, id string) (*model.Job, error)`
 - `func (*JobStorage) Heartbeat (ctx context.Context, jobID,agentID string) error`
+- `func (*JobStorage) LeaseTTL () time.Duration`
 - `func (*JobStorage) List (ctx context.Context, filter ListFilter) ([]model.Job, error)`
+- `func (*JobStorage) MaxDepth () int64`
 - `func (*JobStorage) Purge (ctx context.Context, req RetentionRequest) (RetentionResult, error)`
 - `func (*JobStorage) ReclaimExpired (ctx context.Context) (int64, error)`
 - `func (*JobStorage) RecordCheckout (ctx context.Context, jobID string, req CheckoutRequest) error`
@@ -482,6 +493,7 @@ const (
 - `func (*SettingStorage) Get (name string) string`
 - `func (*SettingStorage) Int (name string) int64`
 - `func (*SettingStorage) Load (ctx context.Context) error`
+- `func (*SettingStorage) Override (name string) (string, bool)`
 - `func (*SettingStorage) Reset (ctx context.Context, name string) error`
 - `func (*SettingStorage) Set (ctx context.Context, name,value,userID string) error`
 - `func (*UserStorage) Authenticate (ctx context.Context, email,password string) (*model.User, error)`
@@ -537,10 +549,12 @@ func NewJobLogStorage(db *sqlx.DB) *JobLogStorage
 ### NewJobStorage
 
 NewJobStorage returns a JobStorage backed by the given pool.
-Zero values for maxDepth and leaseTTL select the package defaults.
+
+maxDepth and leaseTTL are the configured values, and stand in when no
+admin has stored an override; zero selects the registry default.
 
 ```go
-func NewJobStorage(db *sqlx.DB, maxDepth int64, leaseTTL time.Duration) *JobStorage
+func NewJobStorage(db *sqlx.DB, settings *SettingStorage, maxDepth int64, leaseTTL time.Duration) *JobStorage
 ```
 
 ### NewRepositoryRuleStorage
@@ -728,12 +742,32 @@ the job may extend it.
 func (*JobStorage) Heartbeat(ctx context.Context, jobID, agentID string) error
 ```
 
+### LeaseTTL
+
+LeaseTTL is how long a claim is good for.
+
+```go
+func (*JobStorage) LeaseTTL() time.Duration
+```
+
 ### List
 
 List returns jobs matching the filter, newest first.
 
 ```go
 func (*JobStorage) List(ctx context.Context, filter ListFilter) ([]model.Job, error)
+```
+
+### MaxDepth
+
+MaxDepth is the nesting limit in force.
+
+Precedence is the same for both of these: a stored setting is an
+admin's decision and wins; a configured value is the operator's and
+comes next; the registry default is nobody's, and is what is left.
+
+```go
+func (*JobStorage) MaxDepth() int64
 ```
 
 ### Purge
@@ -1068,6 +1102,21 @@ Load fills the cache from the database.
 
 ```go
 func (*SettingStorage) Load(ctx context.Context) error
+```
+
+### Override
+
+Override returns the stored value for a setting, and whether an admin
+has stored one at all.
+
+It is the distinction Get deliberately hides: Get answers "what is
+this setting worth", falling back to the registry default, which is
+the wrong question when a start-up flag configures the same thing.
+A default is not a decision, and it must not outrank one written in
+the configuration file.
+
+```go
+func (*SettingStorage) Override(name string) (string, bool)
 ```
 
 ### Reset

--- a/server/server.go
+++ b/server/server.go
@@ -110,18 +110,11 @@ func (m *Module) Start(ctx context.Context) error {
 		return fmt.Errorf("atkins server: artefact directory %q: %w", artefactDir, err)
 	}
 
-	// A setting overrides the corresponding start-up flag, so an admin
-	// can change these without a restart.
-	maxDepth := m.opts.MaxJobDepth
-	if configured := settings.Int(model.SettingJobMaxDepth); configured > 0 {
-		maxDepth = configured
-	}
-	leaseTTL := m.opts.LeaseTTL
-	if configured := settings.Duration(model.SettingJobLeaseTTL); configured > 0 {
-		leaseTTL = configured
-	}
-
-	m.jobs = storage.NewJobStorage(db, maxDepth, leaseTTL)
+	// The settings store goes in rather than two values read out of it:
+	// `job.max_depth` and `job.lease_ttl` are runtime configuration, and
+	// resolving them here would mean an admin's change waited for a
+	// restart while the API reported it as already in force.
+	m.jobs = storage.NewJobStorage(db, settings, m.opts.MaxJobDepth, m.opts.LeaseTTL)
 	m.artefacts = storage.NewJobArtefactStorage(db, blobs)
 	jobLogs := storage.NewJobLogStorage(db)
 	repositories := storage.NewRepositoryStorage(db)

--- a/server/setting_test.go
+++ b/server/setting_test.go
@@ -1,0 +1,121 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server"
+	"github.com/titpetric/atkins/server/model"
+)
+
+// claim takes one job off the queue as an enrolled agent.
+func claim(t *testing.T, url, token, agentID string) claimResponse {
+	t.Helper()
+
+	var claimed claimResponse
+	status := call(t, http.MethodPost, url+"/api/job/claim", token, map[string]any{
+		"agent_id": agentID,
+	}, &claimed)
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, claimed.Job)
+	require.NotNil(t, claimed.Job.StartedAt)
+	require.NotNil(t, claimed.Job.LeaseExpiresAt)
+
+	return claimed
+}
+
+// leaseWindow is how long the claim on a job is good for.
+func leaseWindow(job *model.Job) time.Duration {
+	return job.LeaseExpiresAt.Sub(*job.StartedAt)
+}
+
+func TestLeaseTTLSettingTakesEffectWithoutRestart(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	dispatch(t, url, admin.Token, "atkins build", "")
+	dispatch(t, url, admin.Token, "atkins build", "")
+
+	// The registry default until an admin says otherwise.
+	assert.Equal(t, 15*time.Minute, leaseWindow(claim(t, url, agent.Token, "agent-1").Job))
+
+	setSetting(t, url, admin.Token, model.SettingJobLeaseTTL, "30s")
+
+	// The next claim uses the new window. `job.lease_ttl` is documented
+	// as configuration an admin changes without a restart, and reading
+	// it once at start-up made that promise false.
+	assert.Equal(t, 30*time.Second, leaseWindow(claim(t, url, agent.Token, "agent-1").Job))
+}
+
+func TestMaxDepthSettingTakesEffectWithoutRestart(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	parent := dispatch(t, url, admin.Token, "atkins", "")
+	child := dispatch(t, url, admin.Token, "atkins", parent.JobID)
+	require.Equal(t, int64(1), child.Depth)
+
+	setSetting(t, url, admin.Token, model.SettingJobMaxDepth, "1")
+
+	// A grandchild is depth 2, one past the limit that was just set.
+	status := call(t, http.MethodPost, url+"/api/dispatch", admin.Token, map[string]any{
+		"repository": map[string]string{"remote_url": "git@github.com:titpetric/atkins.git"},
+		"command":    "atkins",
+		"parent_id":  child.JobID,
+	}, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, status)
+}
+
+func TestConfiguredLeaseTTLOutranksTheRegistryDefault(t *testing.T) {
+	url := testServerWith(t, func(opts *server.Options) {
+		opts.LeaseTTL = 90 * time.Second
+	})
+	admin := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	dispatch(t, url, admin.Token, "atkins build", "")
+	dispatch(t, url, admin.Token, "atkins build", "")
+
+	// ATKINS_LEASE_TTL is a decision; the registry default is not. A
+	// setting nobody has stored must not silently outrank the
+	// configuration file.
+	assert.Equal(t, 90*time.Second, leaseWindow(claim(t, url, agent.Token, "agent-1").Job))
+
+	// And an admin still overrides it, without a restart.
+	setSetting(t, url, admin.Token, model.SettingJobLeaseTTL, "45s")
+	assert.Equal(t, 45*time.Second, leaseWindow(claim(t, url, agent.Token, "agent-1").Job))
+}
+
+func TestConfiguredMaxDepthOutranksTheRegistryDefault(t *testing.T) {
+	url := testServerWith(t, func(opts *server.Options) {
+		opts.MaxJobDepth = 1
+	})
+	admin := register(t, url)
+
+	parent := dispatch(t, url, admin.Token, "atkins", "")
+	child := dispatch(t, url, admin.Token, "atkins", parent.JobID)
+
+	status := call(t, http.MethodPost, url+"/api/dispatch", admin.Token, map[string]any{
+		"repository": map[string]string{"remote_url": "git@github.com:titpetric/atkins.git"},
+		"command":    "atkins",
+		"parent_id":  child.JobID,
+	}, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, status)
+
+	// Resetting a setting that was never stored leaves the configured
+	// value in charge rather than falling back to the default of 3.
+	status = call(t, http.MethodDelete, url+"/api/admin/setting/"+model.SettingJobMaxDepth, admin.Token, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+
+	status = call(t, http.MethodPost, url+"/api/dispatch", admin.Token, map[string]any{
+		"repository": map[string]string{"remote_url": "git@github.com:titpetric/atkins.git"},
+		"command":    "atkins",
+		"parent_id":  child.JobID,
+	}, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, status)
+}

--- a/server/storage/job.go
+++ b/server/storage/job.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,14 @@ const defaultListLimit = 100
 type JobStorage struct {
 	db *sqlx.DB
 
+	// settings is consulted per use rather than read once here.
+	// `job.max_depth` and `job.lease_ttl` are documented as runtime
+	// configuration an admin changes without a restart, and a value
+	// captured at start-up would make that documentation false. A nil
+	// settings store leaves the configured values in charge, which is
+	// what a test constructing storage directly wants.
+	settings *SettingStorage
+
 	// maxDepth bounds how deep a job tree may nest. A pipeline that
 	// dispatches a child that dispatches a child is useful; one that
 	// does so without a floor is a fork bomb with a queue in front.
@@ -32,7 +41,8 @@ type JobStorage struct {
 	leaseTTL time.Duration
 }
 
-// Defaults applied when the corresponding JobStorage fields are zero.
+// Defaults applied when neither a stored setting nor a configured value
+// says otherwise.
 const (
 	// DefaultMaxDepth allows a dispatcher job to fan out to children
 	// and those children to fan out once more.
@@ -44,15 +54,61 @@ const (
 )
 
 // NewJobStorage returns a JobStorage backed by the given pool.
-// Zero values for maxDepth and leaseTTL select the package defaults.
-func NewJobStorage(db *sqlx.DB, maxDepth int64, leaseTTL time.Duration) *JobStorage {
-	if maxDepth <= 0 {
-		maxDepth = DefaultMaxDepth
+//
+// maxDepth and leaseTTL are the configured values, and stand in when no
+// admin has stored an override; zero selects the registry default.
+func NewJobStorage(db *sqlx.DB, settings *SettingStorage, maxDepth int64, leaseTTL time.Duration) *JobStorage {
+	return &JobStorage{db: db, settings: settings, maxDepth: maxDepth, leaseTTL: leaseTTL}
+}
+
+// MaxDepth is the nesting limit in force.
+//
+// Precedence is the same for both of these: a stored setting is an
+// admin's decision and wins; a configured value is the operator's and
+// comes next; the registry default is nobody's, and is what is left.
+func (s *JobStorage) MaxDepth() int64 {
+	if stored, ok := s.override(model.SettingJobMaxDepth); ok {
+		if parsed, err := strconv.ParseInt(stored, 10, 64); err == nil && parsed > 0 {
+			return parsed
+		}
+	} else if s.maxDepth > 0 {
+		return s.maxDepth
 	}
-	if leaseTTL <= 0 {
-		leaseTTL = DefaultLeaseTTL
+
+	if s.settings != nil {
+		if fallback := s.settings.Int(model.SettingJobMaxDepth); fallback > 0 {
+			return fallback
+		}
 	}
-	return &JobStorage{db: db, maxDepth: maxDepth, leaseTTL: leaseTTL}
+	return DefaultMaxDepth
+}
+
+// LeaseTTL is how long a claim is good for.
+func (s *JobStorage) LeaseTTL() time.Duration {
+	if stored, ok := s.override(model.SettingJobLeaseTTL); ok {
+		if parsed, err := time.ParseDuration(stored); err == nil && parsed > 0 {
+			return parsed
+		}
+	} else if s.leaseTTL > 0 {
+		return s.leaseTTL
+	}
+
+	if s.settings != nil {
+		if fallback := s.settings.Duration(model.SettingJobLeaseTTL); fallback > 0 {
+			return fallback
+		}
+	}
+	return DefaultLeaseTTL
+}
+
+// override reads a setting an admin has actually stored. A setting
+// nobody has touched reports false rather than its registry default,
+// so a default cannot outrank a configured value.
+func (s *JobStorage) override(name string) (string, bool) {
+	if s.settings == nil {
+		return "", false
+	}
+	return s.settings.Override(name)
 }
 
 // JobRequest is the input for dispatching a job.
@@ -111,7 +167,7 @@ func (s *JobStorage) Create(ctx context.Context, req JobRequest) (*model.Job, er
 			return nil, err
 		}
 		depth = parent.Depth + 1
-		if depth > s.maxDepth {
+		if depth > s.MaxDepth() {
 			return nil, model.ErrMaxDepthExceeded
 		}
 		rootID = parent.RootID
@@ -183,6 +239,7 @@ func (s *JobStorage) Claim(ctx context.Context, agentID string, labels []string)
 	}
 
 	now := time.Now()
+	lease := s.LeaseTTL()
 	for _, job := range candidates {
 		if !agentAcceptsJob(labels, job.Labels) {
 			continue
@@ -191,7 +248,7 @@ func (s *JobStorage) Claim(ctx context.Context, agentID string, labels []string)
 		update := `UPDATE ` + model.JobTable + ` SET status = ?, agent_id = ?, started_at = ?, lease_expires_at = ?, updated_at = ?
 			WHERE id = ? AND status = ?`
 		if err := db.Exec(ctx, update,
-			model.JobStatusRunning, agentID, now, now.Add(s.leaseTTL), now,
+			model.JobStatusRunning, agentID, now, now.Add(lease), now,
 			job.ID, model.JobStatusPending); err != nil {
 			return nil, fmt.Errorf("claim job: %w", err)
 		}
@@ -207,7 +264,7 @@ func (s *JobStorage) Claim(ctx context.Context, agentID string, labels []string)
 		job.Status = model.JobStatusRunning
 		job.AgentID = agentID
 		job.SetStartedAt(now)
-		job.SetLeaseExpiresAt(now.Add(s.leaseTTL))
+		job.SetLeaseExpiresAt(now.Add(lease))
 		job.SetUpdatedAt(now)
 		return &job, nil
 	}
@@ -223,7 +280,7 @@ func (s *JobStorage) Heartbeat(ctx context.Context, jobID, agentID string) error
 
 	query := `UPDATE ` + model.JobTable + ` SET lease_expires_at = ?, updated_at = ?
 		WHERE id = ? AND agent_id = ? AND status = ?`
-	if err := db.Exec(ctx, query, now.Add(s.leaseTTL), now, jobID, agentID, model.JobStatusRunning); err != nil {
+	if err := db.Exec(ctx, query, now.Add(s.LeaseTTL()), now, jobID, agentID, model.JobStatusRunning); err != nil {
 		return fmt.Errorf("heartbeat job: %w", err)
 	}
 	if db.RowsAffected() == 0 {

--- a/server/storage/retention_test.go
+++ b/server/storage/retention_test.go
@@ -42,7 +42,7 @@ func testStorage(t *testing.T) (*sqlx.DB, *JobStorage) {
 	require.NoError(t, err)
 	require.NoError(t, Migrate(t.Context(), db, schema.Migrations()))
 
-	return db, NewJobStorage(db, 0, 0)
+	return db, NewJobStorage(db, nil, 0, 0)
 }
 
 // seedJob writes one job with the given status and finish time, plus

--- a/server/storage/setting.go
+++ b/server/storage/setting.go
@@ -71,6 +71,22 @@ func (s *SettingStorage) Get(name string) string {
 	return ""
 }
 
+// Override returns the stored value for a setting, and whether an admin
+// has stored one at all.
+//
+// It is the distinction Get deliberately hides: Get answers "what is
+// this setting worth", falling back to the registry default, which is
+// the wrong question when a start-up flag configures the same thing.
+// A default is not a decision, and it must not outrank one written in
+// the configuration file.
+func (s *SettingStorage) Override(name string) (string, bool) {
+	s.mu.RLock()
+	value, ok := s.cache[name]
+	s.mu.RUnlock()
+
+	return value, ok
+}
+
 // Bool returns a setting parsed as a boolean.
 func (s *SettingStorage) Bool(name string) bool {
 	parsed, _ := strconv.ParseBool(s.Get(name))


### PR DESCRIPTION
Fixes #38.

Two defects, one cause: both settings were resolved during `Module.Start` and baked into `JobStorage` as scalars.

1. **A change had no effect until restart.** `/admin/setting` showed the new value and reported `is_default=false`, and nothing enforced it — while `repository.policy`, `registration.open`, `job.visibility` and `artefact.*` are all read from the cache on the request path and apply at once. These two were the odd ones out, not a general limitation.

2. **The registry default outranked the configured value.** The guard was `if configured > 0` against the *effective* value, and a setting nobody has stored still resolves to its registry default — never zero. So the branch was always taken and `ATKINS_LEASE_TTL`, `server.lease_ttl` and the max-depth pair were dead: the shipped instance sets `ATKINS_LEASE_TTL=5m` and issued 15m leases.

## Change

`JobStorage` takes the settings cache instead of two scalars and reads `job.max_depth` / `job.lease_ttl` at the point of use, as `MaxDepth()` and `LeaseTTL()`. Precedence is what the API already implies: a stored row is an admin's decision and wins; a configured value is the operator's and comes next; the registry default is nobody's and is what is left.

`SettingStorage.Override(name) (string, bool)` reports whether a row exists at all — the distinction `Get` deliberately hides, and the one that keeps a default from outranking a decision.

## Tests

`server/setting_test.go`:

- a lease claimed after `job.lease_ttl` changes uses the new window, and the claim before it uses the default;
- a job is refused after `job.max_depth` is lowered, without a restart;
- `opts.LeaseTTL` (`ATKINS_LEASE_TTL`) is honoured when no setting row exists, and an admin still overrides it;
- the same for max depth, including after `DELETE /api/admin/setting/job.max_depth` — resetting a setting that was never stored leaves the configured value in charge rather than falling back to 3.

`atkins test:simple` passes: 1373 tests, four more than `main`'s 1369.

Also included: `atkins test:docs` output. `docs/api/atkins_client.md` picked up the `Command` doc comment from #48, which was merged without regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)