### PR TITLE
Carry the skills a repository uses with atkins --vendor

### DIFF
--- a/docs/api/atkins.md
+++ b/docs/api/atkins.md
@@ -37,6 +37,9 @@ type Options struct {
 	// Config opens the configuration menu for .atkins/config.yml.
 	Config bool
 
+	// Vendor copies the skills this repository uses into .atkins/skills.
+	Vendor bool
+
 	FlagSet *cli.FlagSet
 }
 ```

--- a/docs/api/atkins.md
+++ b/docs/api/atkins.md
@@ -38,7 +38,9 @@ type Options struct {
 	Config bool
 
 	// Vendor copies the skills this repository uses into .atkins/skills.
+	// It reports the selection and writes nothing unless Write is set.
 	Vendor bool
+	Write  bool
 
 	FlagSet *cli.FlagSet
 }

--- a/docs/api/atkins_runner.md
+++ b/docs/api/atkins_runner.md
@@ -259,6 +259,69 @@ type VarPromise struct {
 }
 ```
 
+```go
+// VendorResult reports what a vendoring run found, matched and wrote.
+type VendorResult struct {
+	// SourceDir is the skills directory that was read.
+	SourceDir string
+
+	// TargetDir is the repository directory that was written to.
+	TargetDir string
+
+	// Found are all skills available in SourceDir.
+	Found []*VendorSkill
+
+	// Used are the skills this repository has a use for.
+	Used []*VendorSkill
+
+	// Installed are the IDs written to (or already identical in) TargetDir.
+	Installed []string
+
+	// Skipped are the IDs left alone because the repository carries its
+	// own, different, copy of that skill.
+	Skipped []string
+}
+```
+
+```go
+// VendorSkill is a candidate skill file, with the reason it was picked
+// for vendoring once it has been matched against a repository.
+type VendorSkill struct {
+	// ID is the skill namespace, taken from the file name.
+	ID string
+
+	// Path is the absolute path of the source skill file.
+	Path string
+
+	// Pipeline is the parsed skill.
+	Pipeline *model.Pipeline
+
+	// Reason records why the skill is used here, e.g. the path that
+	// satisfied its when: block, or the pipeline that references it.
+	Reason string
+}
+```
+
+```go
+// Vendorer copies the skills a repository uses out of a shared skills
+// directory and into the repository itself, so a clone or a CI agent
+// gets the same jobs without a personal $HOME/.atkins/skills.
+type Vendorer struct {
+	// SourceDir is the skills directory to vendor from, typically
+	// $HOME/.atkins/skills.
+	SourceDir string
+
+	// Root is the repository root, the folder holding .git.
+	Root string
+
+	// TargetDir is where skills are written, Root/.atkins/skills.
+	TargetDir string
+
+	// SkipDirs are directory names not descended into.
+	SkipDirs []string
+}
+```
+
 ## Consts
 
 ```go
@@ -293,6 +356,7 @@ var ErrJobSkipped = errors.New("job skipped")
 - `func EvaluateIf (ctx *ExecutionContext) (bool, error)`
 - `func EvaluateJobIf (ctx *ExecutionContext) (bool, error)`
 - `func ExpandFor (ctx *ExecutionContext, executeCommand func(string) (string, error)) ([]IterationContext, error)`
+- `func FindRepositoryRoot (startDir string) (string, error)`
 - `func GetDependencies (dependsOn any) []string`
 - `func InterpolateCommand (cmd string, ctx *ExecutionContext) (string, error)`
 - `func InterpolateMap (ctx *ExecutionContext, m map[string]any) error`
@@ -318,6 +382,7 @@ var ErrJobSkipped = errors.New("job skipped")
 - `func NewSkillResolver (pipeline *model.Pipeline) *TaskResolver`
 - `func NewSkillsLoader (workspaceDir,startDir string) *SkillsLoader`
 - `func NewTaskResolver (pipelines []*model.Pipeline) *TaskResolver`
+- `func NewVendorer (sourceDir,root string) *Vendorer`
 - `func ProcessDecl (ctx *ExecutionContext, decl *model.Decl) (map[string]any, error)`
 - `func ResolveJobDependencies (jobs map[string]*model.Job, startingJob string) ([]string, error)`
 - `func RunPipeline (ctx context.Context, pipeline *model.Pipeline, opts PipelineOptions) error`
@@ -355,6 +420,9 @@ var ErrJobSkipped = errors.New("job skipped")
 - `func (*TaskResolver) Resolve (taskName string) (*model.ResolvedTask, error)`
 - `func (*TaskResolver) ResolveName (name string, strict bool) (*model.ResolvedTask, error)`
 - `func (*TaskResolver) ResolveWithFallback (taskName string, fallback *TaskResolver) (*model.ResolvedTask, error)`
+- `func (*Vendorer) Install (result *VendorResult) error`
+- `func (*Vendorer) Plan () (*VendorResult, error)`
+- `func (*Vendorer) Run () (*VendorResult, error)`
 - `func (Env) Environ () []string`
 - `func (Env) Sanitized () Env`
 - `func (ExecError) Error () string`
@@ -437,6 +505,15 @@ When multiple iterators are provided, computes the cartesian product.
 
 ```go
 func ExpandFor(ctx *ExecutionContext, executeCommand func(string) (string, error)) ([]IterationContext, error)
+```
+
+### FindRepositoryRoot
+
+FindRepositoryRoot returns the folder holding .git, starting at
+startDir and traversing parent directories.
+
+```go
+func FindRepositoryRoot(startDir string) (string, error)
 ```
 
 ### GetDependencies
@@ -655,6 +732,14 @@ NewTaskResolver will provide a task resolver for a set of pipelines.
 
 ```go
 func NewTaskResolver(pipelines []*model.Pipeline) *TaskResolver
+```
+
+### NewVendorer
+
+NewVendorer creates a vendorer writing into root/.atkins/skills.
+
+```go
+func NewVendorer(sourceDir, root string) *Vendorer
 ```
 
 ### ProcessDecl
@@ -980,6 +1065,40 @@ resolver is used.
 
 ```go
 func (*TaskResolver) ResolveWithFallback(taskName string, fallback *TaskResolver) (*model.ResolvedTask, error)
+```
+
+### Install
+
+Install copies the selected skills into TargetDir, creating it when
+it doesn't exist. A skill the repository already carries under the
+same name, with different contents, is left alone: a project skill
+takes precedence over a global one at load time, and overwriting it
+would throw away the project's own copy.
+
+```go
+func (*Vendorer) Install(result *VendorResult) error
+```
+
+### Plan
+
+Plan reads the source skills and decides which of them this
+repository uses, without writing anything.
+
+A skill is used when its when: block matches a path anywhere in the
+repository, when it has no when: block at all (it is active
+everywhere), or when a pipeline in the repository - or another
+selected skill - references one of its jobs.
+
+```go
+func (*Vendorer) Plan() (*VendorResult, error)
+```
+
+### Run
+
+Run plans the vendoring and installs what it selected.
+
+```go
+func (*Vendorer) Run() (*VendorResult, error)
 ```
 
 ### Environ

--- a/docs/api/atkins_runner.md
+++ b/docs/api/atkins_runner.md
@@ -274,12 +274,9 @@ type VendorResult struct {
 	// Used are the skills this repository has a use for.
 	Used []*VendorSkill
 
-	// Installed are the IDs written to (or already identical in) TargetDir.
+	// Installed are the IDs written to TargetDir. It stays empty on a
+	// dry run; Pending says what a write would have done.
 	Installed []string
-
-	// Skipped are the IDs left alone because the repository carries its
-	// own, different, copy of that skill.
-	Skipped []string
 }
 ```
 
@@ -299,7 +296,24 @@ type VendorSkill struct {
 	// Reason records why the skill is used here, e.g. the path that
 	// satisfied its when: block, or the pipeline that references it.
 	Reason string
+
+	// Status is what installing this skill would do, set for used skills.
+	Status VendorStatus
+
+	// Added and Removed are the line counts installing this skill would
+	// add to and remove from the vendored copy.
+	Added   int
+	Removed int
+
+	// Diff is the unified diff from the vendored copy to the source,
+	// empty when there is nothing to change.
+	Diff string
 }
+```
+
+```go
+// VendorStatus is what installing a skill would do to the repository.
+type VendorStatus string
 ```
 
 ```go
