### PR TITLE
Run the pipeline here and record it, unless --dispatch says otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ With atkins you can:
 - provide project or system skills via `.atkins/skills`
 - run individual pipelines as executables
 - attach to a CI/CD server with `atkins --login https://domain`, so every
-  run records a job that agents can pick up
+  run you make locally is recorded as a job, and `atkins --dispatch` hands
+  one to an agent instead
 
 It's driven by yaml syntax, and supports shell interpolation with `$(...)`, and
 yaml friendly variable interpolation: `name: ${{app.name}}`.

--- a/client/configure.go
+++ b/client/configure.go
@@ -35,7 +35,7 @@ func Settings() config.ClientConfig {
 	defer settings.mu.RUnlock()
 
 	if !settings.set {
-		return config.ClientConfig{Dispatch: true, Timeout: DefaultTimeout}
+		return config.ClientConfig{Record: true, Timeout: DefaultTimeout}
 	}
 	return settings.value
 }

--- a/client/dispatch.go
+++ b/client/dispatch.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -79,29 +80,30 @@ type DispatchOptions struct {
 
 	// Server overrides which logged-in server to dispatch to.
 	Server string
-
-	// Local forces the run to happen here, as if the machine were not
-	// logged in.
-	Local bool
 }
+
+// ErrDispatchDisabled is returned when the environment forbids handing
+// the run over: an agent sets it for the command it runs, which is what
+// stops a job from dispatching itself forever.
+var ErrDispatchDisabled = errors.New(EnvNoDispatch + " is set")
 
 // Dispatch hands the current run to the CI/CD server this machine is
 // logged in to, and returns where to watch it.
 //
