### PR TITLE
Make a job's page link recoverable

### DIFF
--- a/docs/api/atkins_server_api.md
+++ b/docs/api/atkins_server_api.md
@@ -211,6 +211,28 @@ type JobStatusRequest struct {
 ```
 
 ```go
+// JobView is a job as the API returns it: the stored row, plus how to
+// open it in a browser.
+//
+// The token is derived from the job id and the signing key rather than
+// stored, so returning it to a caller who has just been allowed to read
+// the job withholds nothing: they can already read the output and the
+// artefacts the page shows. Leaving it out only meant that whoever lost
+// the URL atkins printed could no longer open a job they own.
+type JobView struct {
+	*model.Job
+
+	// ViewToken opens the job page without a session. Empty on a public
+	// instance, which needs none.
+	ViewToken string `json:"view_token,omitempty"`
+
+	// URL is the page for this job, token and all. It is relative to
+	// this server, the way an artefact's URL is.
+	URL string `json:"url"`
+}
+```
+
+```go
 // LoginRequest is the body of /api/user/login.
 type LoginRequest struct {
 	Email    string `json:"email"`

--- a/docs/api/atkins_server_model.md
+++ b/docs/api/atkins_server_model.md
@@ -488,6 +488,13 @@ const UserTable = "`user`"
 ```
 
 ```go
+// ViewTokenParam is the query parameter carrying a job's view token.
+// One letter, because it rides along in a URL a human copies out of a
+// terminal.
+const ViewTokenParam = "t"
+```
+
+```go
 // Setting kinds.
 const (
 	KindString   SettingKind = "string"
@@ -812,6 +819,7 @@ var (
 - `func ArtefactPattern (value string) string`
 - `func ArtefactPatterns (value string) []string`
 - `func CleanWorkingDirectory (dir string) string`
+- `func JobLink (jobID,viewToken string) string`
 - `func JoinArtefactPatterns (patterns []string) string`
 - `func LookupSetting (name string) (SettingDefinition, bool)`
 - `func MatchArtefactPath (pattern,value string) bool`
@@ -1146,6 +1154,24 @@ here, because a guard on one of them is no guard at all.
 
 ```go
 func CleanWorkingDirectory(dir string) string
+```
+
+### JobLink
+
+JobLink is where a job's page lives on the server.
+
+It is here rather than in the page package because two sides build the
+same link: the pages, for every job they point at, and the API, for
+callers that read a job and want to hand a person somewhere to look.
+A link that differs between them is a link that works in one place and
+403s in the other.
+
+The path is server-relative on purpose. The server is reached through
+whatever hostname the operator put in front of it, and inventing one
+here would be a guess; the caller already knows which server it asked.
+
+```go
+func JobLink(jobID, viewToken string) string
 ```
 
 ### JoinArtefactPatterns

--- a/docs/api/atkins_server_web.md
+++ b/docs/api/atkins_server_web.md
@@ -60,9 +60,18 @@ type IndexPage struct {
 	// that will not change on its own.
 	Refresh int
 
-	// Private is set when the listing is withheld, so the page can say
-	// why rather than looking like an instance nobody has ever used.
+	// Private is set when the listing is withheld for want of a session,
+	// so the page can offer a way in rather than looking like an
+	// instance nobody has ever used.
 	Private bool
+
+	// Scoped is set when the listing is the signed-in user's own runs
+	// rather than everything on the instance.
+	Scoped bool
+
+	// SignedIn is set when the visitor has a session, which decides
+	// whether the page offers a sign-in link or an admin one.
+	SignedIn bool
 }
 ```
 
@@ -133,9 +142,9 @@ type Page struct {
 
 ```go
 // ViewTokenParam is the query parameter carrying a job's view token.
-// One letter, because it rides along in a URL a human copies out of a
-// terminal.
-const ViewTokenParam = "t"
+// The API builds the same links, so the name lives with the model both
+// sides share.
+const ViewTokenParam = model.ViewTokenParam
 ```
 
 ## Function symbols
@@ -213,11 +222,12 @@ func (*Handlers) CreateSSHKey(w http.ResponseWriter, r *http.Request, current *s
 
 Index lists recent jobs.
 
-A private instance lists nothing: no per-job token can scope a
-listing and there is no session to scope it by, so the listing lives
-on /api/job where the caller is authenticated. The page still
-answers, and says why — it is the server's front door, and a health
-check probing it should find a server rather than a refusal.
+A private instance scopes the listing to whoever is signed in, the
+way /api/job does for a bearer token: an owner who lost the URL atkins
+printed can find the job here and the link carries its view token. A
+visitor with no session is told where to sign in — the page still
+answers, because it is the server's front door and a health check
+probing it should find a server rather than a refusal.
 
 ```go
 func (*Handlers) Index(w http.ResponseWriter, r *http.Request)
@@ -383,8 +393,11 @@ func (Links) Job(jobID string) string
 
 ### Listing
 
-Listing reports whether the front page lists anything, which is also
-whether it is worth linking to.
+Listing reports whether the front page lists anything to a visitor
+with no session, which is what a job page opened from a printed URL
+has. A signed-in visitor gets a listing either way, but the markup
+cannot tell one from the other and a link to an empty page is worse
+than no link.
 
 ```go
 func (Links) Listing() bool

--- a/docs/content/usage/ci-cd.md
+++ b/docs/content/usage/ci-cd.md
@@ -93,7 +93,7 @@ The server normalizes the remote URL into a `host/owner/name` slug, so `git@gith
 
 The ref atkins sends is the **commit you are on**, not the branch you are on. A dispatched run belongs to the code in front of you, and a branch name would let the agent build whatever that branch had moved to by the time it claimed the job. The consequence is worth knowing: dispatching a commit you have not pushed fails, naming the ref it could not find, rather than quietly building the branch tip instead.
 
-The response carries the job's ID and, while the instance keeps jobs private, a `view_token` that opens its page in a browser. `atkins` prints the two as one URL; a script driving `/api/dispatch` or a trigger with `curl` builds it the same way.
+The response carries the job's ID and, while the instance keeps jobs private, a `view_token` that opens its page in a browser. `atkins` prints the two as one URL; a script driving `/api/dispatch` or a trigger with `curl` builds it the same way. Losing that line is not losing the link: `GET /api/job/{id}` and `GET /api/job` return the same `view_token`, plus a ready-made `url`, to any caller allowed to read the job.
 
 Delegation degrades to a local run rather than to an error. If the machine isn't logged in, isn't inside a git repository, or the server can't be reached, the pipeline runs here as it always did — with the reason on stderr.
 
@@ -279,7 +279,7 @@ A retry is a **new job** built from the finished one, not a reset: the previous 
 
 The page has no session to check — the browser reading it never logged in — so what a private instance checks instead is the token in the URL. It is an HMAC of the job ID under the server's signing key: nothing is stored, nothing extra leaks from a database dump, and rotating the signing key invalidates every outstanding link along with every token. Paste the whole line and the job opens; trim the query string and you get a 403 saying so. Links between jobs on the page — the parent, and the children a job dispatched — carry the token for the job they point at, so following the tree keeps working. So do the artefact download links: a file a job produced is reachable on exactly the terms its page is, no wider and no narrower.
 
-`/` lists recent jobs, and a private instance lists none: there is no token that could scope a listing and no session to scope it by. The page answers and says so — it is the front door, and a health check probing it should find a server. `GET /api/job` is the listing, and it is scoped to the caller.
+`/` lists recent jobs. On a private instance the session decides what it lists: signed in, it is your own runs, with each link carrying the view token for the job it points at; signed out, it lists nothing and says where to sign in, because there is no token that could scope a listing and no session to scope it by. The page answers either way — it is the front door, and a health check probing it should find a server. `GET /api/job` is the same listing for a bearer token, scoped the same way.
 
 Both of those relax under `job.visibility`:
 

--- a/server/api/dispatch.go
+++ b/server/api/dispatch.go
@@ -99,6 +99,37 @@ type DispatchResponse struct {
 	ViewToken string `json:"view_token,omitempty"`
 }
 
+// JobView is a job as the API returns it: the stored row, plus how to
+// open it in a browser.
+//
+// The token is derived from the job id and the signing key rather than
+// stored, so returning it to a caller who has just been allowed to read
+// the job withholds nothing: they can already read the output and the
+// artefacts the page shows. Leaving it out only meant that whoever lost
+// the URL atkins printed could no longer open a job they own.
+type JobView struct {
+	*model.Job
+
+	// ViewToken opens the job page without a session. Empty on a public
+	// instance, which needs none.
+	ViewToken string `json:"view_token,omitempty"`
+
+	// URL is the page for this job, token and all. It is relative to
+	// this server, the way an artefact's URL is.
+	URL string `json:"url"`
+}
+
+// jobView projects a job for a caller allowed to read it.
+func (s *Handlers) jobView(job *model.Job) JobView {
+	token := s.viewToken(job.ID)
+
+	return JobView{
+		Job:       job,
+		ViewToken: token,
+		URL:       model.JobLink(job.ID, token),
+	}
+}
+
 // JobStatusRequest is the body of /api/job/{jobID}/status.
 type JobStatusRequest struct {
 	Status   string `json:"status"`
@@ -276,7 +307,7 @@ func (s *Handlers) getJob(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	platform.JSON(w, r, http.StatusOK, job)
+	platform.JSON(w, r, http.StatusOK, s.jobView(job))
 	return nil
 }
 
@@ -309,7 +340,14 @@ func (s *Handlers) listJobs(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	platform.JSON(w, r, http.StatusOK, jobs)
+	// A listing carries the same links a single read does: finding a job
+	// here and then having no way to open it is the gap this closes.
+	views := make([]JobView, 0, len(jobs))
+	for i := range jobs {
+		views = append(views, s.jobView(&jobs[i]))
+	}
+
+	platform.JSON(w, r, http.StatusOK, views)
 	return nil
 }
 

--- a/server/job_link_test.go
+++ b/server/job_link_test.go
@@ -1,0 +1,134 @@
+package server_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server/model"
+)
+
+// jobView is the part of the API's job payload this file is about.
+type jobLinkView struct {
+	ID        string `json:"id"`
+	ViewToken string `json:"view_token"`
+	URL       string `json:"url"`
+}
+
+// readJob reads one job as a caller who may see it.
+func readJob(t *testing.T, url, token, jobID string) jobLinkView {
+	t.Helper()
+
+	var job jobLinkView
+	status := call(t, http.MethodGet, url+"/api/job/"+jobID, token, nil, &job)
+	require.Equal(t, http.StatusOK, status)
+
+	return job
+}
+
+func TestJobPayloadCarriesTheViewToken(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	dispatched := dispatch(t, url, admin.Token, "atkins build", "")
+	require.NotEmpty(t, dispatched.ViewToken)
+
+	// The token the dispatch printed is rebuildable from the job itself,
+	// which is the whole point: a lost terminal is not a lost job.
+	job := readJob(t, url, admin.Token, dispatched.JobID)
+	assert.Equal(t, dispatched.ViewToken, job.ViewToken)
+	assert.Equal(t, "/job/"+dispatched.JobID+"?t="+dispatched.ViewToken, job.URL)
+
+	// And the listing carries it too, so a caller that found a job here
+	// is not left without a way to open it.
+	var listed []jobLinkView
+	status := call(t, http.MethodGet, url+"/api/job", admin.Token, nil, &listed)
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, listed, 1)
+	assert.Equal(t, dispatched.ViewToken, listed[0].ViewToken)
+
+	// The link works in a browser with no session, which is what the
+	// token is for.
+	status, _, _ = fetch(t, url+job.URL, "")
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestJobPayloadHasNoTokenOnAPublicInstance(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+
+	setSetting(t, url, admin.Token, model.SettingJobVisibility, model.VisibilityPublic)
+
+	dispatched := dispatch(t, url, admin.Token, "atkins build", "")
+
+	// A public instance guards nothing with the token, and a secret in a
+	// URL that guards nothing is just a longer URL.
+	job := readJob(t, url, admin.Token, dispatched.JobID)
+	assert.Empty(t, job.ViewToken)
+	assert.Equal(t, "/job/"+dispatched.JobID, job.URL)
+
+	status, _, _ := fetch(t, url+job.URL, "")
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestJobPayloadIsStillScoped(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	theirs := dispatch(t, url, admin.Token, "atkins build", "")
+
+	// Handing out the token is safe because the caller had to pass the
+	// job scope to get here. Somebody who may not read the job still
+	// gets a 404 rather than a link to it.
+	status := call(t, http.MethodGet, url+"/api/job/"+theirs.JobID, dev.Token, nil, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestIndexListsTheSignedInUsersJobs(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	openRegistration(t, url, admin.Token)
+
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	mine := dispatch(t, url, dev.Token, "atkins mine", "")
+	theirs := dispatch(t, url, admin.Token, "atkins theirs", "")
+
+	// With no session there is nothing to scope a listing by, so the
+	// page says where to sign in rather than listing the instance.
+	anonymous := newBrowser(t, url)
+	status, body := anonymous.get("/")
+	require.Equal(t, http.StatusOK, status)
+	assert.Contains(t, body, "private on this server")
+	assert.NotContains(t, body, "atkins mine")
+
+	signed := newBrowser(t, url)
+	signed.login("dev@example.com", "correct-horse")
+
+	status, body = signed.get("/")
+	require.Equal(t, http.StatusOK, status)
+	assert.Contains(t, body, "atkins mine")
+	assert.NotContains(t, body, "atkins theirs")
+
+	// The link on the row carries the job's own view token, so the page
+	// it points at opens.
+	assert.Contains(t, body, "/job/"+mine.JobID+"?t="+mine.ViewToken)
+
+	status, _, _ = fetch(t, url+"/job/"+mine.JobID+"?t="+mine.ViewToken, "")
+	assert.Equal(t, http.StatusOK, status)
+
+	// An admin sees the instance, which is the rule the API already
+	// applies to a listing.
+	operator := newBrowser(t, url)
+	operator.login("ci@example.com", "correct-horse")
+
+	status, body = operator.get("/")
+	require.Equal(t, http.StatusOK, status)
+	assert.Contains(t, body, "atkins mine")
+	assert.Contains(t, body, "atkins theirs")
+	assert.Equal(t, 1, strings.Count(body, "/job/"+theirs.JobID+"?t="))
+}

--- a/server/model/link.go
+++ b/server/model/link.go
@@ -1,0 +1,24 @@
+package model
+
+// ViewTokenParam is the query parameter carrying a job's view token.
+// One letter, because it rides along in a URL a human copies out of a
+// terminal.
+const ViewTokenParam = "t"
+
+// JobLink is where a job's page lives on the server.
+//
+// It is here rather than in the page package because two sides build the
+// same link: the pages, for every job they point at, and the API, for
+// callers that read a job and want to hand a person somewhere to look.
+// A link that differs between them is a link that works in one place and
+// 403s in the other.
+//
+// The path is server-relative on purpose. The server is reached through
+// whatever hostname the operator put in front of it, and inventing one
+// here would be a guess; the caller already knows which server it asked.
+func JobLink(jobID, viewToken string) string {
+	if viewToken == "" {
+		return "/job/" + jobID
+	}
+	return "/job/" + jobID + "?" + ViewTokenParam + "=" + viewToken
+}

--- a/server/web/index.templ
+++ b/server/web/index.templ
@@ -7,9 +7,17 @@ templ indexView(page IndexPage, links Links) {
 		<header>
 			<h1>Jobs</h1>
 			<p class="muted">
-				Runs dispatched by <span class="mono">atkins</span>, newest first.
+				if page.Scoped {
+					Runs you dispatched with <span class="mono">atkins</span>, newest first.
+				} else {
+					Runs dispatched by <span class="mono">atkins</span>, newest first.
+				}
 				{ " · " }
-				<a href="/admin/repository">Admin</a>
+				if page.SignedIn {
+					<a href="/admin/repository">Admin</a>
+				} else {
+					<a href="/login?next=%2F">Sign in</a>
+				}
 			</p>
 		</header>
 		if len(page.Jobs) > 0 {
@@ -29,8 +37,9 @@ templ indexView(page IndexPage, links Links) {
 			</table>
 		} else if page.Private {
 			<p class="muted">
-				Job listings are private on this server. Open a job with the URL
-				<span class="mono">atkins</span> printed, or list your own over
+				Job listings are private on this server.
+				<a href="/login?next=%2F">Sign in</a> to see your own runs, open a job
+				with the URL <span class="mono">atkins</span> printed, or list them over
 				<span class="mono">/api/job</span>.
 			</p>
 		} else {

--- a/server/web/index_templ.go
+++ b/server/web/index_templ.go
@@ -45,56 +45,82 @@ func indexView(page IndexPage, links Links) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<header><h1>Jobs</h1><p class=\"muted\">Runs dispatched by <span class=\"mono\">atkins</span>, newest first. ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<header><h1>Jobs</h1><p class=\"muted\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
+			}
+			if page.Scoped {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "Runs you dispatched with <span class=\"mono\">atkins</span>, newest first. ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "Runs dispatched by <span class=\"mono\">atkins</span>, newest first. ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 11, Col: 12}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 15, Col: 12}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " <a href=\"/admin/repository\">Admin</a></p></header>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if page.SignedIn {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<a href=\"/admin/repository\">Admin</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<a href=\"/login?next=%2F\">Sign in</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</p></header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(page.Jobs) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<table><tr><th>Command</th><td>Status</td><td>Queued</td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<table><tr><th>Command</th><td>Status</td><td>Queued</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, job := range page.Jobs {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<tr><th class=\"mono\"><a href=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<tr><th class=\"mono\"><a href=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var4 templ.SafeURL
 					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(links.Job(job.ID)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 24, Col: 61}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 32, Col: 61}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var5 string
 					templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(job.Command)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 24, Col: 77}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 32, Col: 77}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</a></th><td>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</a></th><td>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -103,7 +129,7 @@ func indexView(page IndexPage, links Links) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -116,48 +142,48 @@ func indexView(page IndexPage, links Links) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var8 string
 					templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(job.Status)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 25, Col: 69}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 33, Col: 69}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span></td><td class=\"muted\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span></td><td class=\"muted\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var9 string
 					templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(stamp(job.CreatedAt))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 26, Col: 46}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `index.templ`, Line: 34, Col: 46}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</td></tr>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</td></tr>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</table>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</table>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else if page.Private {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"muted\">Job listings are private on this server. Open a job with the URL <span class=\"mono\">atkins</span> printed, or list your own over <span class=\"mono\">/api/job</span>.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<p class=\"muted\">Job listings are private on this server. <a href=\"/login?next=%2F\">Sign in</a> to see your own runs, open a job with the URL <span class=\"mono\">atkins</span> printed, or list them over <span class=\"mono\">/api/job</span>.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"muted\">Nothing dispatched yet. Attach a machine with <span class=\"mono\">atkins --login</span> and run <span class=\"mono\">atkins</span> inside a git repository.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<p class=\"muted\">Nothing dispatched yet. Attach a machine with <span class=\"mono\">atkins --login</span> and run <span class=\"mono\">atkins</span> inside a git repository.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -33,9 +33,9 @@ import (
 )
 
 // ViewTokenParam is the query parameter carrying a job's view token.
-// One letter, because it rides along in a URL a human copies out of a
-// terminal.
-const ViewTokenParam = "t"
+// The API builds the same links, so the name lives with the model both
+// sides share.
+const ViewTokenParam = model.ViewTokenParam
 
 // Handlers serves the HTML pages.
 type Handlers struct {
@@ -182,31 +182,56 @@ type IndexPage struct {
 	// that will not change on its own.
 	Refresh int
 
-	// Private is set when the listing is withheld, so the page can say
-	// why rather than looking like an instance nobody has ever used.
+	// Private is set when the listing is withheld for want of a session,
+	// so the page can offer a way in rather than looking like an
+	// instance nobody has ever used.
 	Private bool
+
+	// Scoped is set when the listing is the signed-in user's own runs
+	// rather than everything on the instance.
+	Scoped bool
+
+	// SignedIn is set when the visitor has a session, which decides
+	// whether the page offers a sign-in link or an admin one.
+	SignedIn bool
 }
 
 // Index lists recent jobs.
 //
-// A private instance lists nothing: no per-job token can scope a
-// listing and there is no session to scope it by, so the listing lives
-// on /api/job where the caller is authenticated. The page still
-// answers, and says why — it is the server's front door, and a health
-// check probing it should find a server rather than a refusal.
+// A private instance scopes the listing to whoever is signed in, the
+// way /api/job does for a bearer token: an owner who lost the URL atkins
+// printed can find the job here and the link carries its view token. A
+// visitor with no session is told where to sign in — the page still
+// answers, because it is the server's front door and a health check
+// probing it should find a server rather than a refusal.
 func (h *Handlers) Index(w http.ResponseWriter, r *http.Request) {
+	page := IndexPage{Refresh: 5}
+	filter := storage.ListFilter{Limit: 50}
+
 	if !h.public() {
-		h.render(w, r, indexView(IndexPage{Private: true}, h.links()))
-		return
+		current, err := h.authenticate(r)
+		if err != nil {
+			h.render(w, r, indexView(IndexPage{Private: true}, h.links()))
+			return
+		}
+
+		page.SignedIn = true
+		// An admin sees the instance and an agent works the whole queue,
+		// which is the same rule the API scopes jobs by.
+		if !current.User.IsAdmin && !current.User.IsAgent {
+			filter.ViewerID = current.User.ID
+			page.Scoped = true
+		}
 	}
 
-	jobs, err := h.jobs.List(r.Context(), storage.ListFilter{Limit: 50})
+	jobs, err := h.jobs.List(r.Context(), filter)
 	if err != nil {
 		h.fail(w, r, http.StatusInternalServerError, err)
 		return
 	}
+	page.Jobs = jobs
 
-	h.render(w, r, indexView(IndexPage{Jobs: jobs, Refresh: 5}, h.links()))
+	h.render(w, r, indexView(page, h.links()))
 }
 
 // Job renders one job: its status, the command, and captured output.
@@ -333,8 +358,11 @@ func (h *Handlers) links() Links {
 	return Links{tokens: h.tokens, public: h.public()}
 }
 
-// Listing reports whether the front page lists anything, which is also
-// whether it is worth linking to.
+// Listing reports whether the front page lists anything to a visitor
+// with no session, which is what a job page opened from a printed URL
+// has. A signed-in visitor gets a listing either way, but the markup
+// cannot tell one from the other and a link to an empty page is worse
+// than no link.
 func (l Links) Listing() bool {
 	return l.public
 }
@@ -346,7 +374,7 @@ func (l Links) Listing() bool {
 // carries the token for the job it points at, and never the token for
 // the job it came from.
 func (l Links) Job(jobID string) string {
-	return l.withToken("/job/"+jobID, jobID)
+	return model.JobLink(jobID, l.token(jobID))
 }
 
 // Artefact is where an artefact downloads from.
@@ -360,16 +388,21 @@ func (l Links) Artefact(jobID, artefactID string) string {
 // withToken appends a job's view token to a link, unless the instance
 // is public or has no signing key to derive one from.
 func (l Links) withToken(link, jobID string) string {
-	if l.public || l.tokens == nil {
-		return link
-	}
-
-	token := l.tokens.ViewToken(jobID)
+	token := l.token(jobID)
 	if token == "" {
 		return link
 	}
 
 	return link + "?" + ViewTokenParam + "=" + token
+}
+
+// token is the view token a link should carry, or empty when the
+// instance is public or has no signing key to derive one from.
+func (l Links) token(jobID string) string {
+	if l.public || l.tokens == nil {
+		return ""
+	}
+	return l.tokens.ViewToken(jobID)
 }
 
 // filesize renders a byte count the way a person reads one.


### PR DESCRIPTION
Fixes #45. Both halves, as asked.

The view token was returned by the call that created the job and nowhere else, so the URL `atkins` printed was the only copy. Lose the scrollback and the owner of a job — who may read the job, its output and its artefacts over the API — could not open it in a browser. The token is `HMAC(signing key, job id)`, derived rather than stored, so nothing was being withheld for safety.

## API

`GET /api/job/{id}` and `GET /api/job` return `view_token` and a ready-made `url` next to the row, for callers that already passed `readableJob` — the same rule the rest of the payload follows. Empty token on a public instance, exactly as dispatch does today. The `url` is server-relative, like an artefact's: the caller knows which server it asked, and inventing a hostname here would be a guess.

This also covers the fan-out case from the issue — a job that wants to print links for jobs it did not dispatch itself now has a route to one.

## Front page

`/` was refusing to list anything on a private instance, even to a signed-in visitor, so there was no clickable path to a job in the browser at all. It now scopes the listing to the session the way `/api/job` scopes to a token: signed in, your own runs, with each link carrying the view token for the job it points at; an admin or agent sees the instance. Signed out, the page still answers and says where to sign in — it is the front door and a health check should find a server there.

Both sides build the link through the new `model.JobLink`, so the page and the API cannot drift into disagreeing about what opens a job. `web.ViewTokenParam` is now an alias of the model constant.

## Tests

`server/job_link_test.go`:

- the token from dispatch is rebuildable from `GET /api/job/{id}`, appears in the listing, and the returned `url` opens the page with no session;
- a public instance returns no token and a bare `/job/{id}` that still opens;
- a user who may not read the job still gets a 404, not a link — handing out the token is safe *because* the caller passed the scope;
- the front page, driven as a browser: anonymous sees the sign-in notice and no commands, `dev` sees only their own run with a working tokenised link, the admin sees both.

`atkins test:simple` passes: 1378 tests, four more than `main`'s 1374 (checked against a worktree at `main`).

Docs updated in `docs/content/usage/ci-cd.md` — the dispatch paragraph and the `/` paragraph both described the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)