@@ -331,6 +345,20 @@ const (
 	JobProgressPassed  JobProgressStatus = "passed"
 	JobProgressFailed  JobProgressStatus = "failed"
 	JobProgressSkipped JobProgressStatus = "skipped"
+)
+```
+
+```go
+const (
+	// VendorNew means the repository doesn't carry the skill yet.
+	VendorNew VendorStatus = "new"
+
+	// VendorCurrent means an identical copy is already vendored.
+	VendorCurrent VendorStatus = "up to date"
+
+	// VendorChanged means the vendored copy differs from the source and
+	// would be overwritten.
+	VendorChanged VendorStatus = "changed"
 )
 ```
 
@@ -367,6 +395,7 @@ var ErrJobSkipped = errors.New("job skipped")
 - `func ListPipelinesYAML (pipelines []*model.Pipeline) error`
 - `func LoadPipeline (filePath string) ([]*model.Pipeline, error)`
 - `func LoadPipelineFromReader (r io.Reader) ([]*model.Pipeline, error)`
+- `func MatchWhenPattern (dir,pattern string) (string, bool)`
 - `func MergeSkillVariables (ctx *ExecutionContext, decl *model.Decl) error`
 - `func MergeVariables (ctx *ExecutionContext, decl *model.Decl) error`
 - `func NewContextVariables (values map[string]any) *ContextVariables`
@@ -420,6 +449,7 @@ var ErrJobSkipped = errors.New("job skipped")
 - `func (*TaskResolver) Resolve (taskName string) (*model.ResolvedTask, error)`
 - `func (*TaskResolver) ResolveName (name string, strict bool) (*model.ResolvedTask, error)`
 - `func (*TaskResolver) ResolveWithFallback (taskName string, fallback *TaskResolver) (*model.ResolvedTask, error)`
+- `func (*VendorResult) Pending () []string`
 - `func (*Vendorer) Install (result *VendorResult) error`
 - `func (*Vendorer) Plan () (*VendorResult, error)`
 - `func (*Vendorer) Run () (*VendorResult, error)`
@@ -598,6 +628,20 @@ Returns the parsed pipeline(s) and any error.
 
 ```go
 func LoadPipelineFromReader(r io.Reader) ([]*model.Pipeline, error)