-// It returns nil whenever the run belongs here instead: no credential,
-// not inside a git repository, dispatch disabled, or the server could
-// not be reached. Delegation is a convenience, and losing it should
-// degrade to the behaviour of an unattached machine rather than to an
-// error.
-func Dispatch(ctx context.Context, opts DispatchOptions) *Dispatched {
-	if opts.Local || !Settings().Dispatch || DispatchDisabled() {
-		return nil
+// Handing a run over is asked for — by --dispatch, or by
+// `client.dispatch` in the configuration — so every reason it can't
+// happen is an error rather than a quiet local run. The one that isn't
+// worth stopping over is a repository nobody can clone, and that is
+// refused before the job exists: an unpushed commit dispatches a job
+// that dies in `git checkout` on a machine nobody is watching.
+func Dispatch(ctx context.Context, opts DispatchOptions) (*Dispatched, error) {
+	if DispatchDisabled() {
+		return nil, ErrDispatchDisabled
 	}
 
 	c, err := Open(configuredServer(opts.Server))
 	if err != nil {
-		// Not logged in is the common case for a laptop; say nothing.
-		return nil
+		return nil, fmt.Errorf("not logged in to an atkins server: %w", err)
 	}
 
 	directory := opts.Directory
@@ -111,7 +113,15 @@ func Dispatch(ctx context.Context, opts DispatchOptions) *Dispatched {
 
 	checkout, err := DetectCheckout(directory)
 	if err != nil {
-		return nil
+		return nil, err
+	}
+	switch err := checkout.Publishable(); {
+	case errors.Is(err, ErrDirtyCheckout):
+		return nil, fmt.Errorf("%w: an agent would build %s, which does not have them", err, shortRevision(checkout.Revision))
+	case errors.Is(err, ErrUnpushedCheckout):
+		return nil, fmt.Errorf("%w: an agent clones the repository, and %s is only on this machine", err, shortRevision(checkout.Revision))
+	case err != nil:
+		return nil, err
 	}
 
 	command := opts.Command
@@ -130,15 +140,26 @@ func Dispatch(ctx context.Context, opts DispatchOptions) *Dispatched {
 		Labels:           Labels(),
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "atkins: dispatch to %s failed, running locally: %v\n", c.Server(), err)
-		return nil
+		return nil, fmt.Errorf("dispatch to %s failed: %w", c.Server(), err)
 	}
 
 	return &Dispatched{
 		JobID:          response.JobID,
 		URL:            c.JobURL(response.JobID, response.ViewToken),
 		RepositorySlug: response.RepositorySlug,
+	}, nil
+}
+
+// shortRevision abbreviates a commit for a message, leaving anything
+// that isn't a full sha alone.
+func shortRevision(revision string) string {
+	if len(revision) > 12 {
+		return revision[:12]
 	}
+	if revision == "" {
+		return "HEAD"
+	}
+	return revision
 }
 
 // DispatchDisabled reports whether ATKINS_NO_DISPATCH is set to a

--- a/client/record.go
+++ b/client/record.go
@@ -1,0 +1,361 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RecordOptions describes the local run being logged.
+type RecordOptions struct {
+	// Directory is where atkins was invoked. Empty means the process
+	// working directory.
+	Directory string
+
+	// Command is the atkins invocation. Empty means os.Args.
+	Command string
+
+	// Server overrides which logged-in server to record on.
+	Server string
+}
+
+// Recorder is a run happening here that is logged on a CI/CD server.
+//
+// It is the other half of dispatch: the pipeline executes on this
+// machine, as it does on a machine that never logged in, and the server
+// ends up with the job an agent would have produced — the same command,
+// checkout, output, exit code and duration. A history of what a team
+// runs should not depend on where the tooling happens to be installed.
+//
+// A nil *Recorder is the unrecorded run, and every method tolerates it,
+// so the caller has no branch to write.
+type Recorder struct {
+	client  *Client
+	jobID   string
+	url     string
+	agentID string
+
+	mu     sync.Mutex
+	buffer strings.Builder
+
+	// stop ends the lease renewals.
+	stop func()
+}
+
+// recordHeartbeat is how often the lease is renewed. It is well inside
+// the server's default lease of 15 minutes, and a local run that dies
+// without reporting — a closed laptop, a killed terminal — is reclaimed
+// as a timeout the same way an agent that disappears is.
+const recordHeartbeat = 30 * time.Second
+
+// logChunk bounds one append, so a long transcript arrives in pieces
+// rather than as one request the server may refuse.
+const logChunk = 32 * 1024
+
+// Record opens a job for a run about to happen here.
+//
+// It returns nil when there is nothing to record against: no
+// credential, no git repository, recording turned off, or a server that
+// can't be reached. Recording is bookkeeping, and losing it must not
+// cost the run — unlike dispatch, which is the run.
+func Record(ctx context.Context, opts RecordOptions) *Recorder {
+	if !Settings().Record || DispatchDisabled() {
+		return nil
+	}
+
+	// A run an agent started is already a job, streamed by the agent
+	// that owns it. Recording it again would file the same work twice.
+	if os.Getenv(EnvJobID) != "" {
+		return nil
+	}
+
+	c, err := Open(configuredServer(opts.Server))
+	if err != nil {
+		return nil
+	}
+
+	directory := opts.Directory
+	if directory == "" {
+		directory, _ = os.Getwd()
+	}
+
+	checkout, err := DetectCheckout(directory)
+	if err != nil {
+		return nil
+	}
+
+	command := opts.Command
+	if command == "" {
+		command = Command(os.Args)
+	}
+
+	agentID, _ := os.Hostname()
+	if agentID == "" {
+		agentID = "local"
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, configuredTimeout())
+	defer cancel()
+
+	response, err := c.Dispatch(callCtx, DispatchRequest{
+		Repository:       checkout.Payload(),
+		WorkingDirectory: checkout.WorkingDirectory,
+		Command:          command,
+		Labels:           Labels(),
+		Agent:            agentID,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "atkins: recording this run on %s failed: %v\n", c.Server(), err)
+		return nil
+	}
+
+	recorder := &Recorder{
+		client:  c,
+		jobID:   response.JobID,
+		url:     c.JobURL(response.JobID, response.ViewToken),
+		agentID: agentID,
+	}
+
+	// The commit is recorded the way an agent records what it checked
+	// out, so a job page says which code the log came from.
+	recorder.reportCheckout(ctx, checkout)
+	recorder.Log(ctx, header(checkout, command, agentID))
+	recorder.heartbeat(ctx)
+
+	return recorder
+}
+
+// JobID is the server's ID for this run, empty when unrecorded.
+func (r *Recorder) JobID() string {
+	if r == nil {
+		return ""
+	}
+	return r.jobID
+}
+
+// URL is where the run is watched in a browser, empty when unrecorded.
+func (r *Recorder) URL() string {
+	if r == nil {
+		return ""
+	}
+	return r.url
+}
+
+// Write buffers output for the job log. It makes a Recorder an
+// io.Writer, which is what lets the runner hand it a transcript without
+// knowing what a job is.
+func (r *Recorder) Write(p []byte) (int, error) {
+	if r == nil {
+		return len(p), nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buffer.Write(p)
+
+	return len(p), nil
+}
+
+// Log appends content to the job log immediately.
+func (r *Recorder) Log(ctx context.Context, content string) {
+	if r == nil || content == "" {
+		return
+	}
+
+	for _, chunk := range chunks(content, logChunk) {
+		callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuredTimeout())
+		err := r.client.AppendLog(callCtx, r.jobID, StreamOutput, chunk)
+		cancel()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "atkins: appending to job %s failed: %v\n", r.jobID, err)
+			return
+		}
+	}
+}
+
+// Finish flushes what was written and settles the job.
+//
+// The status is derived from the same exit code the shell sees, so a
+// recorded run and the terminal it ran in never disagree.
+func (r *Recorder) Finish(ctx context.Context, exitCode int, runErr error) {
+	if r == nil {
+		return
+	}
+
+	if r.stop != nil {
+		r.stop()
+	}
+
+	r.mu.Lock()
+	transcript := r.buffer.String()
+	r.buffer.Reset()
+	r.mu.Unlock()
+
+	r.Log(ctx, transcript)
+
+	// A pipeline that reported a failure without an exit code — the
+	// shell sees zero, the run did not work — is recorded as failed.
+	// The job page saying passed is the one reading nobody can correct.
+	status := StatusPassed
+	if exitCode != 0 || runErr != nil {
+		status = StatusFailed
+	}
+
+	message := ""
+	if runErr != nil {
+		message = runErr.Error()
+	}
+
+	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuredTimeout())
+	defer cancel()
+
+	if err := r.client.ReportStatus(callCtx, r.jobID, JobStatusRequest{
+		Status:   status,
+		ExitCode: int64(exitCode),
+		Error:    message,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "atkins: settling job %s failed: %v\n", r.jobID, err)
+	}
+}
+
+// Cancelled settles the job as cancelled, for a run the user stopped.
+func (r *Recorder) Cancelled(ctx context.Context) {
+	if r == nil {
+		return
+	}
+
+	if r.stop != nil {
+		r.stop()
+	}
+
+	r.mu.Lock()
+	transcript := r.buffer.String()
+	r.buffer.Reset()
+	r.mu.Unlock()
+
+	r.Log(ctx, transcript)
+
+	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuredTimeout())
+	defer cancel()
+
+	if err := r.client.ReportStatus(callCtx, r.jobID, JobStatusRequest{
+		Status:   StatusCancelled,
+		ExitCode: 1,
+		Error:    "cancelled",
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "atkins: settling job %s failed: %v\n", r.jobID, err)
+	}
+}
+
+// reportCheckout records the commit the run is against.
+func (r *Recorder) reportCheckout(ctx context.Context, checkout *Checkout) {
+	if checkout.Revision == "" {
+		return
+	}
+
+	ref := checkout.Branch
+	if ref == "" {
+		ref = checkout.Revision
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, configuredTimeout())
+	defer cancel()
+
+	// A checkout nobody could record is not worth a word: the log that
+	// follows is the record, and it is already on its way.
+	_ = r.client.ReportCheckout(callCtx, r.jobID, JobCheckoutRequest{
+		Ref:       ref,
+		CommitSHA: checkout.Revision,
+	})
+}
+
+// heartbeat renews the lease until Finish stops it.
+func (r *Recorder) heartbeat(ctx context.Context) {
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		ticker := time.NewTicker(recordHeartbeat)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				callCtx, callCancel := context.WithTimeout(ctx, configuredTimeout())
+				// A missed renewal is retried on the next tick. The run
+				// is here and continues either way; what it risks is the
+				// server reclaiming the record, which is what a run that
+				// really has gone away looks like too.
+				_ = r.client.Heartbeat(callCtx, r.jobID, r.agentID)
+				callCancel()
+			}
+		}
+	}()
+
+	r.stop = func() {
+		cancel()
+		<-done
+	}
+}
+
+// header is the first thing on a recorded job's page: where the run is
+// happening, and against what.
+//
+// It matters because the log arrives at the end. Until then the page
+// says a machine is running a command, which is the same thing a person
+// watching an agent sees while it clones.
+func header(checkout *Checkout, command, agentID string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "running locally on %s\n", agentID)
+	fmt.Fprintf(&b, "$ %s\n", command)
+
+	if checkout.WorkingDirectory != "" {
+		fmt.Fprintf(&b, "directory: %s\n", checkout.WorkingDirectory)
+	}
+	if checkout.Revision != "" {
+		fmt.Fprintf(&b, "commit: %s", shortRevision(checkout.Revision))
+		if checkout.Branch != "" && checkout.Branch != "HEAD" {
+			fmt.Fprintf(&b, " (%s)", checkout.Branch)
+		}
+		// Said out loud, because the log below did not come from the
+		// commit the job names.
+		if checkout.Dirty {
+			b.WriteString(" with uncommitted changes")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	return b.String()
+}
+
+// chunks splits s into pieces of at most size bytes, on a line boundary
+// where one is near enough that a log entry isn't cut mid-line.
+func chunks(s string, size int) []string {
+	var parts []string
+
+	for len(s) > size {
+		cut := size
+		if index := strings.LastIndexByte(s[:size], '\n'); index > size/2 {
+			cut = index + 1
+		}
+
+		parts = append(parts, s[:cut])
+		s = s[cut:]
+	}
+
+	if s != "" {
+		parts = append(parts, s)
+	}
+
+	return parts
+}

--- a/client/record.go
+++ b/client/record.go
@@ -122,18 +122,10 @@ func Record(ctx context.Context, opts RecordOptions) *Recorder {
 	// The commit is recorded the way an agent records what it checked
 	// out, so a job page says which code the log came from.
 	recorder.reportCheckout(ctx, checkout)
-	recorder.Log(ctx, header(checkout, command, agentID))
+	recorder.appendLog(ctx, header(checkout, command, agentID))
 	recorder.heartbeat(ctx)
 
 	return recorder
-}
-
-// JobID is the server's ID for this run, empty when unrecorded.
-func (r *Recorder) JobID() string {
-	if r == nil {
-		return ""
-	}
-	return r.jobID
 }
 
 // URL is where the run is watched in a browser, empty when unrecorded.
@@ -159,9 +151,9 @@ func (r *Recorder) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Log appends content to the job log immediately.
-func (r *Recorder) Log(ctx context.Context, content string) {
-	if r == nil || content == "" {
+// appendLog ships content to the job log immediately.
+func (r *Recorder) appendLog(ctx context.Context, content string) {
+	if content == "" {
 		return
 	}
 
@@ -186,17 +178,6 @@ func (r *Recorder) Finish(ctx context.Context, exitCode int, runErr error) {
 		return
 	}
 
-	if r.stop != nil {
-		r.stop()
-	}
-
-	r.mu.Lock()
-	transcript := r.buffer.String()
-	r.buffer.Reset()
-	r.mu.Unlock()
-
-	r.Log(ctx, transcript)
-
 	// A pipeline that reported a failure without an exit code — the
 	// shell sees zero, the run did not work — is recorded as failed.
 	// The job page saying passed is the one reading nobody can correct.
@@ -210,16 +191,11 @@ func (r *Recorder) Finish(ctx context.Context, exitCode int, runErr error) {
 		message = runErr.Error()
 	}
 
-	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuredTimeout())
-	defer cancel()
-
-	if err := r.client.ReportStatus(callCtx, r.jobID, JobStatusRequest{
+	r.settle(ctx, JobStatusRequest{
 		Status:   status,
 		ExitCode: int64(exitCode),
 		Error:    message,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "atkins: settling job %s failed: %v\n", r.jobID, err)
-	}
+	})
 }
 
 // Cancelled settles the job as cancelled, for a run the user stopped.
@@ -228,6 +204,18 @@ func (r *Recorder) Cancelled(ctx context.Context) {
 		return
 	}
 
+	r.settle(ctx, JobStatusRequest{
+		Status:   StatusCancelled,
+		ExitCode: 1,
+		Error:    "cancelled",
+	})
+}
+
+// settle stops the lease renewals, ships what was buffered and reports
+// the outcome. It runs on a context of its own: a run cancelled with
+// ctrl-C has to file that it was, and the context it was cancelled with
+// would abandon the report along with the run.
+func (r *Recorder) settle(ctx context.Context, status JobStatusRequest) {
 	if r.stop != nil {
 		r.stop()
 	}
@@ -237,16 +225,12 @@ func (r *Recorder) Cancelled(ctx context.Context) {
 	r.buffer.Reset()
 	r.mu.Unlock()
 
-	r.Log(ctx, transcript)
+	r.appendLog(ctx, transcript)
 
 	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuredTimeout())
 	defer cancel()
 
-	if err := r.client.ReportStatus(callCtx, r.jobID, JobStatusRequest{
-		Status:   StatusCancelled,
-		ExitCode: 1,
-		Error:    "cancelled",
-	}); err != nil {
+	if err := r.client.ReportStatus(callCtx, r.jobID, status); err != nil {
 		fmt.Fprintf(os.Stderr, "atkins: settling job %s failed: %v\n", r.jobID, err)
 	}
 }

--- a/client/record_internal_test.go
+++ b/client/record_internal_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChunks covers splitting a transcript into log appends.
+func TestChunks(t *testing.T) {
+	t.Run("leaves a short transcript whole", func(t *testing.T) {
+		assert.Equal(t, []string{"one line\n"}, chunks("one line\n", 32))
+	})
+
+	t.Run("reports nothing for nothing", func(t *testing.T) {
+		assert.Empty(t, chunks("", 32))
+	})
+
+	t.Run("splits on a line boundary", func(t *testing.T) {
+		parts := chunks("aaaa\nbbbb\ncccc\n", 10)
+
+		// The cut lands after a newline rather than mid-line, so a log
+		// entry is never half a line of somebody's build output.
+		require.Len(t, parts, 2)
+		assert.Equal(t, "aaaa\nbbbb\n", parts[0])
+		assert.Equal(t, "cccc\n", parts[1])
+	})
+
+	t.Run("splits a line longer than the chunk", func(t *testing.T) {
+		// One enormous line — minified output, a base64 blob — has no
+		// boundary to find, and must still be shipped rather than held.
+		parts := chunks(strings.Repeat("x", 25), 10)
+
+		require.Len(t, parts, 3)
+		assert.Equal(t, strings.Repeat("x", 10), parts[0])
+		assert.Equal(t, strings.Repeat("x", 5), parts[2])
+	})
+
+	t.Run("loses nothing", func(t *testing.T) {
+		transcript := strings.Repeat("a line of build output\n", 500)
+
+		assert.Equal(t, transcript, strings.Join(chunks(transcript, logChunk), ""))
+	})
+}
+
+// TestHeader covers the first thing a recorded job's page shows.
+func TestHeader(t *testing.T) {
+	t.Run("names the machine, the command and the commit", func(t *testing.T) {
+		text := header(&Checkout{
+			Revision: "0123456789abcdef0123456789abcdef01234567",
+			Branch:   "main",
+		}, "atkins test", "laptop")
+
+		assert.Contains(t, text, "running locally on laptop")
+		assert.Contains(t, text, "$ atkins test")
+		assert.Contains(t, text, "commit: 0123456789ab (main)")
+		assert.NotContains(t, text, "uncommitted")
+	})
+
+	t.Run("says when the log did not come from the commit it names", func(t *testing.T) {
+		text := header(&Checkout{
+			Revision: "0123456789abcdef0123456789abcdef01234567",
+			Branch:   "main",
+			Dirty:    true,
+		}, "atkins test", "laptop")
+
+		assert.Contains(t, text, "with uncommitted changes")
+	})
+
+	t.Run("names the directory a run happened in", func(t *testing.T) {
+		text := header(&Checkout{WorkingDirectory: "server/api"}, "atkins test", "laptop")
+
+		assert.Contains(t, text, "directory: server/api")
+	})
+}

--- a/client/repository.go
+++ b/client/repository.go
@@ -12,6 +12,15 @@ import (
 // there is nothing for another machine to check out.
 var ErrNotARepository = errors.New("not inside a git repository")
 
+// Errors reported when a checkout cannot be reproduced elsewhere.
+var (
+	// ErrDirtyCheckout is a work tree with uncommitted changes.
+	ErrDirtyCheckout = errors.New("the working tree has uncommitted changes")
+
+	// ErrUnpushedCheckout is a commit no remote has.
+	ErrUnpushedCheckout = errors.New("HEAD has not been pushed to a remote")
+)
+
 // Checkout is what the client reports about the working copy a run
 // happens in. It is the whole of what the server needs to reproduce the
 // run elsewhere: which repository, where inside it, at what revision.
@@ -29,6 +38,31 @@ type Checkout struct {
 	Branch        string
 	Revision      string
 	DefaultBranch string
+
+	// Dirty reports uncommitted changes in the work tree, tracked or
+	// not. A local run of a dirty tree is ordinary; a dispatched one
+	// would build something else.
+	Dirty bool
+
+	// Unpushed reports that no remote has HEAD, so nothing can clone it.
+	Unpushed bool
+}
+
+// Publishable reports whether another machine could reproduce this
+// checkout from the repository's remote.
+//
+// A dispatched run names the commit it was started from, so a tree that
+// only exists on this disk queues a job that fails in `git checkout`
+// minutes later. The refusal belongs here, where the fix — commit and
+// push, or run locally — is still in front of the person.
+func (c *Checkout) Publishable() error {
+	switch {
+	case c.Dirty:
+		return ErrDirtyCheckout
+	case c.Unpushed:
+		return ErrUnpushedCheckout
+	}
+	return nil
 }
 
 // Payload converts the checkout into a dispatch payload.
@@ -67,6 +101,8 @@ func DetectCheckout(dir string) (*Checkout, error) {
 		Branch:        git(dir, "rev-parse", "--abbrev-ref", "HEAD"),
 		Revision:      git(dir, "rev-parse", "HEAD"),
 		DefaultBranch: detectDefaultBranch(dir),
+		Dirty:         git(dir, "status", "--porcelain") != "",
+		Unpushed:      detectUnpushed(dir),
 	}
 	if checkout.RemoteURL == "" {
 		return nil, ErrNotARepository
@@ -93,6 +129,20 @@ func detectRemoteURL(dir string) string {
 	}
 
 	return ""
+}
+
+// detectUnpushed reports whether HEAD is missing from every remote.
+//
+// The question is which commit, not which branch: a commit reachable
+// from any remote ref can be cloned, whatever the local branch is
+// called and whether or not it tracks anything.
+func detectUnpushed(dir string) bool {
+	// A repository with no commits has nothing to push and nothing to
+	// dispatch; the empty revision is what reports that.
+	if git(dir, "rev-parse", "HEAD") == "" {
+		return false
+	}
+	return git(dir, "rev-list", "-n", "1", "HEAD", "--not", "--remotes") != ""
 }
 
 // detectDefaultBranch reads origin's HEAD, e.g. `origin/main`. It is

--- a/client/repository_test.go
+++ b/client/repository_test.go
@@ -214,13 +214,11 @@ func TestRecordSkipsWithoutCredentials(t *testing.T) {
 	// And every method tolerates that, so a caller has no branch to
 	// write around it.
 	assert.Empty(t, recorder.URL())
-	assert.Empty(t, recorder.JobID())
 
 	written, err := recorder.Write([]byte("output nobody records\n"))
 	require.NoError(t, err)
 	assert.Equal(t, 22, written)
 
-	recorder.Log(t.Context(), "and none of this either")
 	recorder.Finish(t.Context(), 0, nil)
 	recorder.Cancelled(t.Context())
 }

--- a/client/repository_test.go
+++ b/client/repository_test.go
@@ -12,29 +12,47 @@ import (
 	"github.com/titpetric/atkins/client"
 )
 
+// gitRun runs one git command in dir, failing the test if it does.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=atkins", "GIT_AUTHOR_EMAIL=atkins@example.com",
+		"GIT_COMMITTER_NAME=atkins", "GIT_COMMITTER_EMAIL=atkins@example.com",
+	)
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
 // gitRepository creates a repository with one commit and an origin.
 func gitRepository(t *testing.T, remote string) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=atkins", "GIT_AUTHOR_EMAIL=atkins@example.com",
-			"GIT_COMMITTER_NAME=atkins", "GIT_COMMITTER_EMAIL=atkins@example.com",
-		)
-		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(output))
+
+	gitRun(t, dir, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "atkins.yml"), []byte("jobs: {}\n"), 0o644))
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "initial")
+	if remote != "" {
+		gitRun(t, dir, "remote", "add", "origin", remote)
 	}
 