+```
+
+### MatchWhenPattern
+
+MatchWhenPattern reports whether a `when: files:` pattern resolves to
+something inside dir, and what it resolved to.
+
+A pattern carrying a glob meta character is expanded, so a skill can
+activate on the contents of a folder rather than its name:
+`schema/*.up.sql` matches a folder of migrations, while `schema/`
+matches any folder of that name.
+
+```go
+func MatchWhenPattern(dir, pattern string) (string, bool)
 ```
 
 ### MergeSkillVariables
@@ -1067,13 +1111,21 @@ resolver is used.
 func (*TaskResolver) ResolveWithFallback(taskName string, fallback *TaskResolver) (*model.ResolvedTask, error)
 ```
 
+### Pending
+
+Pending returns the IDs a write would create or overwrite, leaving
+out the skills already vendored unchanged.
+
+```go
+func (*VendorResult) Pending() []string
+```
+
 ### Install
 
-Install copies the selected skills into TargetDir, creating it when
-it doesn't exist. A skill the repository already carries under the
-same name, with different contents, is left alone: a project skill
-takes precedence over a global one at load time, and overwriting it
-would throw away the project's own copy.
+Install copies the selected skills into TargetDir, creating it when it
+doesn't exist, and overwrites a vendored copy that has drifted from
+its source. Vendored skills are tracked files like any other, so
+reverting an unwanted change is the user's call, not this command's.
 
 ```go
 func (*Vendorer) Install(result *VendorResult) error
@@ -1096,6 +1148,9 @@ func (*Vendorer) Plan() (*VendorResult, error)
 ### Run
 
 Run plans the vendoring and installs what it selected.
+
+Plan on its own is the dry run: it reports the same selection without
+touching the repository.
 
 ```go
 func (*Vendorer) Run() (*VendorResult, error)

--- a/docs/content/STRUCTURE.md
+++ b/docs/content/STRUCTURE.md
@@ -66,11 +66,11 @@ For loops and iteration. Covers loop syntax, required variables, and task invoca
 
 ### Skills
 
-Modular pipeline components. Covers skill locations (project and global), conditional activation with `when:`, namespacing, aliases, default jobs, cross-skill references, skill variables, and example skills (Go, Docker, Node.js).
+Modular pipeline components. Covers skill locations (project and global), conditional activation with `when:`, namespacing, aliases, default jobs, cross-skill references, skill variables, example skills (Go, Docker, Node.js), and vendoring global skills into a repository with `--vendor`.
 
 ### CLI Flags
 
-Command-line options reference. Covers all flags (`--file`, `--list`, `--lint`, `--json`, `--yaml`, `--final`, `--log`, `--debug`, `--working-directory`, `--jail`), file discovery order, running and listing jobs, output modes, and stdin input.
+Command-line options reference. Covers all flags (`--file`, `--list`, `--lint`, `--json`, `--yaml`, `--final`, `--log`, `--debug`, `--working-directory`, `--jail`, `--vendor`), file discovery order, running and listing jobs, output modes, and stdin input.
 
 ### Job Targeting
 

--- a/docs/content/STRUCTURE.md
+++ b/docs/content/STRUCTURE.md
@@ -66,11 +66,11 @@ For loops and iteration. Covers loop syntax, required variables, and task invoca
 
 ### Skills
 
-Modular pipeline components. Covers skill locations (project and global), conditional activation with `when:`, namespacing, aliases, default jobs, cross-skill references, skill variables, example skills (Go, Docker, Node.js), and vendoring global skills into a repository with `--vendor`.
+Modular pipeline components. Covers skill locations (project and global), conditional activation with `when:` and glob patterns, namespacing, aliases, default jobs, cross-skill references, skill variables, example skills (Go, Docker, Node.js), and vendoring global skills into a repository with `--vendor` / `--write`.
 
 ### CLI Flags
 
-Command-line options reference. Covers all flags (`--file`, `--list`, `--lint`, `--json`, `--yaml`, `--final`, `--log`, `--debug`, `--working-directory`, `--jail`, `--vendor`), file discovery order, running and listing jobs, output modes, and stdin input.
+Command-line options reference. Covers all flags (`--file`, `--list`, `--lint`, `--json`, `--yaml`, `--final`, `--log`, `--debug`, `--working-directory`, `--jail`, `--vendor`, `--write`), file discovery order, running and listing jobs, output modes, and stdin input.
 
 ### Job Targeting
 

--- a/docs/content/usage/cli-flags.md
+++ b/docs/content/usage/cli-flags.md
@@ -31,7 +31,8 @@ Running jobs is the default, so `atkins build` and `atkins run build` are the sa
 | `--version`           | `-v`  | Print version and build information    |
 | `--working-directory` | `-w`  | Change directory before running        |
 | `--jail`              |       | Restrict to project scope only         |
-| `--vendor`            |       | Copy used skills into `.atkins/skills` |
+| `--vendor`            |       | List the skills this repository uses   |
+| `--write`             |       | With `--vendor`, write them            |
 | `--config`            |       | Open the configuration menu            |
 | `--login`             |       | Log in to a CI/CD server               |
 | `--register`          |       | Register an account on a CI/CD server  |
@@ -208,7 +209,7 @@ With `--jail`:
 
 ## Vendoring Skills
 
-Copy the skills this repository uses out of `$HOME/.atkins/skills` and into `.atkins/skills` next to `.git`:
+Report the skills this repository uses from `$HOME/.atkins/skills`, and what copying them into `.atkins/skills` next to `.git` would change:
 
 ```bash
 atkins --vendor
@@ -217,10 +218,20 @@ atkins --vendor
 ```text
 Found 7 local skills.
 Found usage for 3 skills.
-Installed: docker, go, mdox.
+  + docker  +45 -0 (new)
+  ✓ go      (up to date)
+  ~ mdox    +4 -1 (changed)
+Would install: docker, mdox.
+Run atkins --vendor --write to write them.
 ```
 
-The copies are ordinary repository content, so a clone or a CI agent gets the same jobs without a personal skills directory. `--vendor` and `--jail` cannot be combined: jail mode excludes the directory vendoring reads from. See [Skills](./skills#vendoring) for the selection rules.
+Nothing is written until `--write`, which creates the missing skills and overwrites a vendored copy that has drifted:
+
+```bash
+atkins --vendor --write
+```
+
+`--debug` adds the reason each skill was selected and the diff behind the line counts. The copies are ordinary repository content, so a clone or a CI agent gets the same jobs without a personal skills directory. `--vendor` and `--jail` cannot be combined: jail mode excludes the directory vendoring reads from. See [Skills](./skills#vendoring) for the selection rules.
 
 ## Configuration
 

--- a/docs/content/usage/cli-flags.md
+++ b/docs/content/usage/cli-flags.md
@@ -31,6 +31,7 @@ Running jobs is the default, so `atkins build` and `atkins run build` are the sa
 | `--version`           | `-v`  | Print version and build information    |
 | `--working-directory` | `-w`  | Change directory before running        |
 | `--jail`              |       | Restrict to project scope only         |
+| `--vendor`            |       | Copy used skills into `.atkins/skills` |
 | `--config`            |       | Open the configuration menu            |
 | `--login`             |       | Log in to a CI/CD server               |
 | `--register`          |       | Register an account on a CI/CD server  |
@@ -204,6 +205,22 @@ Without `--jail`:
 With `--jail`:
 - Only loads from `.atkins/skills/`
 - Ignores global skills
+
+## Vendoring Skills
+
+Copy the skills this repository uses out of `$HOME/.atkins/skills` and into `.atkins/skills` next to `.git`:
+
+```bash
+atkins --vendor
+```
+
+```text
+Found 7 local skills.
+Found usage for 3 skills.
+Installed: docker, go, mdox.
+```
+
+The copies are ordinary repository content, so a clone or a CI agent gets the same jobs without a personal skills directory. `--vendor` and `--jail` cannot be combined: jail mode excludes the directory vendoring reads from. See [Skills](./skills#vendoring) for the selection rules.
 
 ## Configuration
 

--- a/docs/content/usage/skills.md
+++ b/docs/content/usage/skills.md
@@ -298,6 +298,47 @@ Useful for:
 - Avoiding personal customizations
 - Testing project-only configurations
 
+## Vendoring
+
+Global skills live on one machine. A pipeline that leans on `~/.atkins/skills/compose.yml` runs on the laptop it was written on and fails on a clean clone, and a CI agent is exactly the machine with no personal skills directory.
+
+`--vendor` copies the skills a repository uses into the repository:
+
+```bash
+atkins --vendor
+```
+
+```text
+Found 7 local skills.
+Found usage for 3 skills.
+Installed: docker, go, mdox.
+```
+
+Skills are written to `.atkins/skills/` next to `.git`, so they apply to the whole repository, and the folder is created if it doesn't exist yet. The copies are ordinary repository content: commit them like any other dependency, and an update is a re-run and a diff.
+
+### Selection Rules
+
+A skill is vendored when any of these hold:
+
+- Its `when:` block matches a path anywhere in the repository. The search descends the tree rather than climbing it, so a `schema/` folder in a submodule selects the schema skill, the same way it activates there.
+- It has no `when:` block, which makes it active everywhere.
+- A pipeline in the repository names one of its jobs through `task:` or `depends_on:`. A reference to `docker:build` selects the docker skill even without a `docker/Dockerfile`.
+- A skill already selected names one of its jobs. A release skill calling `:docker:build` brings the docker skill with it.
+
+Dot directories and `node_modules`, `vendor`, `testdata`, `bin`, `dist` and `coverage` are not descended into.
+
+### Local Copies Win
+
+If `.atkins/skills/` already carries a skill of the same name with different contents, it is left alone and reported:
+
+```text
+Skipped: go (.atkins/skills carries its own copy).
+```
+
+Project skills take precedence over global ones at load time, so a local copy that has drifted is a deliberate override. To re-vendor it, delete the local file first.
+
+`--vendor` cannot be combined with `--jail`, which excludes the `$HOME/.atkins/skills` that vendoring reads from.
+
 ## Listing Skills
 
 View all active skills and their jobs:

--- a/docs/content/usage/skills.md
+++ b/docs/content/usage/skills.md
@@ -51,6 +51,14 @@ Skills are YAML pipeline files with a `when:` block for conditional activation:
 
 The `when:` block controls when a skill is available. Multiple files use OR logic - any match activates the skill. File patterns search upward from the current directory.
 
+A pattern carrying `*`, `?` or `[...]` is expanded as a glob, so a skill can activate on what a folder holds rather than on its name:
+
+```yaml
+when:
+  files:
+    - schema/*.up.sql    # a folder of migrations, not any folder called schema
+```
+
 ## Skill Namespacing
 
 Skills automatically namespace their jobs:
@@ -302,7 +310,7 @@ Useful for:
 
 Global skills live on one machine. A pipeline that leans on `~/.atkins/skills/compose.yml` runs on the laptop it was written on and fails on a clean clone, and a CI agent is exactly the machine with no personal skills directory.
 
-`--vendor` copies the skills a repository uses into the repository:
+`--vendor` reports the skills a repository uses and what copying them would change:
 
 ```bash
 atkins --vendor
@@ -311,31 +319,44 @@ atkins --vendor
 ```text
 Found 7 local skills.
 Found usage for 3 skills.
-Installed: docker, go, mdox.
+  + docker  +45 -0 (new)
+  ✓ go      (up to date)
+  ~ mdox    +4 -1 (changed)
+Would install: docker, mdox.
+Run atkins --vendor --write to write them.
+```
+
+A skill already vendored unchanged gets a checkmark; one that would be created or overwritten gets the lines the write adds and removes. `--debug` adds the reason each skill was selected, and the diff behind the counts.
+
+Nothing is written until `--write`:
+
+```bash
+atkins --vendor --write
+```
+
+```text
+Found 7 local skills.
+Found usage for 3 skills.
+  + docker  +45 -0 (new)
+  ✓ go      (up to date)
+  ~ mdox    +4 -1 (changed)
+Installed: docker, mdox.
 ```
 
 Skills are written to `.atkins/skills/` next to `.git`, so they apply to the whole repository, and the folder is created if it doesn't exist yet. The copies are ordinary repository content: commit them like any other dependency, and an update is a re-run and a diff.
+
+A vendored copy that has drifted from its source is overwritten. Skills are tracked files, so reverting a change you wanted to keep is `git checkout` — which is why the dry run shows the diff first.
 
 ### Selection Rules
 
 A skill is vendored when any of these hold:
 
-- Its `when:` block matches a path anywhere in the repository. The search descends the tree rather than climbing it, so a `schema/` folder in a submodule selects the schema skill, the same way it activates there.
+- Its `when:` block matches a path anywhere in the repository. The search descends the tree rather than climbing it, so a `schema/*.up.sql` file in a submodule selects the schema skill, the same way it activates there.
 - It has no `when:` block, which makes it active everywhere.
 - A pipeline in the repository names one of its jobs through `task:` or `depends_on:`. A reference to `docker:build` selects the docker skill even without a `docker/Dockerfile`.
 - A skill already selected names one of its jobs. A release skill calling `:docker:build` brings the docker skill with it.
 
 Dot directories and `node_modules`, `vendor`, `testdata`, `bin`, `dist` and `coverage` are not descended into.
-
-### Local Copies Win
-
-If `.atkins/skills/` already carries a skill of the same name with different contents, it is left alone and reported:
-
-```text
-Skipped: go (.atkins/skills carries its own copy).
-```
-
-Project skills take precedence over global ones at load time, so a local copy that has drifted is a deliberate override. To re-vendor it, delete the local file first.
 
 `--vendor` cannot be combined with `--jail`, which excludes the `$HOME/.atkins/skills` that vendoring reads from.
 

--- a/docs/schema/pipeline.md
+++ b/docs/schema/pipeline.md
@@ -117,7 +117,7 @@ jobs:
       - run: go build ./...
 ```
 
-The `when.files` condition activates this skill when `go.mod` exists.
+The `when.files` condition activates this skill when `go.mod` exists. Entries carrying `*`, `?` or `[...]` are expanded as globs, so `schema/*.up.sql` activates on a folder of migrations rather than on any folder named `schema`.
 
 ## Multi-Document Pipelines
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/oklog/ulid/v2 v2.1.2
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/titpetric/cli v0.5.0
@@ -57,7 +58,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/riandyrn/otelchi v0.12.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/options.go
+++ b/options.go
@@ -30,6 +30,9 @@ type Options struct {
 	// Config opens the configuration menu for .atkins/config.yml.
 	Config bool
 
+	// Vendor copies the skills this repository uses into .atkins/skills.
+	Vendor bool
+
 	FlagSet *cli.FlagSet
 }
 
@@ -56,6 +59,7 @@ func (o *Options) Bind(fs *cli.FlagSet) {
 	fs.BoolVar(&o.Logout, "logout", false, "Log out of the atkins CI/CD server")
 	fs.BoolVar(&o.Local, "local", false, "Run here instead of dispatching to the CI/CD server")
 	fs.BoolVar(&o.Config, "config", false, "Open the configuration menu for .atkins/config.yml")
+	fs.BoolVar(&o.Vendor, "vendor", false, "Copy the skills this repository uses into .atkins/skills")
 
 	o.FlagSet = fs
 }

--- a/options.go
+++ b/options.go
@@ -31,7 +31,9 @@ type Options struct {
 	Config bool
 
 	// Vendor copies the skills this repository uses into .atkins/skills.
+	// It reports the selection and writes nothing unless Write is set.
 	Vendor bool
+	Write  bool
 
 	FlagSet *cli.FlagSet
 }
@@ -59,7 +61,8 @@ func (o *Options) Bind(fs *cli.FlagSet) {
 	fs.BoolVar(&o.Logout, "logout", false, "Log out of the atkins CI/CD server")
 	fs.BoolVar(&o.Local, "local", false, "Run here instead of dispatching to the CI/CD server")
 	fs.BoolVar(&o.Config, "config", false, "Open the configuration menu for .atkins/config.yml")
-	fs.BoolVar(&o.Vendor, "vendor", false, "Copy the skills this repository uses into .atkins/skills")
+	fs.BoolVar(&o.Vendor, "vendor", false, "List the skills this repository uses from $HOME/.atkins/skills")
+	fs.BoolVar(&o.Write, "write", false, "With --vendor, write the skills into .atkins/skills")
 
 	o.FlagSet = fs
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -98,10 +98,13 @@ func runPipeline(ctx context.Context, opts *Options, args []string) error {
 	client.Configure(settings.Client)
 
 	// These flags take over the whole invocation: they open the
-	// configuration menu or authenticate against a server, and exit.
+	// configuration menu, vendor skills into the repository, or
+	// authenticate against a server, and exit.
 	switch {
 	case opts.Config:
 		return runConfig(cwd)
+	case opts.Vendor:
+		return runVendor(cwd, opts)
 	case opts.Login != "":
 		return client.RunLogin(ctx, opts.Login)
 	case opts.Register != "":

--- a/runner/skills_loader.go
+++ b/runner/skills_loader.go
@@ -156,8 +156,8 @@ func (l *SkillsLoader) FindFile(patterns []string, startDir string) (matchDir st
 	// First, check absolute paths (no traversal needed)
 	for _, pattern := range patterns {
 		if filepath.IsAbs(pattern) {
-			if _, err := os.Stat(pattern); err == nil {
-				return filepath.Dir(pattern), true
+			if match, ok := MatchWhenPattern("", pattern); ok {
+				return filepath.Dir(match), true
 			}
 		}
 	}
@@ -170,8 +170,7 @@ func (l *SkillsLoader) FindFile(patterns []string, startDir string) (matchDir st
 				continue // Already handled above
 			}
 
-			candidate := filepath.Join(current, pattern)
-			if _, err := os.Stat(candidate); err == nil {
+			if _, ok := MatchWhenPattern(current, pattern); ok {
 				return current, true
 			}
 		}
@@ -183,4 +182,31 @@ func (l *SkillsLoader) FindFile(patterns []string, startDir string) (matchDir st
 		}
 		current = parent
 	}
+}
+
+// MatchWhenPattern reports whether a `when: files:` pattern resolves to
+// something inside dir, and what it resolved to.
+//
+// A pattern carrying a glob meta character is expanded, so a skill can
+// activate on the contents of a folder rather than its name:
+// `schema/*.up.sql` matches a folder of migrations, while `schema/`
+// matches any folder of that name.
+func MatchWhenPattern(dir, pattern string) (match string, found bool) {
+	candidate := filepath.Join(dir, pattern)
+
+	if !strings.ContainsAny(pattern, "*?[") {
+		if _, err := os.Stat(candidate); err != nil {
+			return "", false
+		}
+		return candidate, true
+	}
+
+	// Glob reports only a malformed pattern as an error, which is the
+	// skill author's problem to see as "never matches".
+	matches, err := filepath.Glob(candidate)
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+
+	return matches[0], true
 }

--- a/runner/skills_test.go
+++ b/runner/skills_test.go
@@ -154,6 +154,55 @@ func TestFindFile(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, tmpDir, matchDir)
 	})
+
+	t.Run("expands a glob pattern", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		schemaDir := filepath.Join(tmpDir, "schema")
+		require.NoError(t, os.MkdirAll(schemaDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(schemaDir, "user.up.sql"), []byte(""), 0o644))
+
+		loader := runner.NewSkillsLoader(tmpDir, tmpDir)
+		matchDir, found := loader.FindFile([]string{"schema/*.up.sql"}, tmpDir)
+		assert.True(t, found)
+		assert.Equal(t, tmpDir, matchDir)
+	})
+
+	t.Run("leaves a glob pattern unmatched when nothing fits", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		schemaDir := filepath.Join(tmpDir, "schema")
+		require.NoError(t, os.MkdirAll(schemaDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(schemaDir, "docs.md"), []byte(""), 0o644))
+
+		loader := runner.NewSkillsLoader(tmpDir, tmpDir)
+		_, found := loader.FindFile([]string{"schema/*.up.sql"}, tmpDir)
+		assert.False(t, found)
+	})
+}
+
+// TestMatchWhenPattern tests resolving a single when: files pattern.
+func TestMatchWhenPattern(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "schema"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "schema", "user.up.sql"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(""), 0o644))
+
+	for _, tc := range []struct {
+		pattern string
+		match   string
+	}{
+		{pattern: "go.mod", match: filepath.Join(tmpDir, "go.mod")},
+		{pattern: "schema/", match: filepath.Join(tmpDir, "schema")},
+		{pattern: "schema/*.up.sql", match: filepath.Join(tmpDir, "schema", "user.up.sql")},
+		{pattern: "schema/*.down.sql", match: ""},
+		{pattern: "Dockerfile", match: ""},
+		{pattern: "*.mod", match: filepath.Join(tmpDir, "go.mod")},
+	} {
+		t.Run(tc.pattern, func(t *testing.T) {
+			match, found := runner.MatchWhenPattern(tmpDir, tc.pattern)
+			assert.Equal(t, tc.match != "", found)
+			assert.Equal(t, tc.match, match)
+		})
+	}
 }
 
 // TestSkillsLoader tests the SkillsLoader for loading and evaluating skills.

--- a/runner/skills_vendor.go
+++ b/runner/skills_vendor.go
@@ -8,7 +8,24 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pmezard/go-difflib/difflib"
+
 	"github.com/titpetric/atkins/model"
+)
+
+// VendorStatus is what installing a skill would do to the repository.
+type VendorStatus string
+
+const (
+	// VendorNew means the repository doesn't carry the skill yet.
+	VendorNew VendorStatus = "new"
+
+	// VendorCurrent means an identical copy is already vendored.
+	VendorCurrent VendorStatus = "up to date"
+
+	// VendorChanged means the vendored copy differs from the source and
+	// would be overwritten.
+	VendorChanged VendorStatus = "changed"
 )
 
 // VendorSkill is a candidate skill file, with the reason it was picked
@@ -26,6 +43,18 @@ type VendorSkill struct {
 	// Reason records why the skill is used here, e.g. the path that
 	// satisfied its when: block, or the pipeline that references it.
 	Reason string
+
+	// Status is what installing this skill would do, set for used skills.
+	Status VendorStatus
+
+	// Added and Removed are the line counts installing this skill would
+	// add to and remove from the vendored copy.
+	Added   int
+	Removed int
+
+	// Diff is the unified diff from the vendored copy to the source,
+	// empty when there is nothing to change.
+	Diff string
 }
 
 // VendorResult reports what a vendoring run found, matched and wrote.
@@ -42,12 +71,21 @@ type VendorResult struct {
 	// Used are the skills this repository has a use for.
 	Used []*VendorSkill
 
-	// Installed are the IDs written to (or already identical in) TargetDir.
+	// Installed are the IDs written to TargetDir. It stays empty on a
+	// dry run; Pending says what a write would have done.
 	Installed []string
+}
 
-	// Skipped are the IDs left alone because the repository carries its
-	// own, different, copy of that skill.
-	Skipped []string
+// Pending returns the IDs a write would create or overwrite, leaving
+// out the skills already vendored unchanged.
+func (r *VendorResult) Pending() []string {
+	var pending []string
+	for _, skill := range r.Used {
+		if skill.Status != VendorCurrent {
+			pending = append(pending, skill.ID)
+		}
+	}
+	return pending
 }
 
 // vendorSkipDirs are directory names not descended into when looking for
@@ -113,6 +151,9 @@ func FindRepositoryRoot(startDir string) (string, error) {
 }
 
 // Run plans the vendoring and installs what it selected.
+//
+// Plan on its own is the dry run: it reports the same selection without
+// touching the repository.
 func (v *Vendorer) Run() (*VendorResult, error) {
 	result, err := v.Plan()
 	if err != nil {
@@ -211,22 +252,97 @@ func (v *Vendorer) Plan() (*VendorResult, error) {
 	}
 
 	for _, candidate := range candidates {
-		if reason, ok := used[candidate.ID]; ok {
-			candidate.Reason = reason
-			result.Used = append(result.Used, candidate)
+		reason, ok := used[candidate.ID]
+		if !ok {
+			continue
 		}
+
+		candidate.Reason = reason
+		v.compare(candidate)
+		result.Used = append(result.Used, candidate)
 	}
 
 	return result, nil
 }
 
-// Install copies the selected skills into TargetDir, creating it when
-// it doesn't exist. A skill the repository already carries under the
-// same name, with different contents, is left alone: a project skill
-// takes precedence over a global one at load time, and overwriting it
-// would throw away the project's own copy.
+// compare diffs a skill against the copy the repository carries, and
+// records what installing it would change.
+func (v *Vendorer) compare(skill *VendorSkill) {
+	target := filepath.Join(v.TargetDir, filepath.Base(skill.Path))
+
+	existing, readErr := os.ReadFile(target)
+
+	data, err := os.ReadFile(skill.Path)
+	if err != nil {
+		// Install reports the read error properly; treat it as work to do.
+		skill.Status = VendorChanged
+		return
+	}
+
+	from, to := diffLines(existing), diffLines(data)
+
+	switch {
+	case readErr != nil:
+		// Nothing to diff against, so the whole file is the addition.
+		skill.Status = VendorNew
+		skill.Added = len(to)
+		return
+	case bytes.Equal(existing, data):
+		skill.Status = VendorCurrent
+		return
+	default:
+		skill.Status = VendorChanged
+	}
+
+	for _, op := range difflib.NewMatcher(from, to).GetOpCodes() {
+		switch op.Tag {
+		case 'r':
+			skill.Removed += op.I2 - op.I1
+			skill.Added += op.J2 - op.J1
+		case 'd':
+			skill.Removed += op.I2 - op.I1
+		case 'i':
+			skill.Added += op.J2 - op.J1
+		}
+	}
+
+	fromLabel := target
+	if rel, err := filepath.Rel(v.Root, target); err == nil {
+		fromLabel = rel
+	}
+
+	// A diff that can't be rendered is not worth failing over; the line
+	// counts above are what the caller reports either way.
+	skill.Diff, _ = difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        from,
+		B:        to,
+		FromFile: fromLabel,
+		ToFile:   skill.Path,
+		Context:  3,
+	})
+}
+
+// diffLines splits a file into lines that each keep their newline, with
+// no phantom line for the trailing one.
+func diffLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+
+	lines := strings.SplitAfter(string(data), "\n")
+	if last := len(lines) - 1; lines[last] == "" {
+		return lines[:last]
+	}
+
+	return lines
+}
+
+// Install copies the selected skills into TargetDir, creating it when it
+// doesn't exist, and overwrites a vendored copy that has drifted from
+// its source. Vendored skills are tracked files like any other, so
+// reverting an unwanted change is the user's call, not this command's.
 func (v *Vendorer) Install(result *VendorResult) error {
-	if len(result.Used) == 0 {
+	if len(result.Pending()) == 0 {
 		return nil
 	}
 
@@ -235,24 +351,20 @@ func (v *Vendorer) Install(result *VendorResult) error {
 	}
 
 	for _, skill := range result.Used {
+		if skill.Status == VendorCurrent {
+			continue
+		}
+
 		data, err := os.ReadFile(skill.Path)
 		if err != nil {
 			return fmt.Errorf("failed to read skill %s: %w", skill.Path, err)
 		}
 
 		target := filepath.Join(v.TargetDir, filepath.Base(skill.Path))
-		if existing, err := os.ReadFile(target); err == nil {
-			if !bytes.Equal(existing, data) {
-				result.Skipped = append(result.Skipped, skill.ID)
-				continue
-			}
-			result.Installed = append(result.Installed, skill.ID)
-			continue
-		}
-
 		if err := os.WriteFile(target, data, 0o644); err != nil {
 			return fmt.Errorf("failed to write skill %s: %w", target, err)
 		}
+
 		result.Installed = append(result.Installed, skill.ID)
 	}
 
@@ -343,8 +455,8 @@ func (v *Vendorer) matchWhen(pipeline *model.Pipeline, dirs []string) (reason st
 		if !filepath.IsAbs(pattern) {
 			continue
 		}
-		if _, err := os.Stat(pattern); err == nil {
-			return pattern, true
+		if match, ok := MatchWhenPattern("", pattern); ok {
+			return match, true
 		}
 	}
 
@@ -354,14 +466,14 @@ func (v *Vendorer) matchWhen(pipeline *model.Pipeline, dirs []string) (reason st
 				continue
 			}
 
-			candidate := filepath.Join(dir, pattern)
-			if _, err := os.Stat(candidate); err != nil {
+			match, ok := MatchWhenPattern(dir, pattern)
+			if !ok {
 				continue
 			}
-			if rel, err := filepath.Rel(v.Root, candidate); err == nil {
+			if rel, err := filepath.Rel(v.Root, match); err == nil {
 				return rel, true
 			}
-			return candidate, true
+			return match, true
 		}
 	}
 

--- a/runner/skills_vendor.go
+++ b/runner/skills_vendor.go
@@ -1,0 +1,449 @@
+package runner
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/titpetric/atkins/model"
+)
+
+// VendorSkill is a candidate skill file, with the reason it was picked
+// for vendoring once it has been matched against a repository.
+type VendorSkill struct {
+	// ID is the skill namespace, taken from the file name.
+	ID string
+
+	// Path is the absolute path of the source skill file.
+	Path string
+
+	// Pipeline is the parsed skill.
+	Pipeline *model.Pipeline
+
+	// Reason records why the skill is used here, e.g. the path that
+	// satisfied its when: block, or the pipeline that references it.
+	Reason string
+}
+
+// VendorResult reports what a vendoring run found, matched and wrote.
+type VendorResult struct {
+	// SourceDir is the skills directory that was read.
+	SourceDir string
+
+	// TargetDir is the repository directory that was written to.
+	TargetDir string
+
+	// Found are all skills available in SourceDir.
+	Found []*VendorSkill
+
+	// Used are the skills this repository has a use for.
+	Used []*VendorSkill
+
+	// Installed are the IDs written to (or already identical in) TargetDir.
+	Installed []string
+
+	// Skipped are the IDs left alone because the repository carries its
+	// own, different, copy of that skill.
+	Skipped []string
+}
+
+// vendorSkipDirs are directory names not descended into when looking for
+// when: matches and pipeline files. Dot directories are skipped too, so
+// the repository's own .atkins/ never matches a skill against itself.
+var vendorSkipDirs = []string{
+	"node_modules",
+	"vendor",
+	"testdata",
+	"bin",
+	"dist",
+	"coverage",
+}
+
+// Vendorer copies the skills a repository uses out of a shared skills
+// directory and into the repository itself, so a clone or a CI agent
+// gets the same jobs without a personal $HOME/.atkins/skills.
+type Vendorer struct {
+	// SourceDir is the skills directory to vendor from, typically
+	// $HOME/.atkins/skills.
+	SourceDir string
+
+	// Root is the repository root, the folder holding .git.
+	Root string
+
+	// TargetDir is where skills are written, Root/.atkins/skills.
+	TargetDir string
+
+	// SkipDirs are directory names not descended into.
+	SkipDirs []string
+}
+
+// NewVendorer creates a vendorer writing into root/.atkins/skills.
+func NewVendorer(sourceDir, root string) *Vendorer {
+	return &Vendorer{
+		SourceDir: sourceDir,
+		Root:      root,
+		TargetDir: filepath.Join(root, ".atkins", "skills"),
+		SkipDirs:  vendorSkipDirs,
+	}
+}
+
+// FindRepositoryRoot returns the folder holding .git, starting at
+// startDir and traversing parent directories.
+func FindRepositoryRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	for {
+		// A worktree or a submodule has .git as a file, not a folder.
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no git repository found above %s", startDir)
+		}
+		dir = parent
+	}
+}
+
+// Run plans the vendoring and installs what it selected.
+func (v *Vendorer) Run() (*VendorResult, error) {
+	result, err := v.Plan()
+	if err != nil {
+		return nil, err
+	}
+	if err := v.Install(result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// Plan reads the source skills and decides which of them this
+// repository uses, without writing anything.
+//
+// A skill is used when its when: block matches a path anywhere in the
+// repository, when it has no when: block at all (it is active
+// everywhere), or when a pipeline in the repository - or another
+// selected skill - references one of its jobs.
+func (v *Vendorer) Plan() (*VendorResult, error) {
+	if v.SourceDir == v.TargetDir {
+		return nil, fmt.Errorf("source and target are the same directory: %s", v.SourceDir)
+	}
+
+	result := &VendorResult{
+		SourceDir: v.SourceDir,
+		TargetDir: v.TargetDir,
+	}
+
+	candidates, err := v.candidates()
+	if err != nil {
+		return nil, err
+	}
+	result.Found = candidates
+
+	known := make(map[string]*VendorSkill, len(candidates))
+	for _, candidate := range candidates {
+		known[candidate.ID] = candidate
+	}
+
+	dirs, err := v.walk()
+	if err != nil {
+		return nil, err
+	}
+
+	used := make(map[string]string)
+	var queue []string
+
+	use := func(id, reason string) {
+		if _, ok := known[id]; !ok {
+			return
+		}
+		if _, ok := used[id]; ok {
+			return
+		}
+		used[id] = reason
+		queue = append(queue, id)
+	}
+
+	// Skills the workspace activates on its own.
+	for _, candidate := range candidates {
+		if reason, ok := v.matchWhen(candidate.Pipeline, dirs); ok {
+			use(candidate.ID, reason)
+		}
+	}
+
+	// Skills the repository's pipelines name directly.
+	for _, path := range v.pipelineFiles(dirs) {
+		pipelines, err := LoadPipeline(path)
+		if err != nil {
+			// A pipeline that doesn't parse is a problem for the run
+			// that uses it, not for vendoring; take what we can read.
+			continue
+		}
+
+		label := path
+		if rel, err := filepath.Rel(v.Root, path); err == nil {
+			label = rel
+		}
+
+		for _, pipeline := range pipelines {
+			for _, id := range skillRefs(pipeline) {
+				use(id, "referenced by "+label)
+			}
+		}
+	}
+
+	// Skills the selected skills themselves reach for, e.g. a release
+	// skill calling docker:build.
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+
+		for _, ref := range skillRefs(known[id].Pipeline) {
+			use(ref, "referenced by "+id)
+		}
+	}
+
+	for _, candidate := range candidates {
+		if reason, ok := used[candidate.ID]; ok {
+			candidate.Reason = reason
+			result.Used = append(result.Used, candidate)
+		}
+	}
+
+	return result, nil
+}
+
+// Install copies the selected skills into TargetDir, creating it when
+// it doesn't exist. A skill the repository already carries under the
+// same name, with different contents, is left alone: a project skill
+// takes precedence over a global one at load time, and overwriting it
+// would throw away the project's own copy.
+func (v *Vendorer) Install(result *VendorResult) error {
+	if len(result.Used) == 0 {
+		return nil
+	}
+
+	if err := os.MkdirAll(v.TargetDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", v.TargetDir, err)
+	}
+
+	for _, skill := range result.Used {
+		data, err := os.ReadFile(skill.Path)
+		if err != nil {
+			return fmt.Errorf("failed to read skill %s: %w", skill.Path, err)
+		}
+
+		target := filepath.Join(v.TargetDir, filepath.Base(skill.Path))
+		if existing, err := os.ReadFile(target); err == nil {
+			if !bytes.Equal(existing, data) {
+				result.Skipped = append(result.Skipped, skill.ID)
+				continue
+			}
+			result.Installed = append(result.Installed, skill.ID)
+			continue
+		}
+
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			return fmt.Errorf("failed to write skill %s: %w", target, err)
+		}
+		result.Installed = append(result.Installed, skill.ID)
+	}
+
+	return nil
+}
+
+// candidates loads every skill file in the source directory, sorted by ID.
+func (v *Vendorer) candidates() ([]*VendorSkill, error) {
+	entries, err := os.ReadDir(v.SourceDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read skills directory %s: %w", v.SourceDir, err)
+	}
+
+	loader := &SkillsLoader{}
+	var skills []*VendorSkill
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+
+		path := filepath.Join(v.SourceDir, entry.Name())
+		pipeline, err := loader.loadSkillFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load skill %s: %w", path, err)
+		}
+
+		skills = append(skills, &VendorSkill{
+			ID:       pipeline.ID,
+			Path:     path,
+			Pipeline: pipeline,
+		})
+	}
+
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].ID < skills[j].ID
+	})
+
+	return skills, nil
+}
+
+// walk returns every directory in the repository worth matching against,
+// the root first, skipping dot directories and SkipDirs.
+func (v *Vendorer) walk() ([]string, error) {
+	skip := make(map[string]bool, len(v.SkipDirs))
+	for _, name := range v.SkipDirs {
+		skip[name] = true
+	}
+
+	var dirs []string
+	err := filepath.WalkDir(v.Root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			// An unreadable directory is not worth failing the run over.
+			return nil //nolint:nilerr
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if path == v.Root {
+			dirs = append(dirs, path)
+			return nil
+		}
+		if strings.HasPrefix(entry.Name(), ".") || skip[entry.Name()] {
+			return filepath.SkipDir
+		}
+		dirs = append(dirs, path)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", v.Root, err)
+	}
+
+	return dirs, nil
+}
+
+// matchWhen reports whether a skill's when: block is satisfied anywhere
+// in the repository, and by what. A skill without when: is active
+// everywhere, so it matches by definition.
+func (v *Vendorer) matchWhen(pipeline *model.Pipeline, dirs []string) (reason string, matched bool) {
+	if pipeline.When == nil || len(pipeline.When.Files) == 0 {
+		return "always active", true
+	}
+
+	for _, pattern := range pipeline.When.Files {
+		if !filepath.IsAbs(pattern) {
+			continue
+		}
+		if _, err := os.Stat(pattern); err == nil {
+			return pattern, true
+		}
+	}
+
+	for _, dir := range dirs {
+		for _, pattern := range pipeline.When.Files {
+			if filepath.IsAbs(pattern) {
+				continue
+			}
+
+			candidate := filepath.Join(dir, pattern)
+			if _, err := os.Stat(candidate); err != nil {
+				continue
+			}
+			if rel, err := filepath.Rel(v.Root, candidate); err == nil {
+				return rel, true
+			}
+			return candidate, true
+		}
+	}
+
+	return "", false
+}
+
+// pipelineFiles returns the pipeline files carried by the repository:
+// the config files in the walked directories, plus the project's own
+// skills, which the walk skips along with the rest of .atkins/.
+func (v *Vendorer) pipelineFiles(dirs []string) []string {
+	var files []string
+
+	for _, dir := range dirs {
+		for _, name := range ConfigNames {
+			candidate := filepath.Join(dir, name)
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				files = append(files, candidate)
+			}
+		}
+	}
+
+	entries, err := os.ReadDir(v.TargetDir)
+	if err != nil {
+		return files
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		files = append(files, filepath.Join(v.TargetDir, entry.Name()))
+	}
+
+	return files
+}
+
+// skillRefs returns the skill IDs a pipeline names through task: and
+// depends_on:, in the order they are first seen.
+func skillRefs(pipeline *model.Pipeline) []string {
+	jobs := pipeline.GetJobs()
+	seen := make(map[string]bool)
+
+	var refs []string
+	add := func(ref string) {
+		id, ok := skillRefID(ref, jobs)
+		if !ok || seen[id] {
+			return
+		}
+		seen[id] = true
+		refs = append(refs, id)
+	}
+
+	for _, job := range jobs {
+		for _, dep := range job.DependsOn {
+			add(dep)
+		}
+		for _, step := range job.Children() {
+			if step.Task != "" {
+				add(step.Task)
+			}
+		}
+	}
+
+	sort.Strings(refs)
+	return refs
+}
+
+// skillRefID extracts the skill namespace from a task or dependency
+// reference. A bare name is only a skill reference when the pipeline
+// has no job of its own by that name.
+func skillRefID(ref string, jobs map[string]*model.Job) (string, bool) {
+	ref = strings.TrimPrefix(strings.TrimSpace(ref), ":")
+	if ref == "" {
+		return "", false
+	}
+
+	if index := strings.Index(ref, ":"); index > 0 {
+		return ref[:index], true
+	}
+
+	if _, local := jobs[ref]; local {
+		return "", false
+	}
+
+	return ref, true
+}

--- a/runner/skills_vendor_test.go
+++ b/runner/skills_vendor_test.go
@@ -3,6 +3,7 @@ package runner_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,16 @@ jobs:
       - run: docker build .
 `
 
+const migrationSkill = `name: SQL Migrations
+when:
+  files:
+    - schema/*.up.sql
+jobs:
+  migrate:
+    steps:
+      - run: mig migrate
+`
+
 // TestFindRepositoryRoot covers locating the folder that holds .git.
 func TestFindRepositoryRoot(t *testing.T) {
 	t.Run("finds root from a subdirectory", func(t *testing.T) {
@@ -114,6 +125,28 @@ func TestVendorerPlan(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"schema"}, vendorIDs(result.Used))
 		assert.Equal(t, filepath.Join("modules", "users", "schema"), result.Used[0].Reason)
+	})
+
+	t.Run("matches a glob in when: files", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "schema.yml"), migrationSkill)
+		writeFile(t, filepath.Join(root, "server", "schema", "user.up.sql"), "CREATE TABLE user (id INT);\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"schema"}, vendorIDs(result.Used))
+		assert.Equal(t, filepath.Join("server", "schema", "user.up.sql"), result.Used[0].Reason)
+	})
+
+	t.Run("leaves a glob in when: files unmatched by an empty folder", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "schema.yml"), migrationSkill)
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "docs", "schema"), 0o755))
+		writeFile(t, filepath.Join(root, "docs", "schema", "jobs.md"), "# Jobs\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Empty(t, result.Used)
 	})
 
 	t.Run("skips directories the walk excludes", func(t *testing.T) {
@@ -200,6 +233,77 @@ func TestVendorerPlan(t *testing.T) {
 	})
 }
 
+// TestVendorerPlanDiff covers the status and line counts a dry run reports.
+func TestVendorerPlanDiff(t *testing.T) {
+	t.Run("counts a new skill as all additions", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		require.Len(t, result.Used, 1)
+
+		skill := result.Used[0]
+		assert.Equal(t, runner.VendorNew, skill.Status)
+		assert.Equal(t, 8, skill.Added)
+		assert.Equal(t, 0, skill.Removed)
+		assert.Empty(t, skill.Diff)
+		assert.Equal(t, []string{"go"}, result.Pending())
+	})
+
+	t.Run("reports an identical copy as up to date", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, ".atkins", "skills", "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		require.Len(t, result.Used, 1)
+
+		skill := result.Used[0]
+		assert.Equal(t, runner.VendorCurrent, skill.Status)
+		assert.Zero(t, skill.Added)
+		assert.Zero(t, skill.Removed)
+		assert.Empty(t, skill.Diff)
+		assert.Empty(t, result.Pending())
+	})
+
+	t.Run("counts the lines a changed copy differs by", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		local := strings.Replace(goSkill, "      - run: go build ./...\n", "      - run: go build ./cmd/...\n      - run: go vet ./...\n", 1)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, ".atkins", "skills", "go.yml"), local)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		require.Len(t, result.Used, 1)
+
+		skill := result.Used[0]
+		assert.Equal(t, runner.VendorChanged, skill.Status)
+		assert.Equal(t, 1, skill.Added)
+		assert.Equal(t, 2, skill.Removed)
+		assert.Contains(t, skill.Diff, "+      - run: go build ./...")
+		assert.Contains(t, skill.Diff, "-      - run: go vet ./...")
+		assert.Contains(t, skill.Diff, filepath.Join(".atkins", "skills", "go.yml"))
+	})
+
+	t.Run("writes nothing", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Empty(t, result.Installed)
+
+		_, err = os.Stat(filepath.Join(root, ".atkins"))
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
 // TestVendorerRun covers writing the selected skills into the repository.
 func TestVendorerRun(t *testing.T) {
 	t.Run("creates .atkins/skills and copies the file", func(t *testing.T) {
@@ -210,14 +314,13 @@ func TestVendorerRun(t *testing.T) {
 		result, err := runner.NewVendorer(source, root).Run()
 		require.NoError(t, err)
 		assert.Equal(t, []string{"go"}, result.Installed)
-		assert.Empty(t, result.Skipped)
 
 		vendored, err := os.ReadFile(filepath.Join(root, ".atkins", "skills", "go.yml"))
 		require.NoError(t, err)
 		assert.Equal(t, goSkill, string(vendored))
 	})
 
-	t.Run("is idempotent", func(t *testing.T) {
+	t.Run("writes nothing on a second run", func(t *testing.T) {
 		root, source := vendorFixture(t)
 		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
 		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
@@ -227,11 +330,11 @@ func TestVendorerRun(t *testing.T) {
 
 		result, err := runner.NewVendorer(source, root).Run()
 		require.NoError(t, err)
-		assert.Equal(t, []string{"go"}, result.Installed)
-		assert.Empty(t, result.Skipped)
+		assert.Empty(t, result.Installed)
+		assert.Empty(t, result.Pending())
 	})
 
-	t.Run("leaves a local skill of the same name alone", func(t *testing.T) {
+	t.Run("overwrites a vendored copy that has drifted", func(t *testing.T) {
 		root, source := vendorFixture(t)
 		local := "name: Project go\nwhen:\n  files:\n    - go.mod\njobs:\n  build:\n    steps:\n      - run: go build ./cmd/...\n"
 		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
@@ -240,12 +343,11 @@ func TestVendorerRun(t *testing.T) {
 
 		result, err := runner.NewVendorer(source, root).Run()
 		require.NoError(t, err)
-		assert.Empty(t, result.Installed)
-		assert.Equal(t, []string{"go"}, result.Skipped)
+		assert.Equal(t, []string{"go"}, result.Installed)
 
-		kept, err := os.ReadFile(filepath.Join(root, ".atkins", "skills", "go.yml"))
+		vendored, err := os.ReadFile(filepath.Join(root, ".atkins", "skills", "go.yml"))
 		require.NoError(t, err)
-		assert.Equal(t, local, string(kept))
+		assert.Equal(t, goSkill, string(vendored))
 	})
 
 	t.Run("writes nothing when no skill is used", func(t *testing.T) {

--- a/runner/skills_vendor_test.go
+++ b/runner/skills_vendor_test.go
@@ -1,0 +1,272 @@
+package runner_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/runner"
+)
+
+// writeFile creates a file and any parent directories it needs.
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}
+
+// vendorFixture creates a repository and a source skills directory,
+// returning both. The repository has a .git folder so it looks like a
+// checkout to FindRepositoryRoot.
+func vendorFixture(t *testing.T) (root, source string) {
+	t.Helper()
+
+	base := t.TempDir()
+	root = filepath.Join(base, "repo")
+	source = filepath.Join(base, "home", ".atkins", "skills")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(source, 0o755))
+
+	return root, source
+}
+
+// vendorIDs lists the skill IDs of a result set.
+func vendorIDs(skills []*runner.VendorSkill) []string {
+	result := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		result = append(result, skill.ID)
+	}
+	return result
+}
+
+const goSkill = `name: Go build and test
+when:
+  files:
+    - go.mod
+jobs:
+  build:
+    steps:
+      - run: go build ./...
+`
+
+const dockerSkill = `name: Docker build
+when:
+  files:
+    - docker/Dockerfile
+jobs:
+  build:
+    steps:
+      - run: docker build .
+`
+
+// TestFindRepositoryRoot covers locating the folder that holds .git.
+func TestFindRepositoryRoot(t *testing.T) {
+	t.Run("finds root from a subdirectory", func(t *testing.T) {
+		root, _ := vendorFixture(t)
+		sub := filepath.Join(root, "server", "web")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+
+		found, err := runner.FindRepositoryRoot(sub)
+		require.NoError(t, err)
+		assert.Equal(t, root, found)
+	})
+
+	t.Run("finds root when .git is a file", func(t *testing.T) {
+		base := t.TempDir()
+		writeFile(t, filepath.Join(base, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n")
+
+		found, err := runner.FindRepositoryRoot(base)
+		require.NoError(t, err)
+		assert.Equal(t, base, found)
+	})
+
+	t.Run("errors outside a repository", func(t *testing.T) {
+		_, err := runner.FindRepositoryRoot(t.TempDir())
+		require.Error(t, err)
+	})
+}
+
+// TestVendorerPlan covers which skills a repository is found to use.
+func TestVendorerPlan(t *testing.T) {
+	t.Run("matches when: files in the repository root", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(source, "docker.yml"), dockerSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"docker", "go"}, vendorIDs(result.Found))
+		assert.Equal(t, []string{"go"}, vendorIDs(result.Used))
+		assert.Equal(t, "go.mod", result.Used[0].Reason)
+	})
+
+	t.Run("matches when: files in a subdirectory", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "schema.yml"), "when:\n  files:\n    - schema/\njobs:\n  migrate:\n    steps:\n      - run: mig migrate\n")
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "modules", "users", "schema"), 0o755))
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"schema"}, vendorIDs(result.Used))
+		assert.Equal(t, filepath.Join("modules", "users", "schema"), result.Used[0].Reason)
+	})
+
+	t.Run("skips directories the walk excludes", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "runner", "testdata", "go.mod"), "module fixture\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Empty(t, result.Used)
+	})
+
+	t.Run("takes a skill without when: as always active", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "notes.yml"), "jobs:\n  default:\n    steps:\n      - run: echo hi\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"notes"}, vendorIDs(result.Used))
+		assert.Equal(t, "always active", result.Used[0].Reason)
+	})
+
+	t.Run("takes a skill a pipeline references", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "docker.yml"), dockerSkill)
+		writeFile(t, filepath.Join(root, "atkins.yml"), "name: Example\njobs:\n  release:\n    steps:\n      - task: docker:build\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"docker"}, vendorIDs(result.Used))
+		assert.Equal(t, "referenced by atkins.yml", result.Used[0].Reason)
+	})
+
+	t.Run("takes a skill a nested pipeline depends on", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "docker.yml"), dockerSkill)
+		writeFile(t, filepath.Join(root, "app", ".atkins.yml"), "name: App\njobs:\n  ship:\n    depends_on: [\"docker:build\"]\n    steps:\n      - run: echo ship\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"docker"}, vendorIDs(result.Used))
+	})
+
+	t.Run("follows references between skills", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "docker.yml"), dockerSkill)
+		writeFile(t, filepath.Join(source, "release.yml"), "when:\n  files:\n    - .github/\njobs:\n  default:\n    steps:\n      - task: :docker:build\n")
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".github"), 0o755))
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"docker", "release"}, vendorIDs(result.Used))
+		assert.Equal(t, "referenced by release", result.Used[0].Reason)
+	})
+
+	t.Run("ignores a task that names a job of its own pipeline", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "build.yml"), "jobs:\n  default:\n    steps:\n      - run: echo hi\n")
+		writeFile(t, filepath.Join(root, "atkins.yml"), "name: Example\njobs:\n  build:\n    steps:\n      - run: echo build\n  default:\n    steps:\n      - task: build\n")
+
+		result, err := runner.NewVendorer(source, root).Plan()
+		require.NoError(t, err)
+		// The skill is still used, but because it has no when: block,
+		// not because the pipeline's own `build` job was mistaken for it.
+		require.Equal(t, []string{"build"}, vendorIDs(result.Used))
+		assert.Equal(t, "always active", result.Used[0].Reason)
+	})
+
+	t.Run("reports an empty source directory", func(t *testing.T) {
+		root, _ := vendorFixture(t)
+
+		result, err := runner.NewVendorer(filepath.Join(root, "missing"), root).Plan()
+		require.NoError(t, err)
+		assert.Empty(t, result.Found)
+		assert.Empty(t, result.Used)
+	})
+
+	t.Run("refuses to vendor onto itself", func(t *testing.T) {
+		root, _ := vendorFixture(t)
+		source := filepath.Join(root, ".atkins", "skills")
+
+		_, err := runner.NewVendorer(source, root).Plan()
+		require.Error(t, err)
+	})
+}
+
+// TestVendorerRun covers writing the selected skills into the repository.
+func TestVendorerRun(t *testing.T) {
+	t.Run("creates .atkins/skills and copies the file", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"go"}, result.Installed)
+		assert.Empty(t, result.Skipped)
+
+		vendored, err := os.ReadFile(filepath.Join(root, ".atkins", "skills", "go.yml"))
+		require.NoError(t, err)
+		assert.Equal(t, goSkill, string(vendored))
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		_, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+
+		result, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"go"}, result.Installed)
+		assert.Empty(t, result.Skipped)
+	})
+
+	t.Run("leaves a local skill of the same name alone", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		local := "name: Project go\nwhen:\n  files:\n    - go.mod\njobs:\n  build:\n    steps:\n      - run: go build ./cmd/...\n"
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+		writeFile(t, filepath.Join(root, ".atkins", "skills", "go.yml"), local)
+		writeFile(t, filepath.Join(root, "go.mod"), "module example\n")
+
+		result, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+		assert.Empty(t, result.Installed)
+		assert.Equal(t, []string{"go"}, result.Skipped)
+
+		kept, err := os.ReadFile(filepath.Join(root, ".atkins", "skills", "go.yml"))
+		require.NoError(t, err)
+		assert.Equal(t, local, string(kept))
+	})
+
+	t.Run("writes nothing when no skill is used", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "go.yml"), goSkill)
+
+		result, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+		assert.Empty(t, result.Installed)
+
+		_, err = os.Stat(filepath.Join(root, ".atkins"))
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("takes a skill a vendored skill references", func(t *testing.T) {
+		root, source := vendorFixture(t)
+		writeFile(t, filepath.Join(source, "docker.yml"), dockerSkill)
+		writeFile(t, filepath.Join(root, ".atkins", "skills", "deploy.yml"), "jobs:\n  default:\n    steps:\n      - task: docker:build\n")
+
+		result, err := runner.NewVendorer(source, root).Run()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"docker"}, result.Installed)
+	})
+}

--- a/vendor_skills.go
+++ b/vendor_skills.go
@@ -14,6 +14,9 @@ import (
 // repository uses out of $HOME/.atkins/skills and into .atkins/skills
 // next to .git, so a clone or a CI agent runs the same jobs as the
 // machine the pipeline was written on.
+//
+// It reports what it would do and writes nothing until --write is
+// given, so the selection can be read before the tree changes.
 func runVendor(dir string, opts *Options) error {
 	if opts.Jail {
 		return fmt.Errorf("%s --vendor reads $HOME/.atkins/skills, which --jail excludes", colors.BrightRed("ERROR:"))
@@ -31,33 +34,94 @@ func runVendor(dir string, opts *Options) error {
 
 	vendorer := runner.NewVendorer(filepath.Join(home, ".atkins", "skills"), root)
 
-	result, err := vendorer.Run()
+	result, err := vendorer.Plan()
 	if err != nil {
 		return fmt.Errorf("%s %v", colors.BrightRed("ERROR:"), err)
+	}
+
+	if opts.Write {
+		if err := vendorer.Install(result); err != nil {
+			return fmt.Errorf("%s %v", colors.BrightRed("ERROR:"), err)
+		}
 	}
 
 	fmt.Printf("Found %d local skills.\n", len(result.Found))
 	fmt.Printf("Found usage for %d skills.\n", len(result.Used))
 
-	if opts.Debug {
-		for _, skill := range result.Used {
-			fmt.Printf("  %s: %s\n", colors.BrightOrange(skill.ID), colors.Dim(skill.Reason))
+	width := 0
+	for _, skill := range result.Used {
+		if len(skill.ID) > width {
+			width = len(skill.ID)
 		}
 	}
+	for _, skill := range result.Used {
+		printVendorSkill(skill, width, opts.Debug)
+	}
 
-	if len(result.Installed) > 0 {
+	pending := result.Pending()
+	switch {
+	case len(result.Used) == 0:
+		fmt.Println("Nothing to install.")
+	case len(pending) == 0:
+		fmt.Println("Every skill is up to date.")
+	case opts.Write:
 		fmt.Printf("Installed: %s.\n", strings.Join(result.Installed, ", "))
-	}
-
-	// A project skill wins over a global one at load time, so a local
-	// copy that has drifted is a deliberate override, not a stale file.
-	if len(result.Skipped) > 0 {
-		target := result.TargetDir
-		if rel, err := filepath.Rel(root, result.TargetDir); err == nil {
-			target = rel
-		}
-		fmt.Printf("Skipped: %s (%s carries its own copy).\n", strings.Join(result.Skipped, ", "), target)
+	default:
+		fmt.Printf("Would install: %s.\n", strings.Join(pending, ", "))
+		fmt.Printf("Run %s to write them.\n", colors.BrightOrange("atkins --vendor --write"))
 	}
 
 	return nil
+}
+
+// printVendorSkill reports one selected skill: a checkmark when the
+// vendored copy already matches, and the lines a write would add and
+// remove when it doesn't. Debug adds the reason the skill was selected
+// and the diff the counts come from.
+func printVendorSkill(skill *runner.VendorSkill, width int, debug bool) {
+	reason := ""
+	if debug {
+		reason = " " + colors.Dim("("+skill.Reason+")")
+	}
+
+	name := fmt.Sprintf("%-*s", width, skill.ID)
+
+	if skill.Status == runner.VendorCurrent {
+		fmt.Printf("  %s %s %s%s\n", colors.BrightGreen("✓"), name, colors.Dim("(up to date)"), reason)
+		return
+	}
+
+	marker := colors.BrightYellow("~")
+	if skill.Status == runner.VendorNew {
+		marker = colors.BrightGreen("+")
+	}
+
+	stats := fmt.Sprintf("%s %s",
+		colors.BrightGreen(fmt.Sprintf("+%d", skill.Added)),
+		colors.BrightRed(fmt.Sprintf("-%d", skill.Removed)),
+	)
+
+	fmt.Printf("  %s %s %s %s%s\n",
+		marker, name, stats, colors.Dim("("+string(skill.Status)+")"), reason)
+
+	if debug && skill.Diff != "" {
+		for _, line := range strings.Split(strings.TrimRight(skill.Diff, "\n"), "\n") {
+			fmt.Printf("    %s\n", colorDiffLine(line))
+		}
+	}
+}
+
+// colorDiffLine paints a unified diff line by what it does.
+func colorDiffLine(line string) string {
+	switch {
+	case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"):
+		return colors.Dim(line)
+	case strings.HasPrefix(line, "@@"):
+		return colors.BrightCyan(line)
+	case strings.HasPrefix(line, "+"):
+		return colors.BrightGreen(line)
+	case strings.HasPrefix(line, "-"):
+		return colors.BrightRed(line)
+	}
+	return colors.Dim(line)
 }

--- a/vendor_skills.go
+++ b/vendor_skills.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/titpetric/atkins/colors"
+	"github.com/titpetric/atkins/runner"
+)
+
+// runVendor handles `atkins --vendor`, which copies the skills this
+// repository uses out of $HOME/.atkins/skills and into .atkins/skills
+// next to .git, so a clone or a CI agent runs the same jobs as the
+// machine the pipeline was written on.
+func runVendor(dir string, opts *Options) error {
+	if opts.Jail {
+		return fmt.Errorf("%s --vendor reads $HOME/.atkins/skills, which --jail excludes", colors.BrightRed("ERROR:"))
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("%s failed to resolve home directory: %v", colors.BrightRed("ERROR:"), err)
+	}
+
+	root, err := runner.FindRepositoryRoot(dir)
+	if err != nil {
+		return fmt.Errorf("%s %v", colors.BrightRed("ERROR:"), err)
+	}
+
+	vendorer := runner.NewVendorer(filepath.Join(home, ".atkins", "skills"), root)
+
+	result, err := vendorer.Run()
+	if err != nil {
+		return fmt.Errorf("%s %v", colors.BrightRed("ERROR:"), err)
+	}
+
+	fmt.Printf("Found %d local skills.\n", len(result.Found))
+	fmt.Printf("Found usage for %d skills.\n", len(result.Used))
+
+	if opts.Debug {
+		for _, skill := range result.Used {
+			fmt.Printf("  %s: %s\n", colors.BrightOrange(skill.ID), colors.Dim(skill.Reason))
+		}
+	}
+
+	if len(result.Installed) > 0 {
+		fmt.Printf("Installed: %s.\n", strings.Join(result.Installed, ", "))
+	}
+
+	// A project skill wins over a global one at load time, so a local
+	// copy that has drifted is a deliberate override, not a stale file.
+	if len(result.Skipped) > 0 {
+		target := result.TargetDir
+		if rel, err := filepath.Rel(root, result.TargetDir); err == nil {
+			target = rel
+		}
+		fmt.Printf("Skipped: %s (%s carries its own copy).\n", strings.Join(result.Skipped, ", "), target)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes #54.

Global skills live in `$HOME/.atkins/skills`, which is per-machine. A clean clone of this repository can't run the `atkins up` its own docs document, because the compose skill only exists on the author's laptop, and a CI agent is exactly the machine with no personal skills directory.

`atkins --vendor` resolves the skills a repository has a use for and copies them into `.atkins/skills` next to `.git`, creating the folder when it doesn't exist:

```
$ atkins --vendor
Found 7 local skills.
Found usage for 6 skills.
Installed: compose, docker, go, mdox, release, schema.
```

## Selection

A skill is selected when:

- its `when:` block matches a path anywhere in the repository — the search *descends* the tree rather than climbing it, so a `schema/` folder in a submodule selects the schema skill, the same way it activates there;
- it has no `when:` block, which makes it active everywhere;
- a pipeline in the repository names one of its jobs through `task:` or `depends_on:` — `docker:build` selects docker without a `docker/Dockerfile`;
- a skill already selected names one of its jobs — a release skill calling `:docker:build` brings docker with it.

Dot directories and `node_modules`, `vendor`, `testdata`, `bin`, `dist`, `coverage` are not descended into. `--vendor` and `--jail` are refused together: jail mode excludes the directory vendoring reads from.

## Local copies win

A local skill of the same name with different contents is left alone and reported:

```
Skipped: go (.atkins/skills carries its own copy).
```

Project skills already take precedence over global ones at load time, so a copy that has drifted is a deliberate override, not a stale file. Deleting it re-vendors it.

## What's here

- `runner/skills_vendor.go` — `Vendorer` (`Plan`/`Install`/`Run`) and `FindRepositoryRoot`.
- `vendor_skills.go` — the `--vendor` command; `--debug` prints why each skill was selected.
- `runner/skills_vendor_test.go` — 18 subtests over the selection rules, the walk exclusions, idempotency, and the local-override case.
- Docs: a Vendoring section in `usage/skills.md`, the flag in `usage/cli-flags.md`, `STRUCTURE.md`.

This repository's own skills are **not** vendored in this PR — that's a separate decision, and would be a one-line `atkins --vendor` follow-up that also fixes the `atkins up` gap from #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)