-	run("init", "--initial-branch=main")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "atkins.yml"), []byte("jobs: {}\n"), 0o644))
-	run("add", ".")
-	run("commit", "-m", "initial")
-	if remote != "" {
-		run("remote", "add", "origin", remote)
-	}
+	return dir
+}
+
+// pushedRepository creates a repository whose commit is on a remote that
+// exists, which is what a dispatchable checkout looks like.
+func pushedRepository(t *testing.T) string {
+	t.Helper()
+
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	gitRun(t, t.TempDir(), "init", "--bare", remote)
+
+	dir := gitRepository(t, remote)
+	gitRun(t, dir, "push", "-u", "origin", "main")
 
 	return dir
 }
@@ -81,6 +99,70 @@ func TestDetectCheckoutOutsideRepository(t *testing.T) {
 	assert.ErrorIs(t, err, client.ErrNotARepository)
 }
 
+func TestPublishable(t *testing.T) {
+	t.Run("accepts a clean checkout a remote has", func(t *testing.T) {
+		checkout, err := client.DetectCheckout(pushedRepository(t))
+		require.NoError(t, err)
+
+		assert.False(t, checkout.Dirty)
+		assert.False(t, checkout.Unpushed)
+		assert.NoError(t, checkout.Publishable())
+	})
+
+	t.Run("refuses uncommitted changes", func(t *testing.T) {
+		dir := pushedRepository(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "atkins.yml"), []byte("jobs: {build: {}}\n"), 0o644))
+
+		checkout, err := client.DetectCheckout(dir)
+		require.NoError(t, err)
+
+		// An agent would check out the commit and build what is in it,
+		// which is not what is in front of the person dispatching.
+		assert.True(t, checkout.Dirty)
+		assert.ErrorIs(t, checkout.Publishable(), client.ErrDirtyCheckout)
+	})
+
+	t.Run("refuses an untracked file", func(t *testing.T) {
+		dir := pushedRepository(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.md"), []byte("wip\n"), 0o644))
+
+		checkout, err := client.DetectCheckout(dir)
+		require.NoError(t, err)
+		assert.ErrorIs(t, checkout.Publishable(), client.ErrDirtyCheckout)
+	})
+
+	t.Run("refuses a commit no remote has", func(t *testing.T) {
+		dir := pushedRepository(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "atkins.yml"), []byte("jobs: {build: {}}\n"), 0o644))
+		gitRun(t, dir, "commit", "-am", "local only")
+
+		checkout, err := client.DetectCheckout(dir)
+		require.NoError(t, err)
+
+		assert.False(t, checkout.Dirty)
+		assert.True(t, checkout.Unpushed)
+		assert.ErrorIs(t, checkout.Publishable(), client.ErrUnpushedCheckout)
+	})
+
+	t.Run("accepts a commit on a remote branch nothing tracks", func(t *testing.T) {
+		dir := pushedRepository(t)
+		gitRun(t, dir, "checkout", "-b", "detached-work")
+
+		// The question is whether the commit can be cloned, not whether
+		// the local branch has an upstream.
+		checkout, err := client.DetectCheckout(dir)
+		require.NoError(t, err)
+		assert.NoError(t, checkout.Publishable())
+	})
+
+	t.Run("refuses a repository nobody has pushed at all", func(t *testing.T) {
+		checkout, err := client.DetectCheckout(gitRepository(t, "git@github.com:titpetric/atkins.git"))
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, checkout.Publishable(), client.ErrUnpushedCheckout)
+	})
+}
+
 func TestLabels(t *testing.T) {
 	t.Setenv(client.EnvLabels, "")
 	assert.Nil(t, client.Labels())
@@ -103,20 +185,52 @@ func TestCommand(t *testing.T) {
 	assert.Equal(t, "atkins", client.Command([]string{"/usr/local/bin/atkins.old"}))
 }
 
-func TestDispatchSkipsWithoutCredentials(t *testing.T) {
+func TestDispatchFailsWithoutCredentials(t *testing.T) {
 	t.Setenv("ATKINS_CREDENTIALS", filepath.Join(t.TempDir(), "credentials.json"))
 
-	assert.Nil(t, client.Dispatch(t.Context(), client.DispatchOptions{}))
+	// Handing a run over is asked for, so being unable to is an error
+	// rather than a silent local run.
+	dispatched, err := client.Dispatch(t.Context(), client.DispatchOptions{})
+	require.Error(t, err)
+	assert.Nil(t, dispatched)
 }
 
 func TestDispatchRespectsNoDispatch(t *testing.T) {
 	t.Setenv(client.EnvNoDispatch, "1")
 
-	assert.Nil(t, client.Dispatch(t.Context(), client.DispatchOptions{}))
+	dispatched, err := client.Dispatch(t.Context(), client.DispatchOptions{})
+	require.ErrorIs(t, err, client.ErrDispatchDisabled)
+	assert.Nil(t, dispatched)
 }
 
-func TestDispatchRespectsLocal(t *testing.T) {
-	assert.Nil(t, client.Dispatch(t.Context(), client.DispatchOptions{Local: true}))
+func TestRecordSkipsWithoutCredentials(t *testing.T) {
+	t.Setenv("ATKINS_CREDENTIALS", filepath.Join(t.TempDir(), "credentials.json"))
+
+	// Recording is bookkeeping: it drops out silently rather than
+	// costing the run it was meant to describe.
+	recorder := client.Record(t.Context(), client.RecordOptions{})
+	assert.Nil(t, recorder)
+
+	// And every method tolerates that, so a caller has no branch to
+	// write around it.
+	assert.Empty(t, recorder.URL())
+	assert.Empty(t, recorder.JobID())
+
+	written, err := recorder.Write([]byte("output nobody records\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 22, written)
+
+	recorder.Log(t.Context(), "and none of this either")
+	recorder.Finish(t.Context(), 0, nil)
+	recorder.Cancelled(t.Context())
+}
+
+func TestRecordSkipsInsideAJob(t *testing.T) {
+	// A run an agent started is already a job, streamed by the agent
+	// that owns it; recording it again would file the same work twice.
+	t.Setenv(client.EnvJobID, "01JBJZ0000000000000000000")
+
+	assert.Nil(t, client.Record(t.Context(), client.RecordOptions{}))
 }
 
 func TestDispatchDisabled(t *testing.T) {

--- a/client/types.go
+++ b/client/types.go
@@ -63,6 +63,13 @@ type DispatchRequest struct {
 	Labels           []string          `json:"labels,omitempty"`
 	Params           map[string]any    `json:"params,omitempty"`
 	Artefacts        []string          `json:"artefacts,omitempty"`
+
+	// Agent names the machine already running the job. Set, the job is
+	// recorded as running there instead of queued for an agent to
+	// claim: it is how a run that happens on a laptop still appears on
+	// the server, with the log and the outcome an agent would have
+	// reported.
+	Agent string `json:"agent,omitempty"`
 }
 
 // DispatchResponse is returned by POST /api/dispatch.

--- a/config/config.go
+++ b/config/config.go
@@ -44,9 +44,14 @@ type ClientConfig struct {
 	// Labels constrain which agents may run this machine's jobs.
 	Labels []string `yaml:"labels" json:"labels" env:"ATKINS_LABELS"`
 
-	// Dispatch hands runs to the server when logged in. Off means
-	// always run locally.
+	// Dispatch hands every run to an agent instead of running it here.
+	// Off, the default, is what `--dispatch` turns on for one run.
 	Dispatch bool `yaml:"dispatch" json:"dispatch" env:"ATKINS_DISPATCH"`
+
+	// Record logs local runs on the server when logged in: the run
+	// happens here and the job page holds its output and outcome. Off
+	// means a logged-in machine records nothing, the same as `--local`.
+	Record bool `yaml:"record" json:"record" env:"ATKINS_RECORD"`
 
 	// Timeout bounds an API call before the run falls back to local.
 	Timeout time.Duration `yaml:"timeout" json:"timeout" env:"ATKINS_TIMEOUT"`

--- a/config/config.yml
+++ b/config/config.yml
@@ -22,9 +22,15 @@ client:
   # empty list runs anywhere.
   labels: []
 
-  # Hand runs to the server when logged in. With this off, atkins
-  # always runs locally, the same as `--local`.
-  dispatch: true
+  # Hand every run to an agent instead of running it here. With this
+  # off, atkins runs the pipeline locally and `--dispatch` hands over a
+  # single run.
+  dispatch: false
+
+  # Log local runs on the server when logged in: the run happens here,
+  # and the job page holds its output and its outcome. With this off a
+  # logged-in machine records nothing, the same as `--local`.
+  record: true
 
   # How long to wait on an API call before giving up and running
   # locally.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,10 @@ func TestDefaultIsComplete(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, config.Version, cfg.Version)
-	assert.True(t, cfg.Client.Dispatch)
+	// Dispatch is the one default that is off: logging in records what
+	// this machine runs, it does not move where it runs.
+	assert.False(t, cfg.Client.Dispatch)
+	assert.True(t, cfg.Client.Record)
 	assert.Positive(t, cfg.Client.Timeout)
 
 	assert.NotEmpty(t, cfg.Server.Addr)

--- a/config/menu_test.go
+++ b/config/menu_test.go
@@ -71,8 +71,8 @@ func TestMenuQuitDiscardsUnsavedChanges(t *testing.T) {
 func TestMenuRefusesAnInvalidValue(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".atkins", "config.yml")
 
-	// Field 5 is client.timeout, a duration.
-	output := runMenu(t, path, "5\nnot-a-duration\nq\n")
+	// Field 6 is client.timeout, a duration.
+	output := runMenu(t, path, "6\nnot-a-duration\nq\n")
 
 	assert.Contains(t, output, "must be a duration")
 }
@@ -99,9 +99,9 @@ func TestMenuMarksEnvironmentOverrides(t *testing.T) {
 func TestMenuWriteRefusesAnInvalidDocument(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".atkins", "config.yml")
 
-	// server.addr without a port cannot work; writing must not
-	// silently persist it.
-	output := runMenu(t, path, "6\nlocalhost\nw\nq\ny\n")
+	// Field 7 is server.addr, which without a port cannot work; writing
+	// must not silently persist it.
+	output := runMenu(t, path, "7\nlocalhost\nw\nq\ny\n")
 
 	assert.Contains(t, output, "must include a port")
 	assert.NoFileExists(t, path)

--- a/docs/api/atkins.md
+++ b/docs/api/atkins.md
@@ -27,11 +27,13 @@ type Options struct {
 	Exec             string
 
 	// CI/CD client flags. Login and Register take the server URL;
-	// Logout applies to the server last logged in to. Local runs here
-	// instead of handing the job to the server.
+	// Logout applies to the server last logged in to. Dispatch hands
+	// the run to an agent instead of running it here, and Local runs
+	// here without recording anything on the server.
 	Login    string
 	Register string
 	Logout   bool
+	Dispatch bool
 	Local    bool
 
 	// Config opens the configuration menu for .atkins/config.yml.

--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -617,8 +617,6 @@ var (
 - `func (*Prompter) Password (label string) (string, error)`
 - `func (*Recorder) Cancelled (ctx context.Context)`
 - `func (*Recorder) Finish (ctx context.Context, exitCode int, runErr error)`
-- `func (*Recorder) JobID () string`
-- `func (*Recorder) Log (ctx context.Context, content string)`
 - `func (*Recorder) URL () string`
 - `func (*Recorder) Write (p []byte) (int, error)`
 - `func (*Store) Get (server string) (*Credential, bool)`
@@ -1081,22 +1079,6 @@ recorded run and the terminal it ran in never disagree.
 
 ```go
 func (*Recorder) Finish(ctx context.Context, exitCode int, runErr error)
-```
-
-### JobID
-
-JobID is the server's ID for this run, empty when unrecorded.
-
-```go
-func (*Recorder) JobID() string
-```
-
-### Log
-
-Log appends content to the job log immediately.
-
-```go
-func (*Recorder) Log(ctx context.Context, content string)
 ```
 
 ### URL

--- a/docs/api/atkins_client.md
+++ b/docs/api/atkins_client.md
@@ -92,6 +92,14 @@ type Checkout struct {
 	Branch        string
 	Revision      string
 	DefaultBranch string
+
+	// Dirty reports uncommitted changes in the work tree, tracked or
+	// not. A local run of a dirty tree is ordinary; a dispatched one
+	// would build something else.
+	Dirty bool
+
+	// Unpushed reports that no remote has HEAD, so nothing can clone it.
+	Unpushed bool
 }
 ```
 
@@ -150,10 +158,6 @@ type DispatchOptions struct {
 
 	// Server overrides which logged-in server to dispatch to.
 	Server string
-
-	// Local forces the run to happen here, as if the machine were not
-	// logged in.
-	Local bool
 }
 ```
 
@@ -167,6 +171,13 @@ type DispatchRequest struct {
 	Labels           []string          `json:"labels,omitempty"`
 	Params           map[string]any    `json:"params,omitempty"`
 	Artefacts        []string          `json:"artefacts,omitempty"`
+
+	// Agent names the machine already running the job. Set, the job is
+	// recorded as running there instead of queued for an agent to
+	// claim: it is how a run that happens on a laptop still appears on
+	// the server, with the log and the outcome an agent would have
+	// reported.
+	Agent string `json:"agent,omitempty"`
 }
 ```
 
@@ -295,6 +306,45 @@ type Prompter struct {
 
 	// fd is the file descriptor used for the no-echo password read.
 	fd int
+}
+```
+
+```go
+// RecordOptions describes the local run being logged.
+type RecordOptions struct {
+	// Directory is where atkins was invoked. Empty means the process
+	// working directory.
+	Directory string
+
+	// Command is the atkins invocation. Empty means os.Args.
+	Command string
+
+	// Server overrides which logged-in server to record on.
+	Server string
+}
+```
+
+```go
+// Recorder is a run happening here that is logged on a CI/CD server.
+// It is the other half of dispatch: the pipeline executes on this
+// machine, as it does on a machine that never logged in, and the server
+// ends up with the job an agent would have produced — the same command,
+// checkout, output, exit code and duration. A history of what a team
+// runs should not depend on where the tooling happens to be installed.
+//
+// A nil *Recorder is the unrecorded run, and every method tolerates it,
+// so the caller has no branch to write.
+type Recorder struct {
+	client  *Client
+	jobID   string
+	url     string
+	agentID string
+
+	mu     sync.Mutex
+	buffer strings.Builder
+
+	// stop ends the lease renewals.
+	stop func()
 }
 ```
 
@@ -478,6 +528,13 @@ const (
 ## Vars
 
 ```go
+// ErrDispatchDisabled is returned when the environment forbids handing
+// the run over: an agent sets it for the command it runs, which is what
+// stops a job from dispatching itself forever.
+var ErrDispatchDisabled = errors.New(EnvNoDispatch + " is set")
+```
+
+```go
 // ErrNoTerminal is returned when a password is needed but stdin isn't a
 // terminal and no environment override was provided.
 var ErrNoTerminal = errors.New("stdin is not a terminal: set ATKINS_PASSWORD to log in non-interactively")
@@ -502,13 +559,24 @@ var ErrNotLoggedIn = errors.New("not logged in: run `atkins --login <url>`")
 var UserAgent = "atkins"
 ```
 
+```go
+// Errors reported when a checkout cannot be reproduced elsewhere.
+var (
+	// ErrDirtyCheckout is a work tree with uncommitted changes.
+	ErrDirtyCheckout = errors.New("the working tree has uncommitted changes")
+
+	// ErrUnpushedCheckout is a commit no remote has.
+	ErrUnpushedCheckout = errors.New("HEAD has not been pushed to a remote")
+)
+```
+
 ## Function symbols
 
 - `func Command (argv []string) string`
 - `func Configure (value config.ClientConfig)`
 - `func CredentialsPath () (string, error)`
 - `func DetectCheckout (dir string) (*Checkout, error)`
-- `func Dispatch (ctx context.Context, opts DispatchOptions) *Dispatched`
+- `func Dispatch (ctx context.Context, opts DispatchOptions) (*Dispatched, error)`
 - `func DispatchDisabled () bool`
 - `func Labels () []string`
 - `func LoadStore () (*Store, error)`
@@ -517,6 +585,7 @@ var UserAgent = "atkins"
 - `func NewPrompterFrom (in io.Reader, out io.Writer) *Prompter`
 - `func NormalizeServer (server string) string`
 - `func Open (server string) (*Client, error)`
+- `func Record (ctx context.Context, opts RecordOptions) *Recorder`
 - `func RunLogin (ctx context.Context, server string) error`
 - `func RunLogout (ctx context.Context, server string) error`
 - `func RunRegister (ctx context.Context, server string) error`
@@ -524,6 +593,7 @@ var UserAgent = "atkins"
 - `func SplitLabels (value string) []string`
 - `func (*APIError) Error () string`
 - `func (*Checkout) Payload () RepositoryPayload`
+- `func (*Checkout) Publishable () error`
 - `func (*Client) AppendLog (ctx context.Context, jobID,stream,content string) error`
 - `func (*Client) Artefacts (ctx context.Context, jobID string) ([]Artefact, error)`
 - `func (*Client) Claim (ctx context.Context, agentID string, labels []string) (*ClaimResponse, error)`
@@ -545,6 +615,12 @@ var UserAgent = "atkins"
 - `func (*Credential) Expired () bool`
 - `func (*Prompter) Line (label,env string) (string, error)`
 - `func (*Prompter) Password (label string) (string, error)`
+- `func (*Recorder) Cancelled (ctx context.Context)`
+- `func (*Recorder) Finish (ctx context.Context, exitCode int, runErr error)`
+- `func (*Recorder) JobID () string`
+- `func (*Recorder) Log (ctx context.Context, content string)`
+- `func (*Recorder) URL () string`
+- `func (*Recorder) Write (p []byte) (int, error)`
 - `func (*Store) Get (server string) (*Credential, bool)`
 - `func (*Store) Remove (server string)`
 - `func (*Store) Save () error`
@@ -607,14 +683,15 @@ func DetectCheckout(dir string) (*Checkout, error)
 Dispatch hands the current run to the CI/CD server this machine is
 logged in to, and returns where to watch it.
 
-It returns nil whenever the run belongs here instead: no credential,
-not inside a git repository, dispatch disabled, or the server could
-not be reached. Delegation is a convenience, and losing it should
-degrade to the behaviour of an unattached machine rather than to an
-error.
+Handing a run over is asked for — by --dispatch, or by
+`client.dispatch` in the configuration — so every reason it can't
+happen is an error rather than a quiet local run. The one that isn't
+worth stopping over is a repository nobody can clone, and that is
+refused before the job exists: an unpushed commit dispatches a job
+that dies in `git checkout` on a machine nobody is watching.
 
 ```go
-func Dispatch(ctx context.Context, opts DispatchOptions) *Dispatched
+func Dispatch(ctx context.Context, opts DispatchOptions) (*Dispatched, error)
 ```
 
 ### DispatchDisabled
@@ -698,6 +775,19 @@ server" rather than as a failure.
 func Open(server string) (*Client, error)
 ```
 
+### Record
+
+Record opens a job for a run about to happen here.
+
+It returns nil when there is nothing to record against: no
+credential, no git repository, recording turned off, or a server that
+can't be reached. Recording is bookkeeping, and losing it must not
+cost the run — unlike dispatch, which is the run.
+
+```go
+func Record(ctx context.Context, opts RecordOptions) *Recorder
+```
+
 ### RunLogin
 
 RunLogin drives `atkins --login https://domain`.
@@ -766,6 +856,20 @@ time the job is claimed.
 
 ```go
 func (*Checkout) Payload() RepositoryPayload
+```
+
+### Publishable
+
+Publishable reports whether another machine could reproduce this
+checkout from the repository's remote.
+
+A dispatched run names the commit it was started from, so a tree that
+only exists on this disk queues a job that fails in `git checkout`
+minutes later. The refusal belongs here, where the fix — commit and
+push, or run locally — is still in front of the person.
+
+```go
+func (*Checkout) Publishable() error
 ```
 
 ### AppendLog
@@ -958,6 +1062,59 @@ Password prompts for a secret without echoing it.
 
 ```go
 func (*Prompter) Password(label string) (string, error)
+```
+
+### Cancelled
+
+Cancelled settles the job as cancelled, for a run the user stopped.
+
+```go
+func (*Recorder) Cancelled(ctx context.Context)
+```
+
+### Finish
+
+Finish flushes what was written and settles the job.
+
+The status is derived from the same exit code the shell sees, so a
+recorded run and the terminal it ran in never disagree.
+
+```go
+func (*Recorder) Finish(ctx context.Context, exitCode int, runErr error)
+```
+
+### JobID
+
+JobID is the server's ID for this run, empty when unrecorded.
+
+```go
+func (*Recorder) JobID() string
+```
+
+### Log
+
+Log appends content to the job log immediately.
+
+```go
+func (*Recorder) Log(ctx context.Context, content string)
+```
+
+### URL
+
+URL is where the run is watched in a browser, empty when unrecorded.
+
+```go
+func (*Recorder) URL() string
+```
+
+### Write
+
+Write buffers output for the job log. It makes a Recorder an
+io.Writer, which is what lets the runner hand it a transcript without
+knowing what a job is.
+
+```go
+func (*Recorder) Write(p []byte) (int, error)
 ```
 
 ### Get

--- a/docs/api/atkins_config.md
+++ b/docs/api/atkins_config.md
@@ -57,9 +57,14 @@ type ClientConfig struct {
 	// Labels constrain which agents may run this machine's jobs.
 	Labels []string `yaml:"labels" json:"labels" env:"ATKINS_LABELS"`
 
-	// Dispatch hands runs to the server when logged in. Off means
-	// always run locally.
+	// Dispatch hands every run to an agent instead of running it here.
+	// Off, the default, is what `--dispatch` turns on for one run.
 	Dispatch bool `yaml:"dispatch" json:"dispatch" env:"ATKINS_DISPATCH"`
+
+	// Record logs local runs on the server when logged in: the run
+	// happens here and the job page holds its output and outcome. Off
+	// means a logged-in machine records nothing, the same as `--local`.
+	Record bool `yaml:"record" json:"record" env:"ATKINS_RECORD"`
 
 	// Timeout bounds an API call before the run falls back to local.
 	Timeout time.Duration `yaml:"timeout" json:"timeout" env:"ATKINS_TIMEOUT"`

--- a/docs/api/atkins_runner.md
+++ b/docs/api/atkins_runner.md
@@ -193,6 +193,12 @@ type PipelineOptions struct {
 	YAML         bool
 	AllPipelines []*model.Pipeline // All loaded pipelines for cross-pipeline task references
 	Progress     ProgressObserver  // Optional observer for job progress events
+
+	// Transcript receives the finished tree, the same rendering the
+	// terminal is left with. It is how a caller records the run
+	// somewhere else — a CI job log — without changing what a person
+	// watching it sees.
+	Transcript io.Writer
 }
 ```
 

--- a/docs/api/atkins_server_api.md
+++ b/docs/api/atkins_server_api.md
@@ -110,6 +110,15 @@ type DispatchRequest struct {
 	// Artefacts are glob patterns the agent collects after the command
 	// exits, relative to the directory it ran in.
 	Artefacts []string `json:"artefacts"`
+
+	// Agent names the machine already running this command. Set, the
+	// job is recorded as running there instead of queued for an agent
+	// to claim, and the caller reports its log and its outcome.
+	//
+	// It is how a run on somebody's laptop is on the server at all: the
+	// pipeline executes where it was started, and the history does not
+	// depend on whether that machine could hand the work over.
+	Agent string `json:"agent"`
 }
 ```
 
@@ -696,7 +705,7 @@ func (*Handlers) GetJobLog(w http.ResponseWriter, r *http.Request)
 
 ### JobCheckout
 
-JobCheckout records what an agent checked out for a job.
+JobCheckout records what the machine running a job checked out.
 
 ```go
 func (*Handlers) JobCheckout(w http.ResponseWriter, r *http.Request)
@@ -704,7 +713,7 @@ func (*Handlers) JobCheckout(w http.ResponseWriter, r *http.Request)
 
 ### JobHeartbeat
 
-JobHeartbeat extends the lease the calling agent holds on a job.
+JobHeartbeat extends the lease held on a job by whoever is running it.
 
 ```go
 func (*Handlers) JobHeartbeat(w http.ResponseWriter, r *http.Request)

--- a/docs/api/atkins_server_storage.md
+++ b/docs/api/atkins_server_storage.md
@@ -140,6 +140,16 @@ type JobRequest struct {
 	// Artefacts are glob patterns the agent collects after the command
 	// exits, relative to the directory it ran in.
 	Artefacts []string
+
+	// AgentID names the machine already running the job. Set, the job
+	// is created running and leased to it rather than pending: it is a
+	// run happening somewhere the queue cannot reach — `atkins` on a
+	// laptop — which reports its own log and outcome.
+	//
+	// The lease is what makes that safe to trust. A local run that dies
+	// without reporting stops renewing, and the server reclaims it as a
+	// timeout exactly as it does for an agent that disappears.
+	AgentID string
 }
 ```
 

--- a/docs/content/STRUCTURE.md
+++ b/docs/content/STRUCTURE.md
@@ -70,7 +70,55 @@ Modular pipeline components. Covers skill locations (project and global), condit
 
 ### CLI Flags
 
-Command-line options reference. Covers all flags (`--file`, `--list`, `--lint`, `--json`, `--yaml`, `--final`, `--log`, `--debug`, `--working-directory`, `--jail`, `--vendor`, `--write`), file discovery order, running and listing jobs, output modes, and stdin input.
+Command-line options reference: file discovery order, running and listing jobs, output modes, and stdin input.
+
+**Choosing what runs**
+
+| Flag                  | Short | Description                                                 |
+|-----------------------|-------|-------------------------------------------------------------|
+| `--file`              | `-f`  | Pipeline file to use, instead of the discovered one         |
+| `--working-directory` | `-w`  | Change to this directory before running                     |
+| `--jail`              |       | Load skills from the project only, ignoring `$HOME/.atkins` |
+| `--list`              | `-l`  | List the jobs and dependencies instead of running them      |
+| `--lint`              |       | Check the pipeline for errors and exit                      |
+
+**Output**
+
+| Flag        | Short | Description                                             |
+|-------------|-------|---------------------------------------------------------|
+| `--json`    | `-j`  | Emit the run, or the listing, as JSON                   |
+| `--yaml`    | `-y`  | Emit the run, or the listing, as YAML                   |
+| `--final`   |       | Print the tree once at the end rather than redrawing it |
+| `--log`     |       | Write an execution log to this file                     |
+| `--debug`   |       | Print interpolation, evaluation and timing detail       |
+| `--version` | `-v`  | Print the version and build information                 |
+
+**CI/CD server**
+
+| Flag         | Description                                                     |
+|--------------|-----------------------------------------------------------------|
+| `--login`    | Log in to a server, e.g. `--login https://ci.example.com`       |
+| `--register` | Create an account on a server and log in                        |
+| `--logout`   | Detach this machine from the server it last logged in to        |
+| `--dispatch` | Hand this run to an agent; refuses a dirty or unpushed checkout |
+| `--local`    | Run here without recording the run on the server                |
+
+**Project setup**
+
+| Flag       | Description                                                        |
+|------------|--------------------------------------------------------------------|
+| `--config` | Open the configuration menu over `.atkins/config.yml`              |
+| `--vendor` | Report the skills this repository uses from `$HOME/.atkins/skills` |
+| `--write`  | With `--vendor`, write them into `.atkins/skills`                  |
+
+**Agent**
+
+| Flag      | Short | Description                               |
+|-----------|-------|-------------------------------------------|
+| `--agent` |       | Start the interactive agent REPL          |
+| `--exec`  | `-x`  | Run one prompt through the agent and exit |
+
+`atkins server` and `atkins worker` take their own flags; see [CI/CD Server](./usage/ci-cd.md).
 
 ### Job Targeting
 
@@ -86,7 +134,7 @@ Machine-readable output for tooling integration. Covers list and execution outpu
 
 ### CI/CD Server
 
-Distributed job dispatch. Covers the throwaway compose instance, attaching a machine with `atkins --login`, creating an account with `atkins --register`, credential storage and non-interactive login, what each run dispatches (repository, working directory, command) and the job URL it prints, the job page, the environment an agent exports to a job, nested dispatch and depth limits, `.atkins/config.yml` and the `atkins --config` menu, running `atkins server` and `atkins worker`, the repository allowlist, deploy keys, runtime settings, user roles, and the HTTP API.
+Distributed job dispatch. Covers the throwaway compose instance, attaching a machine with `atkins --login`, creating an account with `atkins --register`, credential storage and non-interactive login, how a logged-in machine records the run it performs locally, handing a run to an agent with `atkins --dispatch` and the clean-checkout it requires, what each run dispatches (repository, working directory, command) and the job URL it prints, the job page, the environment an agent exports to a job, nested dispatch and depth limits, `.atkins/config.yml` and the `atkins --config` menu, running `atkins server` and `atkins worker`, the repository allowlist, deploy keys, runtime settings, user roles, and the HTTP API.
 
 ## Migrating
 

--- a/docs/content/usage/ci-cd.md
+++ b/docs/content/usage/ci-cd.md
@@ -4,7 +4,7 @@ subtitle: Distributed job dispatch with atkins --login
 layout: page
 ---
 
-Atkins can attach to a CI/CD server. Once a machine is logged in, `atkins` stops running the pipeline itself: it records the run as a job, prints one URL, and exits. An agent checks the repository out somewhere else and runs it there.
+Atkins can attach to a CI/CD server. Logging in changes what is **recorded**, not where a run happens: `atkins` still runs the pipeline on the machine you typed it on, and the server ends up with the job an agent would have produced — the same command, checkout, output and exit code. `atkins --dispatch` is the opt-in that hands a run to an agent instead.
 
 The design keeps atkins in charge. The server is a queue and a ledger; it does not decide what a pipeline does. Three things travel with every run — the git repository, the directory inside its work tree, and the atkins command — which is everything another machine needs to reproduce it.
 
@@ -12,7 +12,13 @@ The design keeps atkins in charge. The server is a queue and a ledger; it does n
 laptop                     server (:3200)            agent (container)
 ------                     --------------            -----------------
 atkins --login  ─────────► /api/user/login
-atkins          ─────────► /api/dispatch  ──┐
+
+atkins          ─────────► /api/dispatch  (agent: this machine)
+   runs here                              │  job starts running
+                           /api/job/{id}/log ◄─ the run's transcript
+                           /api/job/{id}/status ◄ terminal state
+
+atkins --dispatch ───────► /api/dispatch  ──┐
    prints job URL, exits                    │  job queued
                                             ▼
                            /api/job/claim ◄──── poll
@@ -31,7 +37,8 @@ The repository ships a throwaway instance: a server and one agent, on port 3200.
 ```bash
 atkins up                                 # build and start
 atkins --register http://localhost:3200   # first account, becomes admin
-atkins                                    # prints http://localhost:3200/job/<ULID>?t=<token>
+atkins                                    # runs here, recorded at http://localhost:3200/job/<ULID>?t=<token>
+atkins --dispatch                         # queues it for the agent instead
 atkins down
 ```
 
@@ -75,36 +82,67 @@ Set the credentials in the environment and no prompt is shown. This is how a con
 | `ATKINS_USERNAME` | Username, `--register` only |
 | `ATKINS_PASSWORD` | Password, skips the prompt  |
 
+## What a run records
+
+A logged-in machine posts every run to `/api/dispatch` and goes on to run the pipeline itself. The job is created **running**, leased to this machine rather than queued, and the same terminal that draws the tree reports the outcome:
+
+```bash
+$ atkins test
+recording: http://localhost:3200/job/01J8…?t=…
+Atkins project tests, build
+└─ test:simple - Simple go test with gotestsum ✓
+```
+
+What lands on the job page is the finished tree, the commit it ran against, the exit code the shell saw, and how long it took. A run stopped with ctrl-C is recorded as cancelled; one that dies with the terminal stops renewing its lease and is reclaimed as a timeout, the same way a lost agent's job is.
+
+The transcript arrives when the run finishes rather than line by line, so a page opened mid-run says which machine is running what and fills in at the end. Artefacts are not collected from a local run — nothing here has an `ATKINS_ARTEFACTS` directory to sweep.
+
+To run without recording anything:
+
+```bash
+atkins --local                 # this run only
+```
+
+Setting `client.record: false` in the configuration turns recording off for good, and a machine that never logged in has nothing to record to.
+
 ## What a run dispatches
 
-Once logged in, `atkins` posts to `/api/dispatch` and prints the job URL:
+`atkins --dispatch` hands the run to an agent instead of running it here, and prints the job URL:
 
-| Field               | Value                                               |
-|---------------------|-----------------------------------------------------|
-| `repository`        | `origin` remote URL, ref and default branch         |
-| `working_directory` | Pipeline directory, relative to the repository root |
-| `command`           | The atkins invocation, e.g. `atkins test:build`     |
-| `parent_id`         | `ATKINS_JOB_ID`, when a job dispatches further work |
-| `labels`            | Which agents may run it                             |
-| `clone_depth`       | History the agent's work tree needs; 0 is all of it |
-| `artefacts`         | Globs the agent collects when the command exits     |
+| Field               | Value                                                        |
+|---------------------|--------------------------------------------------------------|
+| `repository`        | `origin` remote URL, ref and default branch                  |
+| `working_directory` | Pipeline directory, relative to the repository root          |
+| `command`           | The atkins invocation, e.g. `atkins test:build`              |
+| `parent_id`         | `ATKINS_JOB_ID`, when a job dispatches further work          |
+| `labels`            | Which agents may run it                                      |
+| `clone_depth`       | History the agent's work tree needs; 0 is all of it          |
+| `artefacts`         | Globs the agent collects when the command exits              |
+| `agent`             | Set only by a recorded local run: the machine running it now |
 
 The server normalizes the remote URL into a `host/owner/name` slug, so `git@github.com:you/repo.git` and `https://github.com/you/repo` are one repository. Repositories are created on first sight; nothing has to be registered up front.
 
-The ref atkins sends is the **commit you are on**, not the branch you are on. A dispatched run belongs to the code in front of you, and a branch name would let the agent build whatever that branch had moved to by the time it claimed the job. The consequence is worth knowing: dispatching a commit you have not pushed fails, naming the ref it could not find, rather than quietly building the branch tip instead.
+The ref atkins sends is the **commit you are on**, not the branch you are on. A dispatched run belongs to the code in front of you, and a branch name would let the agent build whatever that branch had moved to by the time it claimed the job.
+
+That is why `--dispatch` inspects the work tree before it queues anything:
+
+```text
+$ atkins --dispatch test
+ERROR: the working tree has uncommitted changes: an agent would build 41c9d0e2a7b1, which does not have them
+
+$ atkins --dispatch test
+ERROR: HEAD has not been pushed to a remote: an agent clones the repository, and 41c9d0e2a7b1 is only on this machine
+```
+
+Both are refused here, where committing and pushing is still in front of you, rather than minutes later as a job that died in `git checkout`. The test is on the commit rather than the branch: a commit any remote has can be cloned, whether or not the local branch tracks anything.
 
 The response carries the job's ID and, while the instance keeps jobs private, a `view_token` that opens its page in a browser. `atkins` prints the two as one URL; a script driving `/api/dispatch` or a trigger with `curl` builds it the same way. Losing that line is not losing the link: `GET /api/job/{id}` and `GET /api/job` return the same `view_token`, plus a ready-made `url`, to any caller allowed to read the job.
 
-Delegation degrades to a local run rather than to an error. If the machine isn't logged in, isn't inside a git repository, or the server can't be reached, the pipeline runs here as it always did — with the reason on stderr.
+`--dispatch` fails rather than degrading. A machine that isn't logged in, isn't inside a git repository or can't reach the server was asked to hand a run over and couldn't, and quietly running it here instead is how a person ends up watching a queue nothing was ever queued on. Recording is the opposite: it is bookkeeping, so it drops out silently rather than costing the run it was meant to describe.
 
-To run locally on purpose:
+Setting `client.dispatch: true` in the configuration makes dispatch the default for a machine, as if every run carried the flag.
 
-```bash
-atkins --local              # this run only
-ATKINS_NO_DISPATCH=1 atkins # same, for a script
-```
-
-Setting `client.dispatch: false` in the configuration turns delegation off for good.
+`ATKINS_NO_DISPATCH=1` outranks both, and an agent sets it for the command it runs. Without it the atkins the agent runs would hand the work straight back to the server, and a job recorded as `atkins --dispatch test` would bounce forever; the guard is why that job runs where it was claimed instead.
 
 ### Environment exported to a job
 
@@ -375,7 +413,8 @@ opens a menu over the project document, creating it from the built-in defaults i
 client:
   server: https://ci.example.com
   labels: [linux, amd64]
-  dispatch: true
+  dispatch: false
+  record: true
 
 server:
   addr: ":3200"
@@ -549,10 +588,10 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/job/{id}/retry`          | POST            | user   | Queue a copy of a finished job         |
 | `/api/job/{id}/cancel`         | POST            | user   | Settle an unfinished job               |
 | `/api/job/claim`               | POST            | agent  | Lease the oldest pending job           |
-| `/api/job/{id}/status`         | POST            | agent  | Settle a job                           |
-| `/api/job/{id}/checkout`       | POST            | agent  | Record the ref and commit it built     |
-| `/api/job/{id}/heartbeat`      | POST            | agent  | Extend the lease                       |
-| `/api/job/{id}/log`            | POST            | agent  | Append output                          |
+| `/api/job/{id}/status`         | POST            | runner | Settle a job                           |
+| `/api/job/{id}/checkout`       | POST            | runner | Record the ref and commit it built     |
+| `/api/job/{id}/heartbeat`      | POST            | runner | Extend the lease                       |
+| `/api/job/{id}/log`            | POST            | runner | Append output                          |
 | `/api/job/{id}/artefact`       | POST            | agent  | Upload a file, `?path=` names it       |
 | `/api/agent/enrol`             | POST            | token  | Trade the shared token for credentials |
 | `/api/agent/policy`            | GET             | agent  | The repository policy to enforce       |
@@ -563,6 +602,8 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
 | `/api/admin/ssh-key[/{id}]`    | GET/POST/DELETE | admin  | Manage deploy keys                     |
 
 Authentication is `Authorization: Bearer <token>`. Access tokens live an hour and carry the session they came from, so logout takes effect immediately rather than when the token expires. Refresh tokens are single-use and rotate on every refresh, which makes a leaked one detectable: the legitimate client's next refresh fails.
+
+**runner** in the table is whoever is running the job: an agent, for anything it claimed, or the owner of a job that is already running, which is the machine recording a local run. Ownership is required outright rather than through readability, so making an instance public does not hand every user everybody else's runs to settle, and a *pending* job is refused — nobody has started it, so a report on it would be fiction and `/cancel` is the way to stop it.
 
 ## Pages
 

--- a/docs/content/usage/cli-flags.md
+++ b/docs/content/usage/cli-flags.md
@@ -18,26 +18,51 @@ Running jobs is the default, so `atkins build` and `atkins run build` are the sa
 
 ## Flag Reference
 
-| Flag                  | Short | Description                            |
-|-----------------------|-------|----------------------------------------|
-| `--file`              | `-f`  | Path to pipeline file                  |
-| `--list`              | `-l`  | List available jobs                    |
-| `--lint`              |       | Validate pipeline syntax               |
-| `--json`              | `-j`  | Output in JSON format                  |
-| `--yaml`              | `-y`  | Output in YAML format                  |
-| `--final`             |       | Show only final tree (no live updates) |
-| `--log`               |       | Log execution to file                  |
-| `--debug`             |       | Enable debug output                    |
-| `--version`           | `-v`  | Print version and build information    |
-| `--working-directory` | `-w`  | Change directory before running        |
-| `--jail`              |       | Restrict to project scope only         |
-| `--vendor`            |       | List the skills this repository uses   |
-| `--write`             |       | With `--vendor`, write them            |
-| `--config`            |       | Open the configuration menu            |
-| `--login`             |       | Log in to a CI/CD server               |
-| `--register`          |       | Register an account on a CI/CD server  |
-| `--logout`            |       | Log out of the CI/CD server            |
-| `--local`             |       | Run here instead of dispatching        |
+### Choosing what runs
+
+| Flag                  | Short | Description                                                 |
+|-----------------------|-------|-------------------------------------------------------------|
+| `--file`              | `-f`  | Pipeline file to use, instead of the discovered one         |
+| `--working-directory` | `-w`  | Change to this directory before running                     |
+| `--jail`              |       | Load skills from the project only, ignoring `$HOME/.atkins` |
+| `--list`              | `-l`  | List the jobs and dependencies instead of running them      |
+| `--lint`              |       | Check the pipeline for errors and exit                      |
+
+### Output
+
+| Flag        | Short | Description                                       |
+|-------------|-------|---------------------------------------------------|
+| `--json`    | `-j`  | Emit the run, or the listing, as JSON             |
+| `--yaml`    | `-y`  | Emit the run, or the listing, as YAML             |
+| `--final`   |       | Print the tree once at the end, without redrawing |
+| `--log`     |       | Write an execution log to this file               |
+| `--debug`   |       | Print interpolation, evaluation and timing detail |
+| `--version` | `-v`  | Print the version and build information           |
+
+### CI/CD server
+
+| Flag         | Description                                                     |
+|--------------|-----------------------------------------------------------------|
+| `--login`    | Log in to a server, e.g. `--login https://ci.example.com`       |
+| `--register` | Create an account on a server and log in                        |
+| `--logout`   | Detach this machine from the server it last logged in to        |
+| `--dispatch` | Hand this run to an agent; refuses a dirty or unpushed checkout |
+| `--local`    | Run here without recording the run on the server                |
+
+### Project setup
+
+| Flag       | Description                                                        |
+|------------|--------------------------------------------------------------------|
+| `--config` | Open the configuration menu over `.atkins/config.yml`              |
+| `--vendor` | Report the skills this repository uses from `$HOME/.atkins/skills` |
+| `--write`  | With `--vendor`, write them into `.atkins/skills`                  |
+
+### Agent
+
+| Flag      | Short | Description                               |
+|-----------|-------|-------------------------------------------|
+| `--agent` |       | Start the interactive agent REPL          |
+| `--exec`  | `-x`  | Run one prompt through the agent and exit |
 
 ## File Discovery
 
@@ -233,6 +258,15 @@ atkins --vendor --write
 
 `--debug` adds the reason each skill was selected and the diff behind the line counts. The copies are ordinary repository content, so a clone or a CI agent gets the same jobs without a personal skills directory. `--vendor` and `--jail` cannot be combined: jail mode excludes the directory vendoring reads from. See [Skills](./skills#vendoring) for the selection rules.
 
+## Agent REPL
+
+```bash
+atkins --agent                    # interactive
+atkins -x "run the tests"         # one prompt, then exit
+```
+
+The agent reads the pipelines and skills this project resolves to and drives them for you. It is the same job resolution the flags above use; nothing is available to it that `atkins -l` doesn't show.
+
 ## Configuration
 
 ```bash
@@ -258,7 +292,13 @@ atkins --logout
 
 Credentials are stored per server in `~/.atkins/credentials.json` (mode `0600`).
 
-Once logged in, `atkins` **hands runs to the server** instead of running them: it prints one job URL and exits, and an agent runs the pipeline against a fresh checkout. To run here instead:
+Once logged in, `atkins` still runs the pipeline **here** and records the run on the server: the job page ends up with the transcript, the commit and the exit code an agent would have reported. To hand a run to an agent instead:
+
+```bash
+atkins --dispatch     # prints one job URL and exits
+```
+
+`--dispatch` refuses a dirty or unpushed work tree, since an agent builds the commit rather than your disk. To run here and record nothing:
 
 ```bash
 atkins --local        # this run only

--- a/options.go
+++ b/options.go
@@ -20,11 +20,13 @@ type Options struct {
 	Exec             string
 
 	// CI/CD client flags. Login and Register take the server URL;
-	// Logout applies to the server last logged in to. Local runs here
-	// instead of handing the job to the server.
+	// Logout applies to the server last logged in to. Dispatch hands
+	// the run to an agent instead of running it here, and Local runs
+	// here without recording anything on the server.
 	Login    string
 	Register string
 	Logout   bool
+	Dispatch bool
 	Local    bool
 
 	// Config opens the configuration menu for .atkins/config.yml.
@@ -59,7 +61,8 @@ func (o *Options) Bind(fs *cli.FlagSet) {
 	fs.StringVar(&o.Login, "login", "", "Log in to an atkins CI/CD server, e.g. --login https://ci.example.com")
 	fs.StringVar(&o.Register, "register", "", "Register an account on an atkins CI/CD server and log in")
 	fs.BoolVar(&o.Logout, "logout", false, "Log out of the atkins CI/CD server")
-	fs.BoolVar(&o.Local, "local", false, "Run here instead of dispatching to the CI/CD server")
+	fs.BoolVar(&o.Dispatch, "dispatch", false, "Hand this run to a CI/CD agent instead of running it here")
+	fs.BoolVar(&o.Local, "local", false, "Run here without recording the run on the CI/CD server")
 	fs.BoolVar(&o.Config, "config", false, "Open the configuration menu for .atkins/config.yml")
 	fs.BoolVar(&o.Vendor, "vendor", false, "List the skills this repository uses from $HOME/.atkins/skills")
 	fs.BoolVar(&o.Write, "write", false, "With --vendor, write the skills into .atkins/skills")

--- a/pipeline.go
+++ b/pipeline.go
@@ -28,6 +28,12 @@ func loadSkillPipelines(workspaceDir string, startDir string, opts *Options) ([]
 	return loader.Load()
 }
 
+// pipelineJobs is one pipeline and the jobs resolved onto it.
+type pipelineJobs struct {
+	pipeline *model.Pipeline
+	jobs     []string
+}
+
 // stdinHasData checks if stdin has data available without blocking.
 // Returns true if stdin is piped/redirected with data available.
 func stdinHasData() bool {
@@ -316,10 +322,6 @@ pipelineReady:
 	}
 
 	// Resolve all jobs and group by pipeline
-	type pipelineJobs struct {
-		pipeline *model.Pipeline
-		jobs     []string
-	}
 	pipelineJobsMap := make(map[*model.Pipeline]*pipelineJobs)
 	var pipelineOrder []*model.Pipeline
 	resolver := runner.NewTaskResolver(pipelines)
@@ -369,16 +371,75 @@ pipelineReady:
 		pipelineJobsMap[pipeline].jobs = append(pipelineJobsMap[pipeline].jobs, resolvedName)
 	}
 
-	// Hand the run to the CI/CD server when this machine is logged in
-	// to one and the run happens inside a git repository. An agent
-	// checks the repository out and runs the command there, so all
-	// that's left here is where to watch it.
-	if dispatched := client.Dispatch(ctx, client.DispatchOptions{Local: opts.Local}); dispatched != nil {
+	// Handing the run to an agent is asked for rather than assumed:
+	// logging in records what this machine runs, it does not move where
+	// it runs. An agent checks the repository out and runs the command
+	// there, so all that's left here is where to watch it.
+	//
+	// An agent exports ATKINS_NO_DISPATCH for the command it runs, and
+	// that outranks the flag: the job it is running was recorded with
+	// the whole command line, `--dispatch` and all, and honouring it
+	// there would hand the work straight back to the queue.
+	if (opts.Dispatch || client.Settings().Dispatch) && !client.DispatchDisabled() {
+		dispatched, err := client.Dispatch(ctx, client.DispatchOptions{})
+		if err != nil {
+			return fmt.Errorf("%s %v", colors.BrightRed("ERROR:"), err)
+		}
+
 		fmt.Println(dispatched.URL)
 		return nil
 	}
 
-	// Run each pipeline with its collected jobs
+	// The run happens here, and the server ends up with the job an
+	// agent would have produced. The link is printed before the run so
+	// it can be handed to somebody while the pipeline is still going.
+	var recorder *client.Recorder
+	if !opts.Local {
+		recorder = client.Record(ctx, client.RecordOptions{})
+		if url := recorder.URL(); url != "" {
+			fmt.Printf("%s %s\n", colors.Dim("recording:"), url)
+		}
+	}
+
+	exitCode, runErr := runPipelines(ctx, opts, pipelineOrder, pipelineJobsMap, allPipelines, recorder)
+
+	// A run stopped by hand is not a run that failed, and the record
+	// should not read as one.
+	if ctx.Err() != nil {
+		recorder.Cancelled(ctx)
+	} else {
+		recorder.Finish(ctx, exitCode, runErr)
+	}
+
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
+	return nil
+}
+
+// runPipelines runs each pipeline with its collected jobs and returns
+// the exit code the shell should see.
+//
+// The exit is the caller's to perform rather than this function's: a
+// recorded run has an outcome to report to the server, and os.Exit from
+// here would file none of it.
+func runPipelines(
+	ctx context.Context,
+	opts *Options,
+	pipelineOrder []*model.Pipeline,
+	pipelineJobsMap map[*model.Pipeline]*pipelineJobs,
+	allPipelines []*model.Pipeline,
+	recorder *client.Recorder,
+) (int, error) {
+	var transcript io.Writer
+	if recorder != nil {
+		transcript = recorder
+	}
+
+	exitCode := 0
+	var runErr error
+
 	for _, pipeline := range pipelineOrder {
 		pj := pipelineJobsMap[pipeline]
 		err := runner.RunPipeline(ctx, pipeline, runner.PipelineOptions{
@@ -390,36 +451,43 @@ pipelineReady:
 			JSON:         opts.JSON,
 			YAML:         opts.YAML,
 			AllPipelines: allPipelines,
+			Transcript:   transcript,
 		})
-		if err != nil {
-			exitCode := 1
-			failedPipeline := pipeline.Name
+		if err == nil {
+			continue
+		}
 
-			var errorLog runner.ExecError
-			if errors.As(err, &errorLog) {
-				if errorLog.Len() > 0 {
-					fmt.Fprintf(os.Stderr, "\nAn error occurred in %q pipeline:\n\n", failedPipeline)
-					fmt.Fprintf(os.Stderr, "  Exit code: %d\n", errorLog.LastExitCode)
-					fmt.Fprintf(os.Stderr, "  Error output:\n")
-					for _, line := range strings.Split(errorLog.Output, "\n") {
-						if line != "" {
-							fmt.Fprintf(os.Stderr, "    %s\n", line)
-						}
+		runErr = err
+		exitCode = 1
+		failedPipeline := pipeline.Name
+
+		var errorLog runner.ExecError
+		if errors.As(err, &errorLog) {
+			if errorLog.Len() > 0 {
+				fmt.Fprintf(os.Stderr, "\nAn error occurred in %q pipeline:\n\n", failedPipeline)
+				fmt.Fprintf(os.Stderr, "  Exit code: %d\n", errorLog.LastExitCode)
+				fmt.Fprintf(os.Stderr, "  Error output:\n")
+				for _, line := range strings.Split(errorLog.Output, "\n") {
+					if line != "" {
+						fmt.Fprintf(os.Stderr, "    %s\n", line)
 					}
 				}
-				exitCode = errorLog.LastExitCode
-			} else {
-				fmt.Fprintf(os.Stderr, "\nAn error occurred in %q pipeline:\n", failedPipeline)
-				fmt.Fprintf(os.Stderr, "  %s\n", err.Error())
 			}
+			exitCode = errorLog.LastExitCode
+		} else {
+			fmt.Fprintf(os.Stderr, "\nAn error occurred in %q pipeline:\n", failedPipeline)
+			fmt.Fprintf(os.Stderr, "  %s\n", err.Error())
+		}
 
-			if exitCode != 0 {
-				os.Exit(exitCode)
-			}
+		// An exit code of zero is a failure the pipeline reported
+		// without one, and the remaining pipelines still run; that is
+		// the behaviour every earlier release had.
+		if exitCode != 0 {
+			return exitCode, runErr
 		}
 	}
 
-	return nil
+	return exitCode, runErr
 }
 
 // runAgent starts the interactive agent REPL.

--- a/pipeline.go
+++ b/pipeline.go
@@ -432,6 +432,8 @@ func runPipelines(
 	allPipelines []*model.Pipeline,
 	recorder *client.Recorder,
 ) (int, error) {
+	// Left nil when nothing is recording, so an unrecorded run doesn't
+	// render a tree into a writer that throws it away.
 	var transcript io.Writer
 	if recorder != nil {
 		transcript = recorder

--- a/runner/pipeline.go
+++ b/runner/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"slices"
@@ -33,6 +34,12 @@ type PipelineOptions struct {
 	YAML         bool
 	AllPipelines []*model.Pipeline // All loaded pipelines for cross-pipeline task references
 	Progress     ProgressObserver  // Optional observer for job progress events
+
+	// Transcript receives the finished tree, the same rendering the
+	// terminal is left with. It is how a caller records the run
+	// somewhere else — a CI job log — without changing what a person
+	// watching it sees.
+	Transcript io.Writer
 }
 
 // Pipeline holds pipeline execution logic.
@@ -527,6 +534,8 @@ func (p *Pipeline) runPipeline(ctx context.Context, logger *eventlog.Logger) err
 				display.RenderFinal(root)
 			}
 
+			p.writeTranscript(root)
+
 			// Write event log on failure
 			writeEventLog(logger, root, err)
 
@@ -554,6 +563,8 @@ func (p *Pipeline) runPipeline(ctx context.Context, logger *eventlog.Logger) err
 		display.RenderFinal(root)
 	}
 
+	p.writeTranscript(root)
+
 	// Write event log
 	writeEventLog(logger, root, runErr)
 
@@ -570,6 +581,21 @@ func (p *Pipeline) runPipeline(ctx context.Context, logger *eventlog.Logger) err
 	}
 
 	return runErr
+}
+
+// writeTranscript hands the finished tree to the caller's writer.
+//
+// It renders the same thing RenderFinal prints, colours included, so a
+// job page reads like the terminal the run happened in rather than like
+// a second, plainer account of it.
+func (p *Pipeline) writeTranscript(root *treeview.Node) {
+	if p.opts.Transcript == nil {
+		return
+	}
+
+	// A transcript nobody could write is not worth interrupting a run
+	// that has already finished.
+	_, _ = fmt.Fprint(p.opts.Transcript, treeview.NewRenderer().Render(root))
 }
 
 // writeEventLog writes the final event log to the file.

--- a/runner/transcript_test.go
+++ b/runner/transcript_test.go
@@ -1,0 +1,84 @@
+package runner_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/model"
+	"github.com/titpetric/atkins/runner"
+)
+
+// TestTranscript covers the writer a caller hands RunPipeline to record
+// the run somewhere else, which is what a locally-run CI job logs.
+func TestTranscript(t *testing.T) {
+	t.Run("receives the finished tree", func(t *testing.T) {
+		pipeline := &model.Pipeline{
+			Name: "transcript",
+			Jobs: map[string]*model.Job{
+				"greet": {
+					Name:     "greet",
+					Desc:     "Say hello",
+					Passthru: true,
+					Steps:    []*model.Step{{Run: "echo hello"}},
+				},
+			},
+		}
+
+		var transcript bytes.Buffer
+		err := runner.RunPipeline(t.Context(), pipeline, runner.PipelineOptions{
+			Jobs:         []string{"greet"},
+			Silent:       true,
+			AllPipelines: []*model.Pipeline{pipeline},
+			Transcript:   &transcript,
+		})
+		require.NoError(t, err)
+
+		assert.Contains(t, transcript.String(), "transcript")
+		assert.Contains(t, transcript.String(), "greet")
+		assert.Contains(t, transcript.String(), "Say hello")
+	})
+
+	t.Run("receives a failed run too", func(t *testing.T) {
+		pipeline := &model.Pipeline{
+			Name: "transcript",
+			Jobs: map[string]*model.Job{
+				"boom": {
+					Name:  "boom",
+					Steps: []*model.Step{{Run: "exit 3"}},
+				},
+			},
+		}
+
+		// A record that stops existing when the run fails is the record
+		// nobody needed in the first place.
+		var transcript bytes.Buffer
+		err := runner.RunPipeline(t.Context(), pipeline, runner.PipelineOptions{
+			Jobs:         []string{"boom"},
+			Silent:       true,
+			AllPipelines: []*model.Pipeline{pipeline},
+			Transcript:   &transcript,
+		})
+		require.Error(t, err)
+
+		assert.Contains(t, transcript.String(), "boom")
+	})
+
+	t.Run("is optional", func(t *testing.T) {
+		pipeline := &model.Pipeline{
+			Name: "transcript",
+			Jobs: map[string]*model.Job{
+				"noop": {Name: "noop", Steps: []*model.Step{{Run: "true"}}},
+			},
+		}
+
+		err := runner.RunPipeline(t.Context(), pipeline, runner.PipelineOptions{
+			Jobs:         []string{"noop"},
+			Silent:       true,
+			AllPipelines: []*model.Pipeline{pipeline},
+		})
+		assert.NoError(t, err)
+	})
+}

--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -65,11 +65,13 @@ func (s *Handlers) MountAgent(r platform.Router) {
 //
 // An admin is not admitted, deliberately. `is_agent` means what the
 // roles section says it means, and widening it for convenience would
-// undo two things built on purpose: SSHKeyView withholds private key
-// material from the admin surface, and this route hands it over; and a
-// job settled here records an `agent_id` that would then name an agent
-// that never ran it. An admin who needs to act as an agent enrols one,
-// which is a decision written down rather than a side effect.
+// undo something built on purpose: SSHKeyView withholds private key
+// material from the admin surface, and these routes hand it over. An
+// admin who needs to act as an agent enrols one, which is a decision
+// written down rather than a side effect.
+//
+// Reporting on a job asks a narrower question than this one — who ran
+// it — and reportableJob answers it.
 func (s *Handlers) requireAgent(r *http.Request) (*model.User, error) {
 	user, _, err := s.authenticateUser(r)
 	if err != nil {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -164,6 +164,53 @@ func (s *Handlers) readableJob(r *http.Request, user *model.User, jobID string) 
 // errJobNotFound covers both "no such job" and "not yours".
 var errJobNotFound = errors.New("job not found")
 
+// reportableJob loads a job the caller may report on: append output to
+// it, renew its lease, record its checkout, settle it.
+//
+// An agent may report on any job, because the queue is its whole
+// business. Everybody else may report on a job of their own that is
+// already running, which is the local run: the pipeline executes on the
+// machine that started it and reports what an agent would have
+// reported, from an ordinary account with no agent credentials.
+//
+// Two limits keep that from being a wider power than it looks. Ownership
+// is required outright rather than through readability, so making an
+// instance public does not hand every user everybody else's jobs. And a
+// pending job is refused: nobody has started it, the report would be
+// fiction, and cancelling is the way to stop work that hasn't begun.
+func (s *Handlers) reportableJob(r *http.Request, jobID string) (*model.Job, error) {
+	user, _, err := s.authenticateUser(r)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := s.jobs.Get(r.Context(), jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, requestError(http.StatusNotFound, errJobNotFound)
+		}
+		return nil, err
+	}
+
+	if user.IsAgent {
+		return job, nil
+	}
+
+	owned, err := s.jobs.VisibleTo(r.Context(), job, user.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !owned {
+		return nil, requestError(http.StatusNotFound, errJobNotFound)
+	}
+
+	if job.Status == model.JobStatusPending {
+		return nil, requestError(http.StatusForbidden, model.ErrForbidden)
+	}
+
+	return job, nil
+}
+
 // viewToken returns the token that opens a job page without a session,
 // or an empty string on an instance whose pages are public anyway.
 func (s *Handlers) viewToken(jobID string) string {

--- a/server/api/dispatch.go
+++ b/server/api/dispatch.go
@@ -49,6 +49,15 @@ type DispatchRequest struct {
 	// Artefacts are glob patterns the agent collects after the command
 	// exits, relative to the directory it ran in.
 	Artefacts []string `json:"artefacts"`
+
+	// Agent names the machine already running this command. Set, the
+	// job is recorded as running there instead of queued for an agent
+	// to claim, and the caller reports its log and its outcome.
+	//
+	// It is how a run on somebody's laptop is on the server at all: the
+	// pipeline executes where it was started, and the history does not
+	// depend on whether that machine could hand the work over.
+	Agent string `json:"agent"`
 }
 
 // RepositoryPayload is the git detail a client reports about its checkout.
@@ -234,6 +243,7 @@ func (s *Handlers) dispatch(w http.ResponseWriter, r *http.Request) error {
 		Labels:           req.Labels,
 		Params:           params,
 		Artefacts:        req.Artefacts,
+		AgentID:          strings.TrimSpace(req.Agent),
 	})
 	if err != nil {
 		switch {
@@ -398,9 +408,10 @@ func (s *Handlers) JobStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) jobStatus(w http.ResponseWriter, r *http.Request) error {
-	// The agent that ran the job reports it; an admin may settle one
-	// by hand to cancel it.
-	if _, err := s.requireAgent(r); err != nil {
+	// Whoever ran the job reports it: the agent that claimed it, or the
+	// machine that ran it locally and owns the record.
+	target, err := s.reportableJob(r, platform.URLParam(r, "jobID"))
+	if err != nil {
 		return err
 	}
 
@@ -412,7 +423,7 @@ func (s *Handlers) jobStatus(w http.ResponseWriter, r *http.Request) error {
 		return requestError(http.StatusBadRequest, errors.New("status must be one of: passed, failed, timeout, cancelled"))
 	}
 
-	job, err := s.jobs.Finish(r.Context(), platform.URLParam(r, "jobID"), storage.StatusRequest{
+	job, err := s.jobs.Finish(r.Context(), target.ID, storage.StatusRequest{
 		Status:   req.Status,
 		ExitCode: req.ExitCode,
 		Error:    req.Error,
@@ -430,13 +441,14 @@ func (s *Handlers) jobStatus(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// JobCheckout records what an agent checked out for a job.
+// JobCheckout records what the machine running a job checked out.
 func (s *Handlers) JobCheckout(w http.ResponseWriter, r *http.Request) {
 	s.respond(w, r, s.jobCheckout(w, r))
 }
 
 func (s *Handlers) jobCheckout(w http.ResponseWriter, r *http.Request) error {
-	if _, err := s.requireAgent(r); err != nil {
+	target, err := s.reportableJob(r, platform.URLParam(r, "jobID"))
+	if err != nil {
 		return err
 	}
 
@@ -450,7 +462,7 @@ func (s *Handlers) jobCheckout(w http.ResponseWriter, r *http.Request) error {
 		return requestError(http.StatusBadRequest, errors.New("commit_sha is required"))
 	}
 
-	if err := s.jobs.RecordCheckout(r.Context(), platform.URLParam(r, "jobID"), storage.CheckoutRequest{
+	if err := s.jobs.RecordCheckout(r.Context(), target.ID, storage.CheckoutRequest{
 		Ref:       strings.TrimSpace(req.Ref),
 		CommitSHA: commit,
 	}); err != nil {
@@ -464,13 +476,14 @@ func (s *Handlers) jobCheckout(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// JobHeartbeat extends the lease the calling agent holds on a job.
+// JobHeartbeat extends the lease held on a job by whoever is running it.
 func (s *Handlers) JobHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.respond(w, r, s.jobHeartbeat(w, r))
 }
 
 func (s *Handlers) jobHeartbeat(w http.ResponseWriter, r *http.Request) error {
-	if _, err := s.requireAgent(r); err != nil {
+	target, err := s.reportableJob(r, platform.URLParam(r, "jobID"))
+	if err != nil {
 		return err
 	}
 
@@ -482,7 +495,7 @@ func (s *Handlers) jobHeartbeat(w http.ResponseWriter, r *http.Request) error {
 		return requestError(http.StatusBadRequest, errors.New("agent_id is required"))
 	}
 
-	if err := s.jobs.Heartbeat(r.Context(), platform.URLParam(r, "jobID"), req.AgentID); err != nil {
+	if err := s.jobs.Heartbeat(r.Context(), target.ID, req.AgentID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return requestError(http.StatusConflict, errors.New("job is not leased by this agent"))
 		}

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"database/sql"
-	"errors"
 	"net/http"
 
 	"github.com/titpetric/platform"
@@ -23,8 +21,10 @@ func (s *Handlers) AppendJobLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Handlers) appendJobLog(w http.ResponseWriter, r *http.Request) error {
-	// Output is written by the agent that ran the job.
-	if _, err := s.requireAgent(r); err != nil {
+	// Output is written by whoever ran the job: the agent that claimed
+	// it, or the machine that ran it locally and owns the record.
+	job, err := s.reportableJob(r, platform.URLParam(r, "jobID"))
+	if err != nil {
 		return err
 	}
 
@@ -37,15 +37,7 @@ func (s *Handlers) appendJobLog(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	jobID := platform.URLParam(r, "jobID")
-	if _, err := s.jobs.Get(r.Context(), jobID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return requestError(http.StatusNotFound, errors.New("job not found"))
-		}
-		return err
-	}
-
-	if err := s.jobLogs.Append(r.Context(), jobID, req.Stream, req.Content); err != nil {
+	if err := s.jobLogs.Append(r.Context(), job.ID, req.Stream, req.Content); err != nil {
 		return err
 	}
 

--- a/server/record_test.go
+++ b/server/record_test.go
@@ -1,0 +1,180 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/titpetric/atkins/server/model"
+)
+
+// recordRun dispatches a job that names the machine already running it,
+// which is what `atkins` does for a run happening on a laptop.
+func recordRun(t *testing.T, url, token, command, agent string) dispatchResponse {
+	t.Helper()
+
+	var response dispatchResponse
+	status := call(t, http.MethodPost, url+"/api/dispatch", token, map[string]any{
+		"repository": map[string]string{
+			"remote_url": "git@github.com:titpetric/atkins.git",
+			"ref":        "0123456789abcdef",
+		},
+		"command": command,
+		"agent":   agent,
+	}, &response)
+	require.Equal(t, http.StatusCreated, status)
+
+	return response
+}
+
+// jobLog reads the recorded output of a job.
+func jobLog(t *testing.T, url, token, jobID string) []map[string]any {
+	t.Helper()
+
+	var entries []map[string]any
+	status := call(t, http.MethodGet, url+"/api/job/"+jobID+"/log", token, nil, &entries)
+	require.Equal(t, http.StatusOK, status)
+
+	return entries
+}
+
+func TestRecordedRunIsRunningAndNeverQueued(t *testing.T) {
+	url := testServer(t)
+	token := register(t, url)
+	agent := enrol(t, url, "agent-1")
+
+	job := recordRun(t, url, token.Token, "atkins test", "laptop")
+
+	// The run is already happening, so the job starts running rather
+	// than pending.
+	assert.Equal(t, model.JobStatusRunning, job.Status)
+
+	// And it is not work for an agent: claiming finds an empty queue.
+	status := call(t, http.MethodPost, url+"/api/job/claim", agent.Token, map[string]any{
+		"agent_id": "agent-1",
+	}, nil)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	var view map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+job.JobID, token.Token, nil, &view)
+	require.Equal(t, http.StatusOK, status)
+
+	// The machine that runs it holds the lease, so a run that dies
+	// without reporting is reclaimed the way a lost agent is.
+	assert.Equal(t, "laptop", view["agent_id"])
+	assert.NotEmpty(t, view["started_at"])
+	assert.NotEmpty(t, view["lease_expires_at"])
+}
+
+func TestRecordedRunIsReportedByItsOwner(t *testing.T) {
+	url := testServer(t)
+	token := register(t, url)
+
+	job := recordRun(t, url, token.Token, "atkins test", "laptop")
+
+	// Everything an agent reports about a job, the machine that ran it
+	// locally reports with an ordinary account and no agent credentials.
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/checkout", token.Token, map[string]any{
+		"ref":        "main",
+		"commit_sha": "0123456789abcdef0123456789abcdef01234567",
+	}, nil)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/heartbeat", token.Token, map[string]any{
+		"agent_id": "laptop",
+	}, nil)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", token.Token, map[string]any{
+		"stream":  "output",
+		"content": "go:build ✓\n",
+	}, nil)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", token.Token, map[string]any{
+		"status":    "failed",
+		"exit_code": 2,
+	}, nil)
+	assert.Equal(t, http.StatusOK, status)
+
+	entries := jobLog(t, url, token.Token, job.JobID)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "go:build ✓\n", entries[0]["content"])
+
+	var view map[string]any
+	status = call(t, http.MethodGet, url+"/api/job/"+job.JobID, token.Token, nil, &view)
+	require.Equal(t, http.StatusOK, status)
+
+	// The exit code the shell saw is the exit code the job page shows.
+	assert.Equal(t, model.JobStatusFailed, view["status"])
+	assert.Equal(t, float64(2), view["exit_code"])
+	assert.Equal(t, "0123456789abcdef0123456789abcdef01234567", view["commit_sha"])
+}
+
+func TestReportingRefusesAPendingJob(t *testing.T) {
+	url := testServer(t)
+	token := register(t, url)
+
+	// Nobody has started this one, so a report on it would be fiction.
+	// Cancelling is how its owner stops it.
+	job := dispatch(t, url, token.Token, "atkins build", "")
+
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", token.Token, map[string]any{
+		"stream":  "output",
+		"content": "output from a run that never happened\n",
+	}, nil)
+	assert.Equal(t, http.StatusForbidden, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", token.Token, map[string]any{
+		"status":    "passed",
+		"exit_code": 0,
+	}, nil)
+	assert.Equal(t, http.StatusForbidden, status)
+}
+
+func TestReportingRefusesAnotherUsersRun(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	job := recordRun(t, url, admin.Token, "atkins test", "laptop")
+
+	// Not their job, so it reads as one that isn't there — the same
+	// answer reading it gives.
+	status := call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/log", dev.Token, map[string]any{
+		"stream":  "output",
+		"content": "output from somebody else's machine\n",
+	}, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", dev.Token, map[string]any{
+		"status":    "passed",
+		"exit_code": 0,
+	}, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestReportingOnAPublicInstanceStillRequiresOwnership(t *testing.T) {
+	url := testServer(t)
+	admin := register(t, url)
+	dev := registerUser(t, url, admin.Token, "dev@example.com", "dev")
+
+	// A public instance lets everyone read every job. Reporting is a
+	// write, and ownership is checked outright rather than through
+	// readability, or making an instance public would hand every user
+	// everybody else's runs to settle.
+	setSetting(t, url, admin.Token, model.SettingJobVisibility, model.VisibilityPublic)
+
+	job := recordRun(t, url, admin.Token, "atkins test", "laptop")
+
+	status := call(t, http.MethodGet, url+"/api/job/"+job.JobID, dev.Token, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+
+	status = call(t, http.MethodPost, url+"/api/job/"+job.JobID+"/status", dev.Token, map[string]any{
+		"status":    "passed",
+		"exit_code": 0,
+	}, nil)
+	assert.Equal(t, http.StatusNotFound, status)
+}

--- a/server/storage/job.go
+++ b/server/storage/job.go
@@ -146,6 +146,16 @@ type JobRequest struct {
 	// Artefacts are glob patterns the agent collects after the command
 	// exits, relative to the directory it ran in.
 	Artefacts []string
+
+	// AgentID names the machine already running the job. Set, the job
+	// is created running and leased to it rather than pending: it is a
+	// run happening somewhere the queue cannot reach — `atkins` on a
+	// laptop — which reports its own log and outcome.
+	//
+	// The lease is what makes that safe to trust. A local run that dies
+	// without reporting stops renewing, and the server reclaims it as a
+	// timeout exactly as it does for an agent that disappears.
+	AgentID string
 }
 
 // Create records a dispatched job.
@@ -202,6 +212,15 @@ func (s *JobStorage) Create(ctx context.Context, req JobRequest) (*model.Job, er
 	}
 	job.SetCreatedAt(now)
 	job.SetUpdatedAt(now)
+
+	// A job that names its runner is already under way; there is no
+	// queue step for it to wait in.
+	if req.AgentID != "" {
+		job.Status = model.JobStatusRunning
+		job.AgentID = req.AgentID
+		job.SetStartedAt(now)
+		job.SetLeaseExpiresAt(now.Add(s.LeaseTTL()))
+	}
 
 	if err := client(s.db).Insert(ctx, model.JobTable, job); err != nil {
 		return nil, fmt.Errorf("create job: %w", err)


### PR DESCRIPTION
Closes #56.

Logging in changes what is **recorded**, not where a run happens.

## A logged-in machine runs its own pipelines

```
$ atkins test
recording: http://localhost:3200/job/01M07…?t=…
Atkins project tests, build
└─ test:simple - Simple go test with gotestsum ✓
```

The job is created **running**, leased to this machine rather than queued, and the page ends up with what an agent would have reported: the finished tree, the commit, the exit code the shell saw, the duration.

```
$ curl .../api/job/01M07… | jq -c '{status, exit_code, agent_id, commit_sha}'
{"status":"passed","exit_code":0,"agent_id":"lab","commit_sha":"ca3ab579…"}

$ curl .../api/job/01M07…/log | jq -r '.[].content'
running locally on lab
$ atkins go:build
commit: ca3ab57984e0 (feat/local-run-logging) with uncommitted changes

Go build and test
└─ go:build - Build app ✓
```

Ctrl-C settles the job as `cancelled`; a run that dies with its terminal stops renewing its lease and is reclaimed as a `timeout`, the way a lost agent's job is. The transcript arrives at the end rather than line by line — the header is what a page opened mid-run shows. Artefacts aren't collected: a local run has no `ATKINS_ARTEFACTS` directory to sweep.

## `--dispatch` is the opt-in, and it checks the tree first

```
$ atkins --dispatch test
ERROR: the working tree has uncommitted changes: an agent would build 41c9d0e2a7b1, which does not have them

$ atkins --dispatch test
ERROR: HEAD has not been pushed to a remote: an agent clones the repository, and 41c9d0e2a7b1 is only on this machine
```

The dispatched ref is the commit, so an unpushed one used to queue a job that died in `git checkout` minutes later. The test is on the commit rather than the branch — a commit any remote has can be cloned, whether or not the local branch tracks anything.

Failing to dispatch is now an **error** rather than a silent local run: it was asked for. Recording is the opposite and stays silent when it can't happen — it is bookkeeping and must not cost the run it describes.

## Reporting is no longer agent-only

`/status`, `/log`, `/heartbeat` and `/checkout` now admit an agent **or** the owner of a job that is already running, which is what a local run reports with (an ordinary account, no agent credentials). Two limits keep that narrow, both covered by tests:

- **Ownership is required outright**, not through readability — making an instance public must not hand every user everybody else's runs to settle.
- **A pending job is refused.** Nobody has started it, a report on it would be fiction, and `/cancel` is how its owner stops it.

## Flags and configuration

| | |
|---|---|
| `atkins` | runs here, records the job (when logged in) |
| `atkins --dispatch` | queues it for an agent, prints the URL, exits |
| `atkins --local` | runs here, records nothing |

`client.dispatch` now defaults to **false** (`--dispatch` sets it per run); the new `client.record` (default true) turns recording off for a machine. `ATKINS_NO_DISPATCH` still outranks both, so an agent running a job whose recorded command carries `--dispatch` runs it where it was claimed instead of handing it straight back.

## Verified end to end

Against a throwaway `atkins server`: a recorded pass, a recorded failure (`exit_code: 3`, status failed), a ctrl-C (`cancelled`), `--local` (nothing recorded), `--dispatch` from a dirty tree (refused) and from a clean clone (queued `pending`), and an agent-style run with `ATKINS_NO_DISPATCH=1 ATKINS_JOB_ID=…` (ran locally, recorded nothing). 1455 tests pass.

Docs: the CLI flag reference is now a set of grouped tables — the flags were a comma-separated list in `STRUCTURE.md` and an incomplete table in `usage/cli-flags.md` (`--agent`, `--exec` and `--dispatch` were missing from